### PR TITLE
Fix spelling of 'fulfil' to 'fulfill' in example prompts

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/Prompts/CoffeePromptsDropdown.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/Prompts/CoffeePromptsDropdown.tsx
@@ -20,7 +20,7 @@ const CoffeePromptsDropdown: React.FC<CoffeePromptsDropdownProps> = ({
   const buyerPrompts = [
     "What yield do the farms have?",
     "What is the current inventory?",
-    "I'd like to buy 200 lbs quantity of coffee and who can fulfil it?",
+    "I'd like to buy 200 lbs quantity of coffee and who can fulfill it?",
     "List all the coffee farms",
     "Where can I get the best coffee with flavors like Ethiopian?",
   ]


### PR DESCRIPTION
# Description

Fix typo in example prompt: "fulfil" -> "fulfill".

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
