### PR TITLE
add nats version to the about modal in lungo ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ We currently provide two setups you can run to see how components from AGNTCY wo
 
 - [AGNTCY App SDK](https://github.com/agntcy/app-sdk) = v0.4.0
 - [SLIM](https://github.com/agntcy/slim) = v0.4.0
+- [NATS](https://github.com/nats-io/nats-server) = v2.11.8
 - [A2A](https://github.com/a2aproject/a2a-python) = v0.3.0
 - [MCP](https://github.com/modelcontextprotocol/python-sdk) >= v1.10.0
 - [LangGraph](https://github.com/langchain-ai/langgraph) >= v0.4.1


### PR DESCRIPTION
# Description

- Connects to the running NATS server via socket with dynamic hostname resolution
- Parses the server's INFO message to get the version number at runtime and resolve 'latest' to the actual version
- Includes NATS version info to Lungo UI about modal
- Updates README to include NATS version info

<img width="1920" height="1080" alt="Screenshot 2025-11-04 at 9 16 25 AM" src="https://github.com/user-attachments/assets/1fb6c9a1-332b-4ef5-8b99-fd2efd6703a0" />


## Issue Link
Fixes #257 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
