### PR TITLE
fix: corto-ui helm chart deployment template optional service account

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/corto-ui/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/corto-ui/templates/deployment.tpl.yaml
@@ -21,7 +21,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
     {{ end }}
+    {{- if .Values.serviceaccount }}
       serviceAccountName: {{ .Values.appName }}-sa
+    {{ end }}
       containers:
       - name: {{ .Values.appName }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
# Description

This PR addresses #96 

This PR adds an `if` statement around the `serviceAccountName` field in the `deployment.tpl.yaml` in the corto-ui example so that it is only rendered if there are values for the service account in `values.yaml` 

This is needed since the service account values are commented out by default, leading to a situation where the `deployment.yaml` defines a `serviceAccountName` without the corresponding service account being created. 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
