### PR TITLE
Fix message classification template to correctly identify invalid prompts

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/graph.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/graph/graph.py
@@ -124,7 +124,8 @@ class ExchangeGraph:
             template="""You are a global coffee exchange agent connecting users to coffee farms in Brazil, Colombia, and Vietnam. 
             Based on the user's message, determine if it's related to 'inventory' or 'orders'.
             Respond with 'inventory' if the message is about checking yield, stock, product availability, regions of origin, or specific coffee item details.
-            Respond with 'orders' if the message is about checking order status, placing an order, or modifying an existing order.
+            Respond with 'orders' if the message is about checking coffee order status, placing a coffee order, or modifying an existing coffee order.
+            Respond with 'none of the above' if the message is unrelated to coffee 'inventory' or 'orders'.
             
             User message: {user_message}
             """,


### PR DESCRIPTION
# Description

This fix updates the message classification template used by the global coffee exchange agent to improve intent detection accuracy. It adds a response for messages unrelated to either the inventory or orders category as 'none of the above'. This change resolves a bug where certain user messages were misclassified, enhancing the agent’s ability to route queries correctly and improving overall user experience.

Fixes #187 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
