### PR TITLE
Refactor: switch relative imports to absolute across codebase (NFC)

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/exchange/main.py
+++ b/coffeeAGNTCY/coffee_agents/corto/exchange/main.py
@@ -3,16 +3,18 @@
 
 import logging
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
-from dotenv import load_dotenv
-from config.logging_config import setup_logging
-from graph import shared
+
 from agntcy_app_sdk.factory import AgntcyFactory
-from graph.graph import ExchangeGraph
 from ioa_observe.sdk.tracing import session_start
+
+from config.logging_config import setup_logging
+from exchange.graph import shared
+from exchange.graph.graph import ExchangeGraph
 
 setup_logging()
 logger = logging.getLogger("corto.supervisor.main")

--- a/coffeeAGNTCY/coffee_agents/corto/farm/agent.py
+++ b/coffeeAGNTCY/coffee_agents/corto/farm/agent.py
@@ -4,11 +4,12 @@
 import logging
 from typing import TypedDict
 
-from langgraph.graph import END, START, StateGraph
 from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.graph import END, START, StateGraph
+
+from ioa_observe.sdk.decorators import agent, graph
 
 from common.llm import get_llm
-from ioa_observe.sdk.decorators import agent, graph
 
 logger = logging.getLogger("corto.farm_agent.graph")
 

--- a/coffeeAGNTCY/coffee_agents/corto/farm/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/corto/farm/agent_executor.py
@@ -17,7 +17,7 @@ from a2a.utils import (
 )
 from a2a.utils.errors import ServerError
 
-from agent import FarmAgent
+from farm.agent import FarmAgent
 
 logger = logging.getLogger("corto.farm_agent.a2a_executor")
 

--- a/coffeeAGNTCY/coffee_agents/corto/farm/card.py
+++ b/coffeeAGNTCY/coffee_agents/corto/farm/card.py
@@ -5,6 +5,7 @@ from a2a.types import (
     AgentCapabilities,
     AgentCard,
     AgentSkill)
+
 from config.config import FARM_AGENT_HOST, FARM_AGENT_PORT
 
 AGENT_SKILL = AgentSkill(

--- a/coffeeAGNTCY/coffee_agents/corto/farm/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/corto/farm/farm_server.py
@@ -5,15 +5,17 @@ import asyncio
 from uvicorn import Config, Server
 
 from a2a.server.apps import A2AStarletteApplication
-from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
-from agntcy_app_sdk.factory import AgntcyFactory
+from a2a.server.tasks import InMemoryTaskStore
 from dotenv import load_dotenv
+
+from agntcy_app_sdk.factory import AgntcyFactory
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
-from agent_executor import FarmAgentExecutor
-from card import AGENT_CARD
+
 from config.config import FARM_AGENT_HOST, FARM_AGENT_PORT
 from config.config import DEFAULT_MESSAGE_TRANSPORT, TRANSPORT_SERVER_ENDPOINT
+from farm.agent_executor import FarmAgentExecutor
+from farm.card import AGENT_CARD
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/agent.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from langgraph.graph import MessagesState
+
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import PromptTemplate
+from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph, END
-from common.llm import get_llm
+
 from ioa_observe.sdk.decorators import agent, graph
+
+from common.llm import get_llm
 
 logger = logging.getLogger("lungo.brazil_farm_agent.agent")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/agent_executor.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
-from a2a.utils.errors import ServerError
 from a2a.types import (
     UnsupportedOperationError,
     JSONRPCResponse,
@@ -17,13 +16,13 @@ from a2a.types import (
     Part,
     TextPart,
     Task)
-
 from a2a.utils import (
     new_task,
 )
+from a2a.utils.errors import ServerError
 
-from agent import FarmAgent
-from card import AGENT_CARD
+from agents.farms.brazil.agent import FarmAgent
+from agents.farms.brazil.card import AGENT_CARD
 
 logger = logging.getLogger("longo.brazil_farm_agent.agent_executor")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/farm_server.py
@@ -5,22 +5,22 @@ import asyncio
 import os
 from uvicorn import Config, Server
 
-from agntcy_app_sdk.factory import AgntcyFactory
-from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
-
 from a2a.server.apps import A2AStarletteApplication
 from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
+from dotenv import load_dotenv
 
-from agent_executor import FarmAgentExecutor
+from agntcy_app_sdk.factory import AgntcyFactory
+from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
+
+from agents.farms.brazil.agent_executor import FarmAgentExecutor
+from agents.farms.brazil.card import AGENT_CARD
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
     FARM_BROADCAST_TOPIC,
     ENABLE_HTTP
 )
-from card import AGENT_CARD
-from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -15,11 +15,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+
 from langgraph.graph import MessagesState
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import PromptTemplate
 from langgraph.graph import StateGraph, END
-from common.llm import get_llm
 
 from agntcy_app_sdk.factory import AgntcyFactory
 from ioa_observe.sdk.decorators import agent, graph
@@ -28,6 +28,7 @@ from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
 )
