### PR TITLE
Send session cookies on agent prompt requests by enabling withCredentials in axios calls

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useAgentAPI.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useAgentAPI.ts
@@ -79,7 +79,7 @@ export const useAgentAPI = (): UseAgentAPIReturn => {
         {
           prompt,
         },
-        { signal: controller.signal },
+        { signal: controller.signal, withCredentials: true },
       )
       return response.data.response
     }
@@ -152,7 +152,7 @@ export const useAgentAPI = (): UseAgentAPIReturn => {
         {
           prompt,
         },
-        { signal: controller.signal },
+        { signal: controller.signal, withCredentials: true },
       )
       return response.data.response
     }


### PR DESCRIPTION
# Description

This PR updates the UI’s agent API client to include cookies on requests to the agent backend by setting `withCredentials: true` in axios POST calls to `/agent/prompt`. This is required for session-based features (authentication enforcement and per-user rate limiting) when the UI and agent backend are hosted on different origins/subdomains.

Reference: https://axios-http.com/docs/req_config

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
