### PR TITLE
feat: Refactor exchange and farm agents to use graph edge transitions…

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/config/config.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/config/config.py
@@ -19,12 +19,14 @@ from dotenv import load_dotenv
 
 load_dotenv()  # Automatically loads from `.env` or `.env.local`
 
-# --- Corto ---
-DEFAULT_MESSAGE_TRANSPORT = os.getenv("DEFAULT_MESSAGE_TRANSPORT", "NATS")
-TRANSPORT_SERVER_ENDPOINT = os.getenv("TRANSPORT_SERVER_ENDPOINT", "localhost:4222")
+# --- Lungo ---
+#DEFAULT_MESSAGE_TRANSPORT = os.getenv("DEFAULT_MESSAGE_TRANSPORT", "NATS")
+#TRANSPORT_SERVER_ENDPOINT = os.getenv("TRANSPORT_SERVER_ENDPOINT", "localhost:4222")
 
-# DEFAULT_MESSAGE_TRANSPORT = os.getenv("DEFAULT_MESSAGE_TRANSPORT", "SLIM")
-# TRANSPORT_SERVER_ENDPOINT = os.getenv("TRANSPORT_SERVER_ENDPOINT", "http://localhost:46357")
+DEFAULT_MESSAGE_TRANSPORT = os.getenv("DEFAULT_MESSAGE_TRANSPORT", "SLIM")
+TRANSPORT_SERVER_ENDPOINT = os.getenv("TRANSPORT_SERVER_ENDPOINT", "http://localhost:46357")
+
+FARM_BROADCAST_TOPIC = os.getenv("FARM_BROADCAST_TOPIC", "farm_broadcast")
 
 LLM_PROVIDER = os.getenv("LLM_PROVIDER")
 LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO").upper()

--- a/coffeeAGNTCY/coffee_agents/lungo/exchange/graph/models.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/exchange/graph/models.py
@@ -14,32 +14,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from typing import Literal
 
-class GetFarmYieldInput(BaseModel):
-    """
-    Represents the input for the get farm yield agent call.
-    This class is used to structure the input payload for the A2A agent.
-    """
-    farm_name: str
+class InventoryArgs(BaseModel):
+    """Arguments for the create_order tool."""
+    prompt: str = Field(
+        ...,
+        description="The prompt to use for the broadcast. Must be a non-empty string."
+    )
+    farm : Literal["brazil", "colombia", "vietnam"] = Field(
+        ...,
+        description="The name of the farm. Must be one of 'brazil', 'colombia', or 'vietnam'."
+    )
 
-class GetFarmYieldOutput(BaseModel):
-    """
-    Represents the output for the get farm yield agent call.
-    This class is used to structure the response from the A2A agent.
-    """
-    yields: dict[str, float] # Mapping of farm names to their yields in pounds
-
-class FetchHarvestInput(BaseModel):
-    """
-    Represents the input for the fetch harvest agent call.
-    This class is used to structure the input payload for the A2A agent.
-    """
-    prompt: str
-
-class FetchHarvestOutput(BaseModel):
-    """
-    Represents the output of the fetch harvest agent call.
-    This class is used to structure the response from the A2A agent.
-    """
-    yield_lb: str
+class CreateOrderArgs(BaseModel):
+    """Arguments for the create_order tool."""
+    farm: Literal["brazil", "colombia", "vietnam"] = Field(
+        ...,
+        description="The name of the farm. Must be one of 'brazil', 'colombia', or 'vietnam'."
+    )
+    quantity: int = Field(
+        ...,
+        description="The quantity of the order. Must be a positive integer."
+    )
+    price: float = Field(
+        ...,
+        description="The price of the order. Must be a positive float."
+    )

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/brazil/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/brazil/agent.py
@@ -15,69 +15,251 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import TypedDict
-
-from langgraph.graph import END, START, StateGraph
-from langchain_core.messages import HumanMessage, SystemMessage
-
+from langgraph.graph import MessagesState
+from langchain_core.messages import AIMessage
+from langchain_core.prompts import PromptTemplate
+from langgraph.graph import StateGraph, END
 from common.llm import get_llm
 
-class State(TypedDict):
-    prompt: str
-    error_type: str
-    error_message: str
-    yield_estimate: str
+logger = logging.getLogger("lungo.brazil_farm_agent.agent")
 
+# --- 1. Define Node Names as Constants ---
+class NodeStates:
+    SUPERVISOR = "supervisor"
+    INVENTORY = "inventory_node"
+    ORDERS = "orders_node"
+    GENERAL_RESPONSE = "general_response_node"
 
+# --- 2. Define the Graph State ---
+class GraphState(MessagesState):
+    """
+    Represents the state of our graph, passed between nodes.
+    """
+    next_node: str
+
+# --- 3. Implement the LangGraph Application Class ---
 class FarmAgent:
     def __init__(self):
-        graph_builder = StateGraph(State)
-        graph_builder.add_node("YieldNode", self.yield_node)
-        graph_builder.add_edge(START, "YieldNode")
-        graph_builder.add_edge("YieldNode", END)
-        self._agent = graph_builder.compile()
-
-    async def yield_node(self, state: State):
         """
-        Generate a yield estimate for coffee beans based on user input by connecting to an LLM.
+        Initializes the CustomerServiceAgent with an LLM and builds the LangGraph workflow.
 
         Args:
-            state (State): The current state containing the user prompt.
-        Returns:
-            dict: A dictionary containing the yield estimate or an error message if the input is invalid.
+            llm_model (str): The name of the OpenAI LLM model to use (e.g., "gpt-4o", "gpt-3.5-turbo").
         """