+from common.llm import get_llm
 
 logger = logging.getLogger("lungo.colombia_farm_agent.agent")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent_executor.py
@@ -17,13 +17,12 @@ from a2a.types import (
     Part,
     TextPart,
     Task)
-
 from a2a.utils import (
     new_task,
 )
 
-from agent import FarmAgent
-from card import AGENT_CARD
+from agents.farms.colombia.agent import FarmAgent
+from agents.farms.colombia.card import AGENT_CARD
 
 logger = logging.getLogger("longo.colombia_farm_agent.agent_executor")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/farm_server.py
@@ -18,10 +18,10 @@ from config.config import (
     FARM_BROADCAST_TOPIC,
     ENABLE_HTTP,
 )
-from farms.colombia.agent import factory
-from farms.colombia.agent_executor import FarmAgentExecutor
-from farms.colombia.card import AGENT_CARD
-from farms.colombia.utils import create_badge_for_colombia_farm
+from agents.farms.colombia.agent import factory
+from agents.farms.colombia.agent_executor import FarmAgentExecutor
+from agents.farms.colombia.card import AGENT_CARD
+from agents.farms.colombia.utils import create_badge_for_colombia_farm
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/farm_server.py
@@ -2,23 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from uvicorn import Config, Server
-from starlette.routing import Route
+
 from a2a.server.apps import A2AStarletteApplication
-from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
-from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
-from agent_executor import FarmAgentExecutor
+from a2a.server.tasks import InMemoryTaskStore
+from dotenv import load_dotenv
+from starlette.routing import Route
+from uvicorn import Config, Server
+
+from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
+
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
     FARM_BROADCAST_TOPIC,
     ENABLE_HTTP,
 )
-from card import AGENT_CARD
-from agent import factory
-from dotenv import load_dotenv
-from utils import create_badge_for_colombia_farm
+from farms.colombia.agent import factory
+from farms.colombia.agent_executor import FarmAgentExecutor
+from farms.colombia.card import AGENT_CARD
+from farms.colombia.utils import create_badge_for_colombia_farm
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/utils.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/utils.py
@@ -3,14 +3,13 @@
 
 import logging
 
-from services.identity_service_impl import IdentityServiceImpl
-
 from config.config import (
   IDENTITY_COLOMBIA_AGENT_SERVICE_API_KEY,
   COLOMBIA_FARM_AGENT_URL,
   IDENTITY_API_KEY,
   IDENTITY_API_SERVER_URL,
 )
+from services.identity_service_impl import IdentityServiceImpl
 
 logger = logging.getLogger("colombia.utils")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/agent.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from langgraph.graph import MessagesState
+
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import PromptTemplate
+from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph, END
-from common.llm import get_llm
+
 from ioa_observe.sdk.decorators import agent, graph
+
+from common.llm import get_llm
 
 logger = logging.getLogger("lungo.vietnam_farm_agent.agent")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/agent_executor.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
-from a2a.utils.errors import ServerError
 from a2a.types import (
     UnsupportedOperationError,
     JSONRPCResponse,
@@ -17,13 +16,13 @@ from a2a.types import (
     Part,
     TextPart,
     Task)
-
 from a2a.utils import (
     new_task,
 )
+from a2a.utils.errors import ServerError
 
-from agent import FarmAgent
-from card import AGENT_CARD
+from agents.farms.vietnam.agent import FarmAgent
+from agents.farms.vietnam.card import AGENT_CARD
 
 logger = logging.getLogger("longo.vietnam_farm_agent.agent_executor")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/farm_server.py
@@ -2,25 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from uvicorn import Config, Server
+
 from agntcy_app_sdk.factory import AgntcyFactory
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
-from starlette.routing import Route
 from a2a.server.apps import A2AStarletteApplication
 from a2a.server.tasks import InMemoryTaskStore
 from a2a.server.request_handlers import DefaultRequestHandler
+from dotenv import load_dotenv
+from uvicorn import Config, Server
 
-from agent_executor import FarmAgentExecutor
+from agents.farms.vietnam.agent_executor import FarmAgentExecutor
+from agents.farms.vietnam.card import AGENT_CARD
+from agents.farms.vietnam.utils import create_badge_for_vietnam_farm
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
     FARM_BROADCAST_TOPIC,
     ENABLE_HTTP,
 )
