### PR TITLE
BugFix: Invalid Path Name in Build and Push Docker Image GH Workflow

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -79,4 +79,4 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository_owner }}/coffeeAgntcy/${{ matrix.image.name }}:latest
+          tags: ghcr.io/${{ github.repository_owner }}/coffee-agntcy/${{ matrix.image.name }}:latest


### PR DESCRIPTION
# Description

Invalid path name in the build and push docker image step in the docker-build-push.yaml GH action where the path contained coffeeAGNTCY which had been remedied everywhere else as coffee-agntcy; therefore leading to issues in the GH action. Quick BugFix PR to modify this.

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/cisco-outshift-ai-agents/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
