### PR TITLE
fix: UI displays app-sdk version as "unknown"

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/common/version.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/version.py
@@ -64,10 +64,8 @@ def get_dependencies():
                 name, op, ver = _extract_name_and_version(dep)
                 display = DISPLAY_NAMES.get(name)
                 if display:
-                    if op == '==':
+                    if op == '==' or op == '>=':
                         dependencies[display] = f"v{ver}"
-                    elif op == '>=':
-                        dependencies[display] = f">= v{ver}"
                     else:
                         dependencies[display] = "unknown"
         

--- a/coffeeAGNTCY/coffee_agents/lungo/pyproject.toml
+++ b/coffeeAGNTCY/coffee_agents/lungo/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "langchain>=0.3.27",
     "langchain-litellm>=0.3.0",
     "litellm[proxy]==1.75.3",
-    "agntcy-app-sdk",
+    "agntcy-app-sdk==0.4.5",
 ]
 
 [project.optional-dependencies]

--- a/coffeeAGNTCY/coffee_agents/lungo/uv.lock
+++ b/coffeeAGNTCY/coffee_agents/lungo/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1938,7 +1938,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = "==0.3.0" },
-    { name = "agntcy-app-sdk" },
+    { name = "agntcy-app-sdk", specifier = "==0.4.5" },
     { name = "agntcy-identity-service-sdk", specifier = "==0.0.7" },
     { name = "autogen-core", marker = "extra == 'dev'", specifier = ">=0.4.3,<0.5" },
     { name = "click", specifier = ">=8.1.8" },


### PR DESCRIPTION
# Description

The app-sdk version should display the actual version number (e.g., v0.4.5)
The package should use a fixed version constraint (==) for accurate version

### Screenshot
<img width="503" height="377" alt="Screenshot 2025-12-01 at 2 04 10 PM" src="https://github.com/user-attachments/assets/1353a664-6347-4737-99a9-29663d5456a3" />


## Issue Link

#304 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
