### PR TITLE
feat: identity integration helm chart

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.3"
 description: A Helm chart for the Colombia Farm
 name: colombia-farm
-version: 0.0.3
+version: 0.0.4

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/templates/configmap.tpl.yaml
@@ -12,3 +12,7 @@ data:
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
   WEATHER_MCP_SERVER_URL: "{{ .Values.config.weatherMcpServerUrl }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"
+  IDENTITY_API_KEY: "{{ .Values.config.identityApiKey }}"
+  IDENTITY_API_SERVER_URL: "{{ .Values.config.identityApiServerUrl }}"
+  COLOMBIA_FARM_AGENT_URL: "{{ .Values.config.colombiaFarmAgentUrl }}"
+  IDENTITY_COLOMBIA_AGENT_SERVICE_API_KEY: "{{ .Values.config.identityColombiaAgentServiceApiKey }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/values.yaml
@@ -23,6 +23,12 @@ config:
   defaultMessageTransport: ""
   weatherMcpServerUrl: ""
   otlpHttpEndpoint: ""
+  # Identity configuration
+  identityApiKey: "" # General Identity SaaS API key
+  identityApiServerUrl: "" # Identity API endpoint
+  colombiaFarmAgentUrl: "" # Colombia farm agent URL
+  identityColombiaAgentServiceApiKey: "" # Colombia agent service API key
+
 # serviceaccount:
 #   annotations:
 #     eks.amazonaws.com/role-arn: REPLACE_WITH_ROLE_ARN

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/exchange/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/exchange/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Helm chart for the Lungo Exchange Server
 name: lungo-exchange
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/exchange/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/exchange/templates/configmap.tpl.yaml
@@ -11,3 +11,5 @@ data:
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"
+  IDENTITY_API_KEY: "{{ .Values.config.identityApiKey }}"
+  IDENTITY_API_SERVER_URL: "{{ .Values.config.identityApiServerUrl }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/exchange/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/exchange/values.yaml
@@ -22,6 +22,9 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  # Identity configuration
+  identityApiKey: "" # General Identity SaaS API key
+  identityApiServerUrl: "" # Identity API endpoint
 # serviceaccount:
 #   annotations:
 #     eks.amazonaws.com/role-arn: REPLACE_WITH_ROLE_ARN

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Helm chart for the Vietnam Farm
 name: vietnam-farm
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/templates/configmap.tpl.yaml
@@ -11,3 +11,7 @@ data:
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"
+  IDENTITY_API_KEY: "{{ .Values.config.identityApiKey }}"
+  IDENTITY_API_SERVER_URL: "{{ .Values.config.identityApiServerUrl }}"
+  VIETNAM_FARM_AGENT_URL: "{{ .Values.config.vietnamFarmAgentUrl }}"
+  IDENTITY_VIETNAM_AGENT_SERVICE_API_KEY: "{{ .Values.config.identityVietnamAgentServiceApiKey }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/values.yaml
@@ -22,6 +22,11 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  # Identity configuration
+  identityApiKey: "" # General Identity SaaS API key
+  identityApiServerUrl: "" # Identity API endpoint
+  vietnamFarmAgentUrl: "" # Vietnam farm agent URL
+  identityVietnamAgentServiceApiKey: "" # Vietnam agent service API key
 # serviceaccount:
 #   annotations:
 #     eks.amazonaws.com/role-arn: REPLACE_WITH_ROLE_ARN


### PR DESCRIPTION
# Description

Updated Helm charts for colombia-farm, vietnam-farm, and lungo-exchange to include Identity configuration variables in values.yaml and configmap.tpl.yaml.
Incremented chart versions to reflect the changes (colombia-farm to 0.0.4, vietnam-farm to 0.0.3, and lungo-exchange to 0.0.3).
Added support for IDENTITY_API_KEY, IDENTITY_API_SERVER_URL, and agent-specific keys and URLs in the ConfigMaps.


## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
