### PR TITLE
fix: update .env.example to use correct environment variable name for OPENAI models

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/.env.example
+++ b/coffeeAGNTCY/coffee_agents/corto/.env.example
@@ -6,7 +6,7 @@ OPENAI_TEMPERATURE=0.7
 # === OpenAI Settings ===
 LLM_PROVIDER=openai
 OPENAI_API_KEY=your_openai_api_key
-OPENAI_MODEL=gpt-4o
+OPENAI_MODEL_NAME=gpt-4o-mini
 
 # OTEL environment variables
 OTLP_HTTP_ENDPOINT="http://localhost:4318"

--- a/coffeeAGNTCY/coffee_agents/corto/README.md
+++ b/coffeeAGNTCY/coffee_agents/corto/README.md
@@ -72,7 +72,7 @@ Before you begin, ensure the following tools are installed:
    ```env
    LLM_PROVIDER=openai
    OPENAI_API_KEY=your_openai_api_key
-   OPENAI_MODEL=gpt-4o
+   OPENAI_MODEL_NAME=gpt-4o-mini
    ```
 
    *Azure OpenAI:*

--- a/coffeeAGNTCY/coffee_agents/lungo/.env.example
+++ b/coffeeAGNTCY/coffee_agents/lungo/.env.example
@@ -6,7 +6,7 @@ OPENAI_TEMPERATURE=0.7
 # === OpenAI Settings ===
 LLM_PROVIDER=openai
 OPENAI_API_KEY=your_openai_api_key
-OPENAI_MODEL=gpt-4o
+OPENAI_MODEL_NAME=gpt-4o-mini
 OTLP_HTTP_ENDPOINT="http://localhost:4318"
 # === Azure OpenAI Settings ===
 # Uncomment and fill in to use Azure instead of OpenAI

--- a/coffeeAGNTCY/coffee_agents/lungo/README.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/README.md
@@ -74,7 +74,7 @@ Before you begin, ensure the following tools are installed:
    ```env
    LLM_PROVIDER=openai
    OPENAI_API_KEY=your_openai_api_key
-   OPENAI_MODEL=gpt-4o
+   OPENAI_MODEL_NAME=gpt-4o-mini
    ```
 
    *Azure OpenAI:*


### PR DESCRIPTION
# Description

This PR addresses #83

The code in `/exchange/graph/graph.py` for both the `corto` and `lungo` examples relies on the package `cisco_outshift_agent_utils` and its `LLMFactory` class to instantiate the connection to the model server. The `LLMFactory`  class expects the model name to be defined using the environment variable `OPENAI_MODEL_NAME` and defaults to `gpt-4o-mini` when using the `openai` provider.

The existing `.env.example` file uses `OPENAI_MODEL` instead of `OPENAI_MODEL_NAME` causing the error mentioned in the linked Issue. 

This PR updates the `.env.example` files and the `README.md` in both examples to fix this issue. It also updates the default model from `gpt-4o` to `gpt-4o-mini` to align with the defaults used in `cisco_outshift_agent_utils`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
