### PR TITLE
fix: set strict version for gateway-sdk to 0.1.0

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/pyproject.toml
+++ b/coffeeAGNTCY/coffee_agents/corto/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "requests",
     "starlette",
     "uvicorn",
-    "gateway-sdk>=0.1.0",
+    "gateway-sdk==0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/coffeeAGNTCY/coffee_agents/corto/uv.lock
+++ b/coffeeAGNTCY/coffee_agents/corto/uv.lock
@@ -380,7 +380,7 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fastapi" },
     { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "gateway-sdk", specifier = ">=0.1.0" },
+    { name = "gateway-sdk", specifier = "==0.1.0" },
     { name = "httpx" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain-anthropic", specifier = ">=0.3.13" },


### PR DESCRIPTION
# Description

Adding strict version for gateway-sdk package in pyproject.toml. Updating "gateway-sdk>=0.1.0" to "gateway-sdk==0.1.0". This will ensure we dont install a later version for corto.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/cisco-outshift-ai-agents/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