-        user_prompt = state.get("prompt")
+        self.supervisor_llm = None
+        self.inventory_llm = None
+        self.orders_llm = None
 
-        system_prompt = (
-            "You are a coffee farm in Brazil\n"
-            "The user will describe a question or scenario related to fetching the yield from your coffee farm. "
-            "Your job is to:\n"
-            "1. Return a random yield estimate for the coffee farm in Brazil. Make sure the estimate is a reasonable value and in pounds.\n"
-            "2. Respond with only the yield estimate in pounds, without any additional text or explanation.\n"
-            "Use tasting terminology like acidity, body, aroma, and finish.\n"
-            "Respond with an empty response if the user prompt does not relate to fetching the yield from the Brazilian coffee farm. Do not include quotes or any placeholder."
+        self.app = self._build_graph()
+
+    # --- Node Definitions ---
+
+    def _supervisor_node(self, state: GraphState) -> dict:
+        """
+        Determines the intent of the user's message and routes to the appropriate node.
+        """
+        if not self.supervisor_llm:
+            self.supervisor_llm = get_llm()
+
+        prompt = PromptTemplate(
+            template="""You are a coffee farm manager in Brazil who delegates farm cultivation and global sales. Based on the 
+            user's message, determine if it's related to 'inventory' or 'orders'.
+            Respond with 'inventory' if the message is about checking yield, stock, product availability, or specific coffee item details.
+            Respond with 'orders' if the message is about checking order status, placing an order, or modifying an existing order.
+            If unsure, respond with 'general'.
+
+            User message: {user_message}
+            """,
+            input_variables=["user_message"]
         )
 
-        messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=user_prompt)
-        ]
-        response = get_llm().invoke(messages)
-        yield_estimate = response.content
-        if not yield_estimate.strip():
-            return {
-                "error_type": "invalid_input",
-                "error_message": "Invalid prompt. Please provide a valid question or scenario related to fetching the yield from the Brazilian coffee farm."
-            }
+        chain = prompt | self.supervisor_llm
+        response = chain.invoke({"user_message": state["messages"]})
+        intent = response.content.strip().lower()
 
-        return {"yield_estimate": yield_estimate}
+        logger.info(f"Supervisor intent determined: {intent}")  # Log the intent for debugging
 
-    async def ainvoke(self, input: str) -> dict:
+        if "inventory" in intent:
+            return {"next_node": NodeStates.INVENTORY, "messages": state["messages"]}
+        elif "orders" in intent:
+            return {"next_node": NodeStates.ORDERS, "messages": state["messages"]}
+        else:
+            return {"next_node": NodeStates.GENERAL_RESPONSE, "messages": state["messages"]}
+
+    def _inventory_node(self, state: GraphState) -> dict:
         """
-        Asynchronously invoke the agent with the given input.
+        Handles inventory-related queries using an LLM to formulate responses.
+        """
+        if not self.inventory_llm:
+            self.inventory_llm = get_llm()
+
+        user_message = state["messages"]
+
+        prompt = PromptTemplate(
+            template="""You are a helpful coffee farm cultivation manager in Brazil who handles yield or inventory requets. 
+            Your job is to:
+            1. Return a random yield estimate for the coffee farm in Brazil. Make sure the estimate is a reasonable value and in pounds.
+            2. Respond with only the yield estimate.\n
+
+            If the user asked in lbs or pounds, respond with the estimate in pounds. If the user asked in kg or kilograms, convert the estimate to kg and respond with that value.\n
+
+            User question: {user_message}
+            """,
+            input_variables=["user_message"]
+        )
+        chain = prompt | self.inventory_llm
+
+        llm_response = chain.invoke({
+            "user_message": user_message,
+        }).content
+
+        logger.info(f"Inventory response generated: {llm_response}")
+
+        return {"messages": [AIMessage(llm_response)]}
+
+    def _orders_node(self, state: GraphState) -> dict:
+        """
+        Handles order-related queries using an LLM to formulate responses.
+        """
+        if not self.orders_llm:
+            self.orders_llm = get_llm()
+
+        user_message = state["messages"]
+
+        logger.info(f"Received order query: {user_message}")
+
+        # Simulate data retrieval - in a real app, this would be a database/API call
+        mock_order_data = {
+            "12345": {"status": "processing", "estimated_delivery": "2 business days"},
+            "67890": {"status": "shipped", "tracking_number": "ABCDEF123"}
+        }
+
+        prompt = PromptTemplate(
+            template="""You are an order assistant. Based on the user's question and the following order data, provide a concise and helpful response.
+            If they ask about a specific order number, provide its status. 
+            If they ask about placing order an order, generate a random order id and tracking number.
+
+            Order Data: {order_data}
+            User question: {user_message}
+            """,
+            input_variables=["user_message", "order_data"]
+        )
+        chain = prompt | self.orders_llm
+
+        llm_response = chain.invoke({
+            "user_message": user_message,
+            "order_data": str(mock_order_data) # Pass data as string for LLM context
+        }).content
+
+        return {"messages": [AIMessage(llm_response)]}
+
+    def _general_response_node(self, state: GraphState) -> dict:
+        """
+        Provides a fallback response for unclear or out-of-scope messages.
+        """
+        response = "I'm designed to help with inventory and order-related questions. Could you please rephrase your request?"
+        return {"messages": [AIMessage(response)]}
+
+    # --- Graph Building Method ---
+
+    def _build_graph(self):
+        """
+        Builds and compiles the LangGraph workflow.
+        """
+        workflow = StateGraph(GraphState)
+
+        # Add nodes
+        workflow.add_node(NodeStates.SUPERVISOR, self._supervisor_node)
+        workflow.add_node(NodeStates.INVENTORY, self._inventory_node)
+        workflow.add_node(NodeStates.ORDERS, self._orders_node)
+        workflow.add_node(NodeStates.GENERAL_RESPONSE, self._general_response_node)
+
+        # Set the entry point
+        workflow.set_entry_point(NodeStates.SUPERVISOR)
+
+        # Add conditional edges from the supervisor
+        workflow.add_conditional_edges(
+            NodeStates.SUPERVISOR,
+            lambda state: state["next_node"],
+            {
+                NodeStates.INVENTORY: NodeStates.INVENTORY,
+                NodeStates.ORDERS: NodeStates.ORDERS,
+                NodeStates.GENERAL_RESPONSE: NodeStates.GENERAL_RESPONSE,
+            },
+        )
+
+        # Add edges from the specific nodes to END
+        workflow.add_edge(NodeStates.INVENTORY, END)
+        workflow.add_edge(NodeStates.ORDERS, END)
+        workflow.add_edge(NodeStates.GENERAL_RESPONSE, END)
+
+        return workflow.compile()
+
+    # --- Public Methods for Interaction ---
+
+    async def ainvoke(self, user_message: str) -> dict:
+        """
+        Invokes the graph with a user message.
+
         Args:
-            input (str): The user input to process.
+            user_message (str): The current message from the user.
+
         Returns:
-            dict: The result of the agent's processing, containing yield estimates or an error message.
+            str: The final state of the graph after processing the message.
         """
