### PR TITLE
Add Write Permission to CI Job

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Second attempt for fixing the CI job - original errors were fixed with #109, but the new error indicates the CI job doesn't have necessary permission: https://github.com/agntcy/coffeeAgntcy/actions/runs/17157869215/job/48679237389#step:5:118

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
