### PR TITLE
chore: increase timeout seconds for liveness probe

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart for the Logistic Accountant agent
 name: logistic-accountant
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/templates/deployment.tpl.yaml
@@ -44,6 +44,7 @@ spec:
             port: {{ .Values.probes.port }}
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         {{ end }}
         {{ if .Values.probes.livenessProbeEnabled }}
         livenessProbe:
@@ -52,6 +53,7 @@ spec:
             port: {{ .Values.probes.port }}
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         {{ end }}
         envFrom:
           - configMapRef:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/values.yaml
@@ -32,6 +32,8 @@ probes:
   endpoint: /v1/health
   initialDelaySeconds: 300  # Wait 5 minutes before the first check
   periodSeconds: 300       # Check every 5 minutes
+  timeoutSeconds: 60
+
 
 
 resources:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/accountant/values.yaml
@@ -32,7 +32,7 @@ probes:
   endpoint: /v1/health
   initialDelaySeconds: 300  # Wait 5 minutes before the first check
   periodSeconds: 300       # Check every 5 minutes
-  timeoutSeconds: 60
+  timeoutSeconds: 30
 
 
 

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart for the Logistic Farm agent
 name: logistic-farm
 version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Helm chart for the Logistic Farm agent
 name: logistic-farm
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/templates/deployment.tpl.yaml
@@ -44,6 +44,7 @@ spec:
             port: {{ .Values.probes.port }}
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         {{ end }}
         {{ if .Values.probes.livenessProbeEnabled }}
         livenessProbe:
@@ -52,6 +53,7 @@ spec:
             port: {{ .Values.probes.port }}
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         {{ end }}
         envFrom:
           - configMapRef:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/values.yaml
@@ -32,6 +32,7 @@ probes:
   endpoint: /v1/health
   initialDelaySeconds: 300  # Wait 5 minutes before the first check
   periodSeconds: 300       # Check every 5 minutes
+  timeoutSeconds: 60
 
 resources:
   enabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistic-farm/values.yaml
@@ -32,7 +32,7 @@ probes:
   endpoint: /v1/health
   initialDelaySeconds: 300  # Wait 5 minutes before the first check
   periodSeconds: 300       # Check every 5 minutes
-  timeoutSeconds: 60
+  timeoutSeconds: 30
 
 resources:
   enabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart for the Logistic Shipper agent
 name: logistic-shipper
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/templates/deployment.tpl.yaml
@@ -44,6 +44,7 @@ spec:
             port: {{ .Values.probes.port }}
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         {{ end }}
         {{ if .Values.probes.livenessProbeEnabled }}
         livenessProbe:
@@ -52,6 +53,7 @@ spec:
             port: {{ .Values.probes.port }}
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         {{ end }}
         envFrom:
           - configMapRef:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/values.yaml
@@ -32,6 +32,7 @@ probes:
   endpoint: /v1/health
   initialDelaySeconds: 300
   periodSeconds: 300
+  timeoutSeconds: 60
 
 resources:
   enabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/shipper/values.yaml
@@ -32,7 +32,7 @@ probes:
   endpoint: /v1/health
   initialDelaySeconds: 300
   periodSeconds: 300
-  timeoutSeconds: 60
+  timeoutSeconds: 30
 
 resources:
   enabled: false


### PR DESCRIPTION
# Description

liveness probe `timeoutSeconds` should be greater than or equal to the timeout we set in health-check endpoint.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