-from card import AGENT_CARD
-from dotenv import load_dotenv
-
-from utils import create_badge_for_vietnam_farm
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/utils.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/utils.py
@@ -3,15 +3,13 @@
 
 import logging
 
-
-from services.identity_service_impl import IdentityServiceImpl
-
 from config.config import (
   IDENTITY_VIETNAM_AGENT_SERVICE_API_KEY,
   VIETNAM_FARM_AGENT_URL,
   IDENTITY_API_KEY,
   IDENTITY_API_SERVER_URL,
 )
+from services.identity_service_impl import IdentityServiceImpl
 
 logger = logging.getLogger("vietnam.utils")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/accountant/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/accountant/agent.py
@@ -2,17 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from langgraph.graph import MessagesState
+
 from langchain_core.messages import AIMessage
+from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph, END
+
 from ioa_observe.sdk.decorators import agent, graph
 
-logger = logging.getLogger("lungo.accountant_agent.agent")
 from common.logistic_states import (
     LogisticStatus,
     extract_status,
 )
 
+logger = logging.getLogger("lungo.accountant_agent.agent")
 
 # --- 1. Define Node Names as Constants ---
 class NodeStates:

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/accountant/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/accountant/agent_executor.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
-from a2a.utils.errors import ServerError
 from a2a.types import (
     UnsupportedOperationError,
     JSONRPCResponse,
@@ -17,13 +16,13 @@ from a2a.types import (
     Part,
     TextPart,
     Task)
-
 from a2a.utils import (
     new_task,
 )
+from a2a.utils.errors import ServerError
 
-from agent import AccountantAgent
-from card import AGENT_CARD
+from agents.logistics.accountant.agent import AccountantAgent
+from agents.logistics.accountant.card import AGENT_CARD
 
 logger = logging.getLogger("lungo.accountant_agent.agent_executor")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/accountant/server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/accountant/server.py
@@ -2,23 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.server.request_handlers import DefaultRequestHandler
+from dotenv import load_dotenv
 from uvicorn import Config, Server
 
 from agntcy_app_sdk.factory import AgntcyFactory
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
 
-from a2a.server.apps import A2AStarletteApplication
-from a2a.server.tasks import InMemoryTaskStore
-from a2a.server.request_handlers import DefaultRequestHandler
-
-from agent_executor import AccountantAgentExecutor
+from agents.logistics.accountant.agent_executor import AccountantAgentExecutor
+from agents.logistics.accountant.card import AGENT_CARD
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
     ENABLE_HTTP
 )
-from card import AGENT_CARD
-from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/farm/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/farm/agent.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from langgraph.graph import MessagesState
+
 from langchain_core.messages import AIMessage
+from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph, END
 from common.logistic_states import (
     LogisticStatus,
@@ -12,7 +13,6 @@ from common.logistic_states import (
 from ioa_observe.sdk.decorators import agent, graph
 
 logger = logging.getLogger("lungo.farm_agent.agent")
-
 
 # --- 1. Define Node Names as Constants ---
 class NodeStates:

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/farm/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/farm/agent_executor.py
@@ -22,8 +22,8 @@ from a2a.utils import (
     new_task,
 )
 
-from agent import FarmAgent
-from card import AGENT_CARD
+from agents.logistics.farm.agent import FarmAgent
+from agents.logistics.farm.card import AGENT_CARD
 
 logger = logging.getLogger("lungo.logistic_farm_agent.agent_executor")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/farm/server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/farm/server.py
@@ -2,23 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.server.request_handlers import DefaultRequestHandler
+from dotenv import load_dotenv
 from uvicorn import Config, Server
 
 from agntcy_app_sdk.factory import AgntcyFactory
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
 
-from a2a.server.apps import A2AStarletteApplication
-from a2a.server.tasks import InMemoryTaskStore
-from a2a.server.request_handlers import DefaultRequestHandler
-
-from agent_executor import FarmAgentExecutor
+from agents.logistics.farm.agent_executor import FarmAgentExecutor
+from agents.logistics.farm.card import AGENT_CARD
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
     ENABLE_HTTP
 )
-from card import AGENT_CARD
-from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/shipper/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/shipper/agent.py
@@ -2,17 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from langgraph.graph import MessagesState
+
 from langchain_core.messages import AIMessage
+from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph, END
+
+from ioa_observe.sdk.decorators import agent, graph
+
 from common.logistic_states import (
     LogisticStatus,
     extract_status,
 )
-from ioa_observe.sdk.decorators import agent, graph
 
 logger = logging.getLogger("lungo.shipper_agent.agent")
-
 
 # --- 1. Define Node Names as Constants ---
 class NodeStates:

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/shipper/agent_executor.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/shipper/agent_executor.py
@@ -17,13 +17,12 @@ from a2a.types import (
     Part,
     TextPart,
     Task)
-
 from a2a.utils import (
     new_task,
 )
 
-from agent import ShipperAgent
-from card import AGENT_CARD
+from agents.logistics.shipper.agent import ShipperAgent
+from agents.logistics.shipper.card import AGENT_CARD
 
 logger = logging.getLogger("lungo.shipper_agent.agent_executor")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/shipper/server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/logistics/shipper/server.py
@@ -2,23 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.server.request_handlers import DefaultRequestHandler
+from dotenv import load_dotenv
 from uvicorn import Config, Server
 
 from agntcy_app_sdk.factory import AgntcyFactory
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
 
-from a2a.server.apps import A2AStarletteApplication
-from a2a.server.tasks import InMemoryTaskStore
-from a2a.server.request_handlers import DefaultRequestHandler
-
-from agent_executor import ShipperAgentExecutor
+from agents.logistics.shipper.agent_executor import ShipperAgentExecutor
+from agents.logistics.shipper.card import AGENT_CARD
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
     ENABLE_HTTP
 )