-        return await self._agent.ainvoke({"prompt": input})
+        inputs = {"messages": [user_message]}
+        result = await self.app.ainvoke(inputs)
+
+        messages = result.get("messages", [])
+        if not messages:
+            raise RuntimeError("No messages found in the graph response.")
+
+        # Find the last AIMessage with non-empty content
+        for message in reversed(messages):
+            if isinstance(message, AIMessage) and message.content.strip():
+                logger.debug(f"Valid AIMessage found: {message.content.strip()}")
+                return message.content.strip()
+
+        # If no valid AIMessage found, return the last message as a fallback
+        return messages[-1].content.strip() if messages else "No valid response generated."
+
+async def main():
+    agent = FarmAgent() # You can specify llm_model='gpt-3.5-turbo' if you prefer
+
+    print("--- Testing Inventory Queries ---")
+    messages = [
+        "How much coffee do we have in stock?",
+        "What is the current yield estimate?",
+    ]
+    for msg in messages:
+        print(f"\nUser: {msg}")
+        final_state = await agent.ainvoke(msg)
+        print(f"Agent: {final_state}")
+
+    print("\n" + "="*50 + "\n")
+
+
+    messages = [
+        "Can you order me 100 lbs of coffee?",
+        "I want to place a new order for 50 kg of coffee",
+    ]
+    for msg in messages:
+        print(f"\nUser: {msg}")
+        final_state = await agent.ainvoke(msg)
+        print(f"Agent: {final_state}")
+
+    print("\n" + "="*50 + "\n")
+
+    messages = [
+        "Tell me a joke.",
+        "What's the weather like today?",
+    ]
+    for msg in messages:
+        print(f"\nUser: {msg}")
+        final_state = await agent.ainvoke(msg)
+        print(f"Agent: {final_state}")
+
+# --- Example Usage ---
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/brazil/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/brazil/agent_executor.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from uuid import uuid4
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -24,21 +25,25 @@ from a2a.types import (
     JSONRPCResponse,
     ContentTypeNotSupportedError,
     InternalError,
+    Message,
+    Role,
+    Part,
+    TextPart,
     Task)
 
 from a2a.utils import (
-    new_agent_text_message,
     new_task,
 )
 
 from agent import FarmAgent
-from agent_executor import FarmAgent
+from card import AGENT_CARD
 
 logger = logging.getLogger("longo.brazil_farm_agent.agent_executor")
 
 class FarmAgentExecutor(AgentExecutor):
     def __init__(self):
         self.agent = FarmAgent()
+        self.agent_card = AGENT_CARD.model_dump(mode="json", exclude_none=True)
 
     def _validate_request(self, context: RequestContext) -> JSONRPCResponse | None:
         """Validates the incoming request."""
