### PR TITLE
remove group communication feed auto collapse

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/GroupCommunicationFeed.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/GroupCommunicationFeed.tsx
@@ -216,13 +216,6 @@ const GroupCommunicationFeed: React.FC<GroupCommunicationFeedProps> = ({
         isComplete: true,
       }))
 
-      setTimeout(() => {
-        setState((prev) => ({
-          ...prev,
-          isExpanded: false,
-        }))
-      }, 1000)
-
       if (onComplete) {
         onComplete()
       }


### PR DESCRIPTION
# Description

Remove auto-collapse of the Group Communication Feed panel and allow users to manually collapse it. Currently, when the stream’s final event arrives with state "DELIVERED", the component marks the stream as complete and then collapses the panel after a 1s delay.


Fixes #234 
<img width="1917" height="1080" alt="image" src="https://github.com/user-attachments/assets/9c425975-bacf-4424-a241-99b3f43605a2" />

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