-from card import AGENT_CARD
-from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/weather_service.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/weather_service.py
@@ -4,20 +4,19 @@
 from typing import Any
 import logging
 
-import httpx
 import asyncio
-
 from mcp.server.fastmcp import FastMCP
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
+import httpx
 
 from agntcy_app_sdk.factory import AgntcyFactory
+
 from config.config import (
     DEFAULT_MESSAGE_TRANSPORT,
     TRANSPORT_SERVER_ENDPOINT,
 )
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Initialize a multi-protocol, multi-transport agntcy factory.
 factory = AgntcyFactory("lungo_mcp_server", enable_tracing=True)

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/graph.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/graph.py
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import uuid
+
 from pydantic import BaseModel, Field
 
 from langchain_core.prompts import PromptTemplate
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage, HumanMessage
-
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph, END
 from langgraph.prebuilt import ToolNode
 from ioa_observe.sdk.decorators import agent, tool, graph
 
-from common.llm import get_llm
-from graph.tools import (
+from agents.supervisors.auction.graph.tools import (
     get_farm_yield_inventory, 
     get_all_farms_yield_inventory,
     create_order, 
     get_order_details, 
     tools_or_next
 )
+from common.llm import get_llm
 
 logger = logging.getLogger("lungo.supervisor.graph")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/models.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/models.py
@@ -1,8 +1,8 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-from pydantic import BaseModel, Field
 from typing import Literal
+from pydantic import BaseModel, Field
 
 class InventoryArgs(BaseModel):
     """Arguments for the create_order tool."""

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/tools.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/tools.py
@@ -6,7 +6,6 @@ from typing import Any, Union, Literal, NoReturn
 from uuid import uuid4
 from pydantic import BaseModel
 
-
 from a2a.types import (
     AgentCard,
     SendMessageRequest,
@@ -19,14 +18,9 @@ from a2a.types import (
 from langchain_core.tools import tool, ToolException
 from langchain_core.messages import AnyMessage, ToolMessage
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
-from graph.shared import get_factory
-from config.config import (
-    DEFAULT_MESSAGE_TRANSPORT, 
-    TRANSPORT_SERVER_ENDPOINT, 
-    FARM_BROADCAST_TOPIC,
-    IDENTITY_API_KEY,
-    IDENTITY_API_SERVER_URL,
-)
+from ioa_observe.sdk.decorators import tool as ioa_tool_decorator
+
+
 from agents.farms.brazil.card import AGENT_CARD as brazil_agent_card
 from agents.farms.colombia.card import AGENT_CARD as colombia_agent_card
 from agents.farms.vietnam.card import AGENT_CARD as vietnam_agent_card
@@ -34,10 +28,17 @@ from agents.supervisors.auction.graph.models import (
     InventoryArgs,
     CreateOrderArgs,
 )
+from agents.supervisors.auction.graph.shared import get_factory
+from config.config import (
+    DEFAULT_MESSAGE_TRANSPORT, 
+    TRANSPORT_SERVER_ENDPOINT, 
+    FARM_BROADCAST_TOPIC,
+    IDENTITY_API_KEY,
+    IDENTITY_API_SERVER_URL,
+)
 from services.identity_service import IdentityService
 from services.identity_service_impl import IdentityServiceImpl
 
-from ioa_observe.sdk.decorators import tool as ioa_tool_decorator
 
 logger = logging.getLogger("lungo.supervisor.tools")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/main.py
@@ -3,17 +3,19 @@
 
 import logging
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
-from config.logging_config import setup_logging
-from graph.graph import ExchangeGraph
-from dotenv import load_dotenv
-from graph import shared
+
 from agntcy_app_sdk.factory import AgntcyFactory
 from ioa_observe.sdk.tracing import session_start
+
+from agents.supervisors.auction.graph.graph import ExchangeGraph
+from agents.supervisors.auction.graph import shared
 from config.config import DEFAULT_MESSAGE_TRANSPORT
+from config.logging_config import setup_logging
 
 setup_logging()
 logger = logging.getLogger("lungo.supervisor.main")

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistic/graph/graph.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistic/graph/graph.py
@@ -6,18 +6,17 @@ import uuid
 
 from langchain_core.prompts import PromptTemplate
 from langchain_core.messages import AIMessage
-
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph
 from langgraph.prebuilt import ToolNode
 from ioa_observe.sdk.decorators import agent, tool, graph
 
-from common.llm import get_llm
 from agents.supervisors.logistic.graph.tools import (
     create_order,
     next_tools_or_end
 )
+from common.llm import get_llm
 
 logger = logging.getLogger("lungo.logistic.supervisor.graph")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistic/graph/tools.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistic/graph/tools.py
@@ -7,6 +7,8 @@ import re
 from typing import Any, Sequence
 from uuid import uuid4
 
+from fastapi import HTTPException
+
 from a2a.types import (
   Message,
   MessageSendParams,
@@ -16,7 +18,7 @@ from a2a.types import (
   TextPart,
 )
 from agntcy_app_sdk.protocols.a2a.protocol import A2AProtocol
-from fastapi import HTTPException
+from ioa_observe.sdk.decorators import tool as ioa_tool_decorator
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 
@@ -30,10 +32,8 @@ from config.config import (
   TRANSPORT_SERVER_ENDPOINT,
 )
 from common.logistic_states import LogisticStatus
-from ioa_observe.sdk.decorators import tool as ioa_tool_decorator
 
 logger = logging.getLogger("lungo.logistic.supervisor.tools")
-
 
 def next_tools_or_end(state: dict[str, Any]) -> str:
   """

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistic/main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistic/main.py
@@ -4,21 +4,23 @@
 import asyncio
 import logging
 import os
+
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
-from config.logging_config import setup_logging
-from agents.supervisors.logistic.graph.graph import LogisticGraph
-from dotenv import load_dotenv
-from graph import shared
+
 from agntcy_app_sdk.factory import AgntcyFactory
 from ioa_observe.sdk.tracing import session_start
+
+from agents.supervisors.logistic.graph.graph import LogisticGraph
+from agents.supervisors.logistic.graph import shared
 from config.config import DEFAULT_MESSAGE_TRANSPORT
+from config.logging_config import setup_logging
 
 setup_logging()
 logger = logging.getLogger("lungo.logistic.supervisor.main")
-
 
 load_dotenv()
 

--- a/coffeeAGNTCY/coffee_agents/lungo/common/llm.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/llm.py
@@ -1,9 +1,8 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 from cnoe_agent_utils import LLMFactory
+
 from config.config import LLM_PROVIDER
 
 def get_llm():

--- a/coffeeAGNTCY/coffee_agents/lungo/services/identity_service_impl.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/services/identity_service_impl.py
@@ -1,13 +1,15 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-import requests
 import asyncio
 from pydantic import ValidationError
-from services.identity_service import IdentityService
+import requests
 from typing import Dict, Any
-from services.models import IdentityServiceApps, Badge
+
 from identityservice.sdk import IdentityServiceSdk
+
+from services.identity_service import IdentityService
+from services.models import IdentityServiceApps, Badge
 
 CLI_MAX_RETRIES = 3
 CLI_RETRY_DELAY = 2


### PR DESCRIPTION
# Description

Convert all Python imports from mixed relative/absolute to absolute imports across the codebase. This is a non-functional change (NFC): no logic or behavior was modified, only import paths.

- Improves clarity and explicitness (PEP 8 favors absolute imports).
- Makes tests more reliable regardless of working directory/PYTHONPATH.
- Fixed any import groups/orders affected by the switch (import sorters)

Tested by running corto and lungo locally.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
