### PR TITLE
Include credentials(e.g. session cookies) for group chat streaming prompt requests

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/groupStreamingStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/groupStreamingStore.ts
@@ -131,6 +131,7 @@ export const useGroupStreamingStore = create<
         `${LOGISTICS_APP_API_URL}/agent/prompt/stream`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
           },


### PR DESCRIPTION
# Description

Same as #328 

(I mistakenly thought the group chat and pub/sub patterns are using the same POST request for streaming prompt requests)

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