@@ -68,7 +73,7 @@ class FarmAgentExecutor(AgentExecutor):
             event_queue: The queue to publish events to.
         """
 
-        logger.info("Received message request: %s", context.message)
+        logger.debug("Received message request: %s", context.message)
 
         validation_error = self._validate_request(context)
         if validation_error:
@@ -83,17 +88,17 @@ class FarmAgentExecutor(AgentExecutor):
 
         try:
             output = await self.agent.ainvoke(prompt)
-            if output.get("error_message") is not None and output.get("error_message") != "":
-                logger.error("Error in agent response: %s", output.get("error_message"))
-                message = new_agent_text_message(
-                    output.get("error_message", "Failed to generate yield estimate"),
-                )
-                event_queue.enqueue_event(message)
-                return
+        
+            message = Message(
+                messageId=str(uuid4()),
+                role=Role.agent,
+                metadata={"name": self.agent_card["name"]},
+                parts=[Part(TextPart(text=output))],
+            )
 
-            yield_estimate = output.get("yield_estimate", "No yield_estimate returned")
-            logger.info("Yield estimate generated: %s", yield_estimate)
-            event_queue.enqueue_event(new_agent_text_message(yield_estimate))
+            logger.info("agent output message: %s", message)
+
+            event_queue.enqueue_event(message)            
         except Exception as e:
             logger.error(f'An error occurred while streaming the yield estimate response: {e}')
             raise ServerError(error=InternalError()) from e

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/brazil/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/brazil/farm_server.py
@@ -23,7 +23,11 @@ from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
 
 from agent_executor import FarmAgentExecutor
-from config.config import DEFAULT_MESSAGE_TRANSPORT, TRANSPORT_SERVER_ENDPOINT
+from config.config import (
+    DEFAULT_MESSAGE_TRANSPORT, 
+    TRANSPORT_SERVER_ENDPOINT,
+    FARM_BROADCAST_TOPIC,
+)
 from card import AGENT_CARD
 
 # Initialize a multi-protocol, multi-transport gateway factory.
@@ -45,7 +49,16 @@ async def main():
         DEFAULT_MESSAGE_TRANSPORT,
         endpoint=TRANSPORT_SERVER_ENDPOINT,
     )
-    bridge = factory.create_bridge(server, transport=transport)
+
+    # explicitly create a broadcast bridge to the farm yield topic
+    broadcast_bridge = factory.create_bridge(
+        server, transport=transport, topic=FARM_BROADCAST_TOPIC
+    )
+
+    # create the default bridge to the server with a topic generated from the agent card
+    bridge = factory.create_bridge(server, transport=transport) 
+
+    await broadcast_bridge.start(blocking=False)
     await bridge.start(blocking=True)
 
 if __name__ == '__main__':

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/colombia/agent.py
@@ -15,55 +15,210 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import TypedDict
-
-from langchain_core.messages import HumanMessage, SystemMessage
-
+from langgraph.graph import MessagesState
+from langchain_core.messages import AIMessage
+from langchain_core.prompts import PromptTemplate
+from langgraph.graph import StateGraph, END
 from common.llm import get_llm
 
-class State(TypedDict):
-    prompt: str
-    error_type: str
-    error_message: str
-    yield_estimate: str
+logger = logging.getLogger("lungo.colombia_farm_agent.agent")
 
+# --- 1. Define Node Names as Constants ---
+class NodeStates:
+    SUPERVISOR = "supervisor"
+    INVENTORY = "inventory_node"
+    ORDERS = "orders_node"
+    GENERAL_RESPONSE = "general_response_node"
 
+# --- 2. Define the Graph State ---
+class GraphState(MessagesState):
+    """
+    Represents the state of our graph, passed between nodes.
+    """
+    next_node: str
+
+# --- 3. Implement the LangGraph Application Class ---
 class FarmAgent:
     def __init__(self):
-        pass  # No graph setup needed
-
-    async def yield_node(self, state: State):
         """
-        Generate a yield estimate for coffee beans based on user input by connecting to an LLM.
-        """
-        user_prompt = state.get("prompt")
+        Initializes the CustomerServiceAgent with an LLM and builds the LangGraph workflow.
 
-        system_prompt = (
-            "You are a coffee farm in Colombia\n"
-            "The user will describe a question or scenario related to fetching the yield from your coffee farm. "
-            "Your job is to:\n"
-            "1. Return a random yield estimate for the coffee farm in Colombia. Make sure the estimate is a reasonable value and in pounds.\n"
-            "2. Respond with only the yield estimate in pounds, without any additional text or explanation.\n"
-            "Use tasting terminology like acidity, body, aroma, and finish.\n"
-            "Respond with an empty response if the user prompt does not relate to fetching the yield from the Colombian coffee farm. Do not include quotes or any placeholder."
+        Args:
+            llm_model (str): The name of the OpenAI LLM model to use (e.g., "gpt-4o", "gpt-3.5-turbo").
+        """
+        self.supervisor_llm = None
+        self.inventory_llm = None
+        self.orders_llm = None
+
+        self.app = self._build_graph()
+
+    # --- Node Definitions ---
+
+    def _supervisor_node(self, state: GraphState) -> dict:
+        """
+        Determines the intent of the user's message and routes to the appropriate node.
+        """
+        if not self.supervisor_llm:
+            self.supervisor_llm = get_llm()
+
+        prompt = PromptTemplate(
+            template="""You are a coffee farm manager in Colombia who delegates farm cultivation and global sales. Based on the 
+            user's message, determine if it's related to 'inventory' or 'orders'.
+            Respond with 'inventory' if the message is about checking yield, stock, product availability, or specific coffee item details.
+            Respond with 'orders' if the message is about checking order status, placing an order, or modifying an existing order.
+            If unsure, respond with 'general'.
+
+            User message: {user_message}
+            """,
+            input_variables=["user_message"]
         )
 
-        messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=user_prompt)
-        ]
-        response = get_llm().invoke(messages)
-        yield_estimate = response.content
-        if not yield_estimate.strip():
-            return {
-                "error_type": "invalid_input",
-                "error_message": "Invalid prompt. Please provide a valid question or scenario related to fetching the yield from the colombian coffee farm."
-            }
+        chain = prompt | self.supervisor_llm
+        response = chain.invoke({"user_message": state["messages"]})
+        intent = response.content.strip().lower()
 
-        return {"yield_estimate": yield_estimate}
+        logger.info(f"Supervisor intent determined: {intent}")  # Log the intent for debugging
 
