### PR TITLE
fix: otel limits and add batch processor for logs

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/config/docker/otel/otel-collector-config.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/config/docker/otel/otel-collector-config.yaml
@@ -9,7 +9,9 @@ receivers:
         endpoint: "0.0.0.0:4317"
       http:
         endpoint: "0.0.0.0:4318"
-        max_request_body_size: 10485760 # 10 MB
+
+processors:
+  batch: {}
 
 exporters:
   clickhouse:


### PR DESCRIPTION
# Description

fix: otel limits and add batch processor for logs
```
2025-09-29 17:54:41,523 [ERROR] opentelemetry.exporter.otlp.proto.http.metric_exporter: Failed to export batch code: 400, reason:http: request body too large
2025-09-29 17:55:42,080 [ERROR] opentelemetry.exporter.otlp.proto.http.metric_exporter: Failed to export batch code: 400, reason:http: request body too large

```
## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
