### PR TITLE
fix: prevent pop-up closed when clicked

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/components/MainArea/CodePopUp.jsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/components/MainArea/CodePopUp.jsx
@@ -18,9 +18,11 @@ const CodePopUp = () => {
     // Toggle the visibility of the code popup
     const toggleCode = () => setShowCode(!showCode);
 
-    // Code block to display
+// Code block to display
     const codeBlock = `
+# ==========================
 # Server setup
+# ==========================
 from a2a.server import A2AServer
 from gateway_sdk.factory import GatewayFactory
 from gateway_sdk.factory import ProtocolTypes
@@ -36,7 +38,9 @@ bridge = factory.create_bridge(server, transport=transport)
 # Start the bridge
 await bridge.start()
 
+# ==========================
 # Client setup
+# ==========================
 from gateway_sdk.factory import GatewayFactory
 from gateway_sdk.protocols.a2a.gateway import A2AProtocol
 
@@ -84,7 +88,7 @@ client = await factory.create_client("A2A", agent_topic=topic, transport=agp_tra
                                 }}
                             />
                             {showBadge && (
-                                <span className="copy-badge">Copied!</span>
+                                <span className={`copy-badge ${showBadge ? 'show' : ''}`}>Copied!</span>
                             )}
                         </div>
                         <SyntaxHighlighter language="python" style={vscDarkPlus}>

--- a/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/components/MainArea/styles/CodePopUp.css
+++ b/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/components/MainArea/styles/CodePopUp.css
@@ -100,10 +100,17 @@
     color: white;
     padding: 5px 10px;
     border-radius: 12px;
-    font-size: 11px;
-    margin-left: 10px;
-    /*animation: fadeInOut 2s ease-in-out;*/
+    font-size: 9px;
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
 }
+
+.copy-badge.show {
+    opacity: 1;
+    transform: scale(1);
+}
+
 
 @keyframes fadeInOut {
     0% {


### PR DESCRIPTION
# Description

To improve the user experience, the pop-up should remain open when clicked. It should only close when an area outside the code block is clicked.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/cisco-outshift-ai-agents/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