-    async def ainvoke(self, input: str) -> dict:
+        if "inventory" in intent:
+            return {"next_node": NodeStates.INVENTORY, "messages": state["messages"]}
+        elif "orders" in intent:
+            return {"next_node": NodeStates.ORDERS, "messages": state["messages"]}
+        else:
+            return {"next_node": NodeStates.GENERAL_RESPONSE, "messages": state["messages"]}
+
+    def _inventory_node(self, state: GraphState) -> dict:
         """
-        Asynchronously invoke the agent with the given input.
+        Handles inventory-related queries using an LLM to formulate responses.
         """
-        return await self.yield_node({"prompt": input})
+        if not self.inventory_llm:
+            self.inventory_llm = get_llm()
+
+        user_message = state["messages"]
+
+        prompt = PromptTemplate(
+            template="""You are a helpful coffee farm cultivation manager in Colombia who handles yield or inventory requets. 
+            Your job is to:
+            1. Return a random yield estimate for the coffee farm in Colombia. Make sure the estimate is a reasonable value and in pounds.
+            2. Respond with only the yield estimate.\n
+
+            If the user asked in lbs or pounds, respond with the estimate in pounds. If the user asked in kg or kilograms, convert the estimate to kg and respond with that value.\n
+
+            User question: {user_message}
+            """,
+            input_variables=["user_message"]
+        )
+        chain = prompt | self.inventory_llm
+
+        llm_response = chain.invoke({
+            "user_message": user_message,
+        }).content
+
+        logger.info(f"Inventory response generated: {llm_response}")
+
+        return {"messages": [AIMessage(llm_response)]}
+
+    def _orders_node(self, state: GraphState) -> dict:
+        """
+        Handles order-related queries using an LLM to formulate responses.
+        """
+        if not self.orders_llm:
+            self.orders_llm = get_llm()
+
+        user_message = state["messages"]
+
+        logger.info(f"Received order query: {user_message}")
+
+        # Simulate data retrieval - in a real app, this would be a database/API call
+        mock_order_data = {
+            "12345": {"status": "processing", "estimated_delivery": "2 business days"},
+            "67890": {"status": "shipped", "tracking_number": "ABCDEF123"}
+        }
+
+        prompt = PromptTemplate(
+            template="""You are an order assistant. Based on the user's question and the following order data, provide a concise and helpful response.
+            If they ask about a specific order number, provide its status. 
+            If they ask about placing order an order, generate a random order id and tracking number.
+
+            Order Data: {order_data}
+            User question: {user_message}
+            """,
+            input_variables=["user_message", "order_data"]
+        )
+        chain = prompt | self.orders_llm
+
+        llm_response = chain.invoke({
+            "user_message": user_message,
+            "order_data": str(mock_order_data) # Pass data as string for LLM context
+        }).content
+
+        return {"messages": [AIMessage(llm_response)]}
+
+    def _general_response_node(self, state: GraphState) -> dict:
+        """
+        Provides a fallback response for unclear or out-of-scope messages.
+        """
+        response = "I'm designed to help with inventory and order-related questions. Could you please rephrase your request?"
+        return {"messages": [AIMessage(response)]}
+
+    # --- Graph Building Method ---
+
+    def _build_graph(self):
+        """
+        Builds and compiles the LangGraph workflow.
+        """
+        workflow = StateGraph(GraphState)
+
+        # Add nodes
+        workflow.add_node(NodeStates.SUPERVISOR, self._supervisor_node)
+        workflow.add_node(NodeStates.INVENTORY, self._inventory_node)
+        workflow.add_node(NodeStates.ORDERS, self._orders_node)
+        workflow.add_node(NodeStates.GENERAL_RESPONSE, self._general_response_node)
+
+        # Set the entry point
+        workflow.set_entry_point(NodeStates.SUPERVISOR)
+
+        # Add conditional edges from the supervisor
+        workflow.add_conditional_edges(
+            NodeStates.SUPERVISOR,
+            lambda state: state["next_node"],
+            {
+                NodeStates.INVENTORY: NodeStates.INVENTORY,
+                NodeStates.ORDERS: NodeStates.ORDERS,
+                NodeStates.GENERAL_RESPONSE: NodeStates.GENERAL_RESPONSE,
+            },
+        )
+
+        # Add edges from the specific nodes to END
+        workflow.add_edge(NodeStates.INVENTORY, END)
+        workflow.add_edge(NodeStates.ORDERS, END)
+        workflow.add_edge(NodeStates.GENERAL_RESPONSE, END)
+
+        return workflow.compile()
+
+    # --- Public Methods for Interaction ---
+
+    async def ainvoke(self, user_message: str) -> dict:
+        """
+        Invokes the graph with a user message.
+
+        Args:
+            user_message (str): The current message from the user.
+
+        Returns:
+            str: The final state of the graph after processing the message.
+        """
+        inputs = {"messages": [user_message]}
+        result = await self.app.ainvoke(inputs)
+
+        messages = result.get("messages", [])
+        if not messages:
+            raise RuntimeError("No messages found in the graph response.")
+
+        # Find the last AIMessage with non-empty content
+        for message in reversed(messages):
+            if isinstance(message, AIMessage) and message.content.strip():
+                logger.debug(f"Valid AIMessage found: {message.content.strip()}")
+                return message.content.strip()
+
+        # If no valid AIMessage found, return the last message as a fallback
+        return messages[-1].content.strip() if messages else "No valid response generated."

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/colombia/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/colombia/agent_executor.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from uuid import uuid4
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -24,21 +25,25 @@ from a2a.types import (
     JSONRPCResponse,
     ContentTypeNotSupportedError,
     InternalError,
+    Message,
+    Role,
+    Part,
+    TextPart,
     Task)
 
 from a2a.utils import (
-    new_agent_text_message,
     new_task,
 )
 
 from agent import FarmAgent
