### PR TITLE
Add YAML document separator between two Ingresses in the same yaml

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart for Auction Supervisor
 name: auction-supervisor
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/ingress.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/ingress.tpl.yaml
@@ -29,6 +29,7 @@ spec:
 
 {{/* Optional second ingress for a specific path prefix and annotations */}}
 {{- if .Values.extraIngress.enabled }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart for the Logistics Supervisor agent
 name: logistics-supervisor
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/ingress.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/ingress.tpl.yaml
@@ -30,6 +30,7 @@ spec:
 
 {{/* Optional second ingress for a specific path prefix and annotations */}}
 {{- if .Values.extraIngress.enabled }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
# Description

Current ingress.yaml files are missing the document separator and the first ingress will get committed on rendering.

## Issue Link
N/A

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
