### PR TITLE
Add additional ingress template to supervisor charts

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.1"
+appVersion: "0.0.2"
 description: A Helm chart for Auction Supervisor
 name: auction-supervisor
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/ingress.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/ingress.tpl.yaml
@@ -26,3 +26,33 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecret }}
 {{- end }}
+
+{{/* Optional second ingress for a specific path prefix and annotations */}}
+{{- if .Values.extraIngress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.extraIngress.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.extraIngress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.extraIngress.className }}
+  rules:
+    - host: {{ .Values.extraIngress.host }}
+      http:
+        paths:
+          - path: {{ .Values.extraIngress.path }}
+            pathType: {{ .Values.extraIngress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ .Values.extraIngress.serviceName }}
+                port:
+                  number: {{ .Values.extraIngress.servicePort }}
+  tls:
+    - hosts:
+        - {{ .Values.extraIngress.host }}
+      secretName: {{ .Values.extraIngress.tlsSecret }}
+{{- end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/values.yaml
@@ -50,6 +50,18 @@ ingress:
   tlsSecret: ""
   annotations: {}
 
+extraIngress:
+    enabled: false  # If set to true, configure the values below for your additional ingress setup
+    name: ""
+    className: ""
+    host: ""
+    serviceName: ""
+    servicePort: ""
+    tlsSecret: ""
+    path: ""
+    pathType: ""
+    annotations: {}
+
 probes:
   livenessProbeEnabled: false
   readinessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.1"
+appVersion: "0.0.2"
 description: A Helm chart for the Logistics Supervisor agent
 name: logistics-supervisor
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/ingress.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/ingress.tpl.yaml
@@ -26,3 +26,34 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecret }}
 {{- end }}
+
+
+{{/* Optional second ingress for a specific path prefix and annotations */}}
+{{- if .Values.extraIngress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.extraIngress.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.extraIngress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.extraIngress.className }}
+  rules:
+    - host: {{ .Values.extraIngress.host }}
+      http:
+        paths:
+          - path: {{ .Values.extraIngress.path }}
+            pathType: {{ .Values.extraIngress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ .Values.extraIngress.serviceName }}
+                port:
+                  number: {{ .Values.extraIngress.servicePort }}
+  tls:
+    - hosts:
+        - {{ .Values.extraIngress.host }}
+      secretName: {{ .Values.extraIngress.tlsSecret }}
+{{- end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/values.yaml
@@ -41,6 +41,18 @@ ingress:
   tlsSecret: ""
   annotations: {}
 
+extraIngress:
+    enabled: false  # If set to true, configure the values below for your additional ingress setup
+    name: ""
+    className: ""
+    host: ""
+    serviceName: ""
+    servicePort: ""
+    tlsSecret: ""
+    path: ""
+    pathType: ""
+    annotations: {}
+
 probes:
   livenessProbeEnabled: false
   readinessProbeEnabled: false


### PR DESCRIPTION
# Description

Add optional extra Ingress for a specific path.

This PR updates the Helm charts for the supervisors to support deploying an additional Ingress resource for a specific path prefix (e.g. `/agent/prompt/...`) while keeping the existing base Ingress `(/)` unchanged. The feature is disabled by default and is intended to be enabled only via environment-specific/internal values overrides.

This enables teams to apply different Ingress annotations (e.g., internal gateways/checks) to specific endpoints (e.g. `/agent/prompt/...`) without affecting other endpoints on the same host.


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