-from agent_executor import FarmAgent
+from card import AGENT_CARD
 
 logger = logging.getLogger("longo.colombia_farm_agent.agent_executor")
 
 class FarmAgentExecutor(AgentExecutor):
     def __init__(self):
         self.agent = FarmAgent()
+        self.agent_card = AGENT_CARD.model_dump(mode="json", exclude_none=True)
 
     def _validate_request(self, context: RequestContext) -> JSONRPCResponse | None:
         """Validates the incoming request."""
@@ -68,7 +73,7 @@ class FarmAgentExecutor(AgentExecutor):
             event_queue: The queue to publish events to.
         """
 
-        logger.info("Received message request: %s", context.message)
+        logger.debug("Received message request: %s", context.message)
 
         validation_error = self._validate_request(context)
         if validation_error:
@@ -83,17 +88,17 @@ class FarmAgentExecutor(AgentExecutor):
 
         try:
             output = await self.agent.ainvoke(prompt)
-            if output.get("error_message") is not None and output.get("error_message") != "":
-                logger.error("Error in agent response: %s", output.get("error_message"))
-                message = new_agent_text_message(
-                    output.get("error_message", "Failed to generate yield estimate"),
-                )
-                event_queue.enqueue_event(message)
-                return
+        
+            message = Message(
+                messageId=str(uuid4()),
+                role=Role.agent,
+                metadata={"name": self.agent_card["name"]},
+                parts=[Part(TextPart(text=output))],
+            )
 
-            yield_estimate = output.get("yield_estimate", "No yield_estimate returned")
-            logger.info("Yield estimate generated: %s", yield_estimate)
-            event_queue.enqueue_event(new_agent_text_message(yield_estimate))
+            logger.info("agent output message: %s", message)
+
+            event_queue.enqueue_event(message)            
         except Exception as e:
             logger.error(f'An error occurred while streaming the yield estimate response: {e}')
             raise ServerError(error=InternalError()) from e

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/colombia/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/colombia/farm_server.py
@@ -23,7 +23,11 @@ from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
 
 from agent_executor import FarmAgentExecutor
-from config.config import DEFAULT_MESSAGE_TRANSPORT, TRANSPORT_SERVER_ENDPOINT
+from config.config import (
+    DEFAULT_MESSAGE_TRANSPORT, 
+    TRANSPORT_SERVER_ENDPOINT,
+    FARM_BROADCAST_TOPIC,
+)
 from card import AGENT_CARD
 
 # Initialize a multi-protocol, multi-transport gateway factory.
@@ -45,7 +49,16 @@ async def main():
         DEFAULT_MESSAGE_TRANSPORT,
         endpoint=TRANSPORT_SERVER_ENDPOINT,
     )
-    bridge = factory.create_bridge(server, transport=transport)
+
+    # explicitly create a broadcast bridge to the farm yield topic
+    broadcast_bridge = factory.create_bridge(
+        server, transport=transport, topic=FARM_BROADCAST_TOPIC
+    )
+
+    # create the default bridge to the server with a topic generated from the agent card
+    bridge = factory.create_bridge(server, transport=transport) 
+
+    await broadcast_bridge.start(blocking=False)
     await bridge.start(blocking=True)
 
 if __name__ == '__main__':

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/vietnam/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/vietnam/agent.py
@@ -15,55 +15,210 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import TypedDict
-
-from langchain_core.messages import HumanMessage, SystemMessage
-
+from langgraph.graph import MessagesState
+from langchain_core.messages import AIMessage
+from langchain_core.prompts import PromptTemplate
+from langgraph.graph import StateGraph, END
 from common.llm import get_llm
 
-class State(TypedDict):
-    prompt: str
-    error_type: str
-    error_message: str
-    yield_estimate: str
+logger = logging.getLogger("lungo.vietnam_farm_agent.agent")
 
+# --- 1. Define Node Names as Constants ---
+class NodeStates:
+    SUPERVISOR = "supervisor"
+    INVENTORY = "inventory_node"
+    ORDERS = "orders_node"
+    GENERAL_RESPONSE = "general_response_node"
 
+# --- 2. Define the Graph State ---
+class GraphState(MessagesState):
+    """
+    Represents the state of our graph, passed between nodes.
+    """
+    next_node: str
+
+# --- 3. Implement the LangGraph Application Class ---
 class FarmAgent:
     def __init__(self):
-        pass  # No graph setup needed
-
-    async def yield_node(self, state: State):
         """
-        Generate a yield estimate for coffee beans based on user input by connecting to an LLM.
-        """
-        user_prompt = state.get("prompt")
+        Initializes the CustomerServiceAgent with an LLM and builds the LangGraph workflow.
 
-        system_prompt = (
-            "You are a coffee farm in Vietnam\n"
-            "The user will describe a question or scenario related to fetching the yield from your coffee farm. "
-            "Your job is to:\n"
-            "1. Return a random yield estimate for the coffee farm in Vietnam. Make sure the estimate is a reasonable value and in pounds.\n"
-            "2. Respond with only the yield estimate in pounds, without any additional text or explanation.\n"
-            "Use tasting terminology like acidity, body, aroma, and finish.\n"
-            "Respond with an empty response if the user prompt does not relate to fetching the yield from the Vietnamn coffee farm. Do not include quotes or any placeholder."
+        Args:
+            llm_model (str): The name of the OpenAI LLM model to use (e.g., "gpt-4o", "gpt-3.5-turbo").
+        """
+        self.supervisor_llm = None
+        self.inventory_llm = None
+        self.orders_llm = None
+
+        self.app = self._build_graph()
+
+    # --- Node Definitions ---
+
+    def _supervisor_node(self, state: GraphState) -> dict:
+        """
+        Determines the intent of the user's message and routes to the appropriate node.
+        """
+        if not self.supervisor_llm:
+            self.supervisor_llm = get_llm()
+
+        prompt = PromptTemplate(
+            template="""You are a coffee farm manager in Vietnam who delegates farm cultivation and global sales. Based on the 
+            user's message, determine if it's related to 'inventory' or 'orders'.
+            Respond with 'inventory' if the message is about checking yield, stock, product availability, or specific coffee item details.
+            Respond with 'orders' if the message is about checking order status, placing an order, or modifying an existing order.
+            If unsure, respond with 'general'.
+
+            User message: {user_message}
+            """,
+            input_variables=["user_message"]
         )
 
