### PR TITLE
Fix Docker Compose Service Communication by Using Container Names Instead of localhost

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/docker-compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - OPENAI_API_VERSION=${OPENAI_API_VERSION}
       - OPENAI_ENDPOINT=${OPENAI_ENDPOINT}
       - LLM_PROVIDER=${LLM_PROVIDER}
+      - TRANSPORT_SERVER_ENDPOINT=http://agp-gateway:46357
     ports:
       - "9999:9999"
 
@@ -48,6 +49,7 @@ services:
       - OPENAI_API_VERSION=${OPENAI_API_VERSION}
       - OPENAI_ENDPOINT=${OPENAI_ENDPOINT}
       - LLM_PROVIDER=${LLM_PROVIDER}
+      - TRANSPORT_SERVER_ENDPOINT=http://agp-gateway:46357
     depends_on:
       - farm-server
     ports:


### PR DESCRIPTION
# Description

This PR fixes a bug where the farm and exchange servers were attempting to connect to the SLIM gateway using localhost, which doesn't work across containers due to Docker’s networking model. This resulted in connection errors and max retries (e.g., connection error: reached max connection retries).

Debugged with help from @shanchunyang0919 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/cisco-outshift-ai-agents/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
