### PR TITLE
BugFix: Improve farm identity verification by raising error when identity service is not enabled

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/tools.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/tools.py
@@ -129,10 +129,10 @@ def verify_farm_identity(identity_service: IdentityService, farm_name: str):
         matched_app = next((app for app in all_apps.apps if app.name.lower() == farm_name.lower()), None)
 
         if not matched_app:
-            logger.warning(f"Identity verification failed for farm {farm_name}: "
-                           f"No matching app found, this farm probably does not have identity service enabled. "
-                           f"Skipping identity verification.")
-            return
+            err_msg = f"Identity verification failed for farm {farm_name}: No matching app found, this farm does not have identity service enabled."
+            logger.error(err_msg)
+            raise A2AAgentError(err_msg)
+
 
         badge = identity_service.get_badge_for_app(matched_app.id)
         success = identity_service.verify_badges(badge)

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/main.py
@@ -91,4 +91,4 @@ async def version_info():
 
 # Run the FastAPI server using uvicorn
 if __name__ == "__main__":
-  uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+  uvicorn.run("agents.supervisors.auction.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
# Description

This fix addresses an issue in the farm identity verification process where the absence of a matching app (indicating the farm does not have identity service enabled) was previously logged as a warning and silently skipped. Now, the code raises an A2AAgentError with a clear error message and logs it as an error. This change ensures that identity verification failures are properly surfaced and handled, improving reliability and observability.

Fixes GitHub issue: [#186](https://github.com/agntcy/coffeeAgntcy/issues/186)

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