-        messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=user_prompt)
-        ]
-        response = get_llm().invoke(messages)
-        yield_estimate = response.content
-        if not yield_estimate.strip():
-            return {
-                "error_type": "invalid_input",
-                "error_message": "Invalid prompt. Please provide a valid question or scenario related to fetching the yield from the Vietnamn coffee farm."
-            }
+        chain = prompt | self.supervisor_llm
+        response = chain.invoke({"user_message": state["messages"]})
+        intent = response.content.strip().lower()
 
-        return {"yield_estimate": yield_estimate}
+        logger.info(f"Supervisor intent determined: {intent}")  # Log the intent for debugging
 
-    async def ainvoke(self, input: str) -> dict:
+        if "inventory" in intent:
+            return {"next_node": NodeStates.INVENTORY, "messages": state["messages"]}
+        elif "orders" in intent:
+            return {"next_node": NodeStates.ORDERS, "messages": state["messages"]}
+        else:
+            return {"next_node": NodeStates.GENERAL_RESPONSE, "messages": state["messages"]}
+
+    def _inventory_node(self, state: GraphState) -> dict:
         """
-        Asynchronously invoke the agent with the given input.
+        Handles inventory-related queries using an LLM to formulate responses.
         """
-        return await self.yield_node({"prompt": input})
+        if not self.inventory_llm:
+            self.inventory_llm = get_llm()
+
+        user_message = state["messages"]
+
+        prompt = PromptTemplate(
+            template="""You are a helpful coffee farm cultivation manager in Vietnam who handles yield or inventory requets. 
+            Your job is to:
+            1. Return a random yield estimate for the coffee farm in Vietnam. Make sure the estimate is a reasonable value and in pounds.
+            2. Respond with only the yield estimate.\n
+
+            If the user asked in lbs or pounds, respond with the estimate in pounds. If the user asked in kg or kilograms, convert the estimate to kg and respond with that value.\n
+
+            User question: {user_message}
+            """,
+            input_variables=["user_message"]
+        )
+        chain = prompt | self.inventory_llm
+
+        llm_response = chain.invoke({
+            "user_message": user_message,
+        }).content
+
+        logger.info(f"Inventory response generated: {llm_response}")
+
+        return {"messages": [AIMessage(llm_response)]}
+
+    def _orders_node(self, state: GraphState) -> dict:
+        """
+        Handles order-related queries using an LLM to formulate responses.
+        """
+        if not self.orders_llm:
+            self.orders_llm = get_llm()
+
+        user_message = state["messages"]
+
+        logger.info(f"Received order query: {user_message}")
+
+        # Simulate data retrieval - in a real app, this would be a database/API call
+        mock_order_data = {
+            "12345": {"status": "processing", "estimated_delivery": "2 business days"},
+            "67890": {"status": "shipped", "tracking_number": "ABCDEF123"}
+        }
+
+        prompt = PromptTemplate(
+            template="""You are an order assistant. Based on the user's question and the following order data, provide a concise and helpful response.
+            If they ask about a specific order number, provide its status. 
+            If they ask about placing order an order, generate a random order id and tracking number.
+
+            Order Data: {order_data}
+            User question: {user_message}
+            """,
+            input_variables=["user_message", "order_data"]
+        )
+        chain = prompt | self.orders_llm
+
+        llm_response = chain.invoke({
+            "user_message": user_message,
+            "order_data": str(mock_order_data) # Pass data as string for LLM context
+        }).content
+
+        return {"messages": [AIMessage(llm_response)]}
+
+    def _general_response_node(self, state: GraphState) -> dict:
+        """
+        Provides a fallback response for unclear or out-of-scope messages.
+        """
+        response = "I'm designed to help with inventory and order-related questions. Could you please rephrase your request?"
+        return {"messages": [AIMessage(response)]}
+
+    # --- Graph Building Method ---
+
+    def _build_graph(self):
+        """
+        Builds and compiles the LangGraph workflow.
+        """
+        workflow = StateGraph(GraphState)
+
+        # Add nodes
+        workflow.add_node(NodeStates.SUPERVISOR, self._supervisor_node)
+        workflow.add_node(NodeStates.INVENTORY, self._inventory_node)
+        workflow.add_node(NodeStates.ORDERS, self._orders_node)
+        workflow.add_node(NodeStates.GENERAL_RESPONSE, self._general_response_node)
+
+        # Set the entry point
+        workflow.set_entry_point(NodeStates.SUPERVISOR)
+
+        # Add conditional edges from the supervisor
+        workflow.add_conditional_edges(
+            NodeStates.SUPERVISOR,
+            lambda state: state["next_node"],
+            {
+                NodeStates.INVENTORY: NodeStates.INVENTORY,
+                NodeStates.ORDERS: NodeStates.ORDERS,
+                NodeStates.GENERAL_RESPONSE: NodeStates.GENERAL_RESPONSE,
+            },
+        )
+
+        # Add edges from the specific nodes to END
+        workflow.add_edge(NodeStates.INVENTORY, END)
+        workflow.add_edge(NodeStates.ORDERS, END)
+        workflow.add_edge(NodeStates.GENERAL_RESPONSE, END)
+
+        return workflow.compile()
+
+    # --- Public Methods for Interaction ---
+
+    async def ainvoke(self, user_message: str) -> dict:
+        """
+        Invokes the graph with a user message.
+
+        Args:
+            user_message (str): The current message from the user.
+
+        Returns:
+            str: The final state of the graph after processing the message.
+        """
+        inputs = {"messages": [user_message]}
+        result = await self.app.ainvoke(inputs)
+
+        messages = result.get("messages", [])
+        if not messages:
+            raise RuntimeError("No messages found in the graph response.")
+
+        # Find the last AIMessage with non-empty content
+        for message in reversed(messages):
+            if isinstance(message, AIMessage) and message.content.strip():
+                logger.debug(f"Valid AIMessage found: {message.content.strip()}")
+                return message.content.strip()
+
+        # If no valid AIMessage found, return the last message as a fallback
+        return messages[-1].content.strip() if messages else "No valid response generated."

