### PR TITLE
feat: removes the boundary between the logo and the header

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/App.css
+++ b/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/App.css
@@ -67,10 +67,20 @@ body {
 /* Sidebar styling */
 .sidebar {
   width: var(--sidebar-width);
-  border-right: 1px solid var(--border-color);
-  padding: 0.75em;                /* 12px */
+  padding: 0.75em; /* 12px */
   overflow-y: hidden;
   background-color: #fff;
+  position: relative; /* Required for pseudo-element positioning */
+}
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  top: 11.25%;
+  right: 0;
+  width: 1px; /* Border thickness */
+  height: calc(100% - 11.25%); /* Adjust height to fill from top to bottom */
+  background-color: var(--border-color); /* Match border color */
 }
 
 /* Chat Container */

--- a/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/components/Chat/styles/Chat.css
+++ b/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/components/Chat/styles/Chat.css
@@ -28,7 +28,7 @@
 .clear_chat_button_container {
     position: absolute;
     z-index: 1;
-    top: 2px;
+    top: -1px;
     right: -10px;
     border: 0.1px solid #ccc;
     border-radius: 5px;

--- a/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/App.css
+++ b/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/App.css
@@ -67,10 +67,20 @@ body {
 /* Sidebar styling */
 .sidebar {
   width: var(--sidebar-width);
-  border-right: 1px solid var(--border-color);
-  padding: 0.75em;                /* 12px */
+  padding: 0.75em; /* 12px */
   overflow-y: hidden;
   background-color: #fff;
+  position: relative; /* Required for pseudo-element positioning */
+}
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  top: 11.25%;
+  right: 0;
+  width: 1px; /* Border thickness */
+  height: calc(100% - 11.25%); /* Adjust height to fill from top to bottom */
+  background-color: var(--border-color); /* Match border color */
 }
 
 /* Chat Container */

--- a/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/components/Chat/styles/Chat.css
+++ b/coffeeAGNTCY/coffee_agents/lungo/exchange/frontend/src/components/Chat/styles/Chat.css
@@ -28,7 +28,7 @@
 .clear_chat_button_container {
     position: absolute;
     z-index: 1;
-    top: 2px;
+    top: -1px;
     right: -10px;
     border: 0.1px solid #ccc;
     border-radius: 5px;


### PR DESCRIPTION
# Description
This PR removes the boundary between the logo and the header section

Lungo
<img width="1796" alt="Screenshot 2025-07-08 at 10 18 28 AM" src="https://github.com/user-attachments/assets/0ca789b4-20d9-4850-8661-e411ad587a4e" />
Corto
<img width="1797" alt="Screenshot 2025-07-08 at 10 28 13 AM" src="https://github.com/user-attachments/assets/74be903a-315a-4e0d-b550-5ffc97211dde" />



Reason for Changes:
- Improved User Focus: By removing the boundary, users can better focus on the logo and header simultaneously, enhancing sight-focus and usability.
- Future Flexibility: The header can now be expanded to include more diverse details, such as dynamic updates or additional contextual information, without being constrained by its previous behavior.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/cisco-outshift-ai-agents/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
