### PR TITLE
Include credentials to allow sending session cookie while making stream prompt processing requests

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/auctionStreamingStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/auctionStreamingStore.ts
@@ -60,6 +60,7 @@ export const useAuctionStreamingStore = create<StreamingState>((set) => ({
 
       const response = await fetch(streamingUrl, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ prompt }),
         signal: abortController.signal,


### PR DESCRIPTION
# Description

Similar to https://github.com/agntcy/coffeeAgntcy/pull/327, this one-liner is to include session cookie when making the requests to the streaming endpoint on Lungo supervisors.


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