--- a/coffeeAGNTCY/coffee_agents/lungo/farms/vietnam/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/farms/vietnam/farm_server.py
@@ -23,7 +23,11 @@ from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
 
 from agent_executor import FarmAgentExecutor
-from config.config import DEFAULT_MESSAGE_TRANSPORT, TRANSPORT_SERVER_ENDPOINT
+from config.config import (
+    DEFAULT_MESSAGE_TRANSPORT, 
+    TRANSPORT_SERVER_ENDPOINT,
+    FARM_BROADCAST_TOPIC,
+)
 from card import AGENT_CARD
 
 # Initialize a multi-protocol, multi-transport gateway factory.
@@ -45,7 +49,16 @@ async def main():
         DEFAULT_MESSAGE_TRANSPORT,
         endpoint=TRANSPORT_SERVER_ENDPOINT,
     )
-    bridge = factory.create_bridge(server, transport=transport)
+
+    # explicitly create a broadcast bridge to the farm yield topic
+    broadcast_bridge = factory.create_bridge(
+        server, transport=transport, topic=FARM_BROADCAST_TOPIC
+    )
+
+    # create the default bridge to the server with a topic generated from the agent card
+    bridge = factory.create_bridge(server, transport=transport) 
+
+    await broadcast_bridge.start(blocking=False)
     await bridge.start(blocking=True)
 
 if __name__ == '__main__':

--- a/coffeeAGNTCY/coffee_agents/lungo/pyproject.toml
+++ b/coffeeAGNTCY/coffee_agents/lungo/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "requests",
     "starlette",
     "uvicorn",
-    "gateway-sdk==0.1.1",
+    "gateway-sdk==0.1.2",
 ]
 
 [project.optional-dependencies]

--- a/coffeeAGNTCY/coffee_agents/lungo/uv.lock
+++ b/coffeeAGNTCY/coffee_agents/lungo/uv.lock
@@ -503,7 +503,7 @@ wheels = [
 
 [[package]]
 name = "gateway-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -517,9 +517,9 @@ dependencies = [
     { name = "traceloop-sdk" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/a9/57f7ea99c6334aa69d0b77407c5ae9cd64642b9534fa418ac5af3b3e4db1/gateway_sdk-0.1.1.tar.gz", hash = "sha256:1f0d7fa55fe33390af2b91c7cb43c34ad56217d454453a6173b0e065de647da4", size = 837749, upload-time = "2025-06-04T15:44:37.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/26/0118c46f440490f7d2421438a4c6f756bd27b2355988e66594165e3d386c/gateway_sdk-0.1.2.tar.gz", hash = "sha256:69ec0015fe9087db07c5d571472947eabe036344c4950c3278255fc37c4646b2", size = 839293, upload-time = "2025-06-23T16:31:54.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/47/0e7e937f269fb67e481e3439accebc64b27f283189855d9ef0c53595e12e/gateway_sdk-0.1.1-py3-none-any.whl", hash = "sha256:ffa4130d63e8871fcab75abeaac58d40bb96c6265abc0708e34b33eabfd37266", size = 30835, upload-time = "2025-06-04T15:44:35.81Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/45/c3b119eac5f643587337f513cdd5bd0c5093327deee46e6e2996756004d0/gateway_sdk-0.1.2-py3-none-any.whl", hash = "sha256:55813b5e79b3c811d59d1a26ded56bca77f9a057cc85354f065ebd3d713593ad", size = 32230, upload-time = "2025-06-23T16:31:53.734Z" },
 ]
 
 [[package]]
@@ -1133,7 +1133,7 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fastapi" },
     { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "gateway-sdk", specifier = "==0.1.1" },
+    { name = "gateway-sdk", specifier = "==0.1.2" },
     { name = "httpx" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain-anthropic", specifier = ">=0.3.13" },


### PR DESCRIPTION
# Description

This PR refactors refactors the farm agents and exchange agent to use langgraph's edge transition pattern with a supervisor and sub agents for inventory and orders. The exchange inventory agent now includes a broadcast tool to message all farm agents via a publish event to a shared farm inventory topic. SLIM is now set as the default transport. 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/cisco-outshift-ai-agents/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
