### PR TITLE
Improve UI error handling on prompt requests for both Lungo and Corto

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/utils/const.ts
+++ b/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/utils/const.ts
@@ -8,3 +8,27 @@ export const Role = {
   USER: "user",
 } as const
 export type RoleType = (typeof Role)[keyof typeof Role]
+
+export type ApiErrorInfo = {
+  status?: number
+  message: string
+}
+
+export const parseApiError = (error: any): ApiErrorInfo => {
+  if (error?.response) {
+    const status = error.response.status
+    const data = error.response.data
+
+    return {
+      status,
+      message:
+        typeof data === "string"
+          ? data
+          : data?.message || "Request failed",
+    }
+  }
+
+  return {
+    message: "Sorry, something went wrong. Please try again later.",
+  }
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/App.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import { ThemeProvider } from "@/contexts/ThemeContext"
 import { Message } from "./types/message"
 import { getGraphConfig } from "@/utils/graphConfigs"
 import { PATTERNS, PatternType } from "@/utils/patternUtils"
+import {parseApiError} from "@/utils/const.ts";
 
 const App: React.FC = () => {
   const { sendMessage } = useAgentAPI()
@@ -227,12 +228,15 @@ const App: React.FC = () => {
         await connect(query)
       } else {
         setShowFinalResponse(true)
+
         const response = await sendMessage(query, selectedPattern)
         handleApiResponse(response, false)
       }
     } catch (error) {
       logger.apiError("/agent/prompt", error)
-      handleApiResponse("Sorry, I encountered an error.", true)
+      const errMessage = error instanceof Error ? error.message : String(error)
+
+      handleApiResponse(errMessage, true)
       setShowProgressTracker(false)
     }
   }


### PR DESCRIPTION
# Description

This PR improves how the UI handles API and streaming errors across all agent interaction patterns.
The goal is to provide consistent, user‑friendly error messages while preserving backend intent, especially for client‑side (4xx) errors such as rate limiting.


## What has changed

### Unified error handling logic

- All 4xx errors are now treated the same and display the backend‑provided message

<img width="1506" height="1175" alt="Screenshot 2026-01-12 at 11 56 14" src="https://github.com/user-attachments/assets/744a72b8-5808-489e-bce1-ec8f101d1be7" />

- 5xx and network errors display a generic, user‑friendly fallback message
<img width="1378" height="1033" alt="Screenshot 2026-01-12 at 13 48 39" src="https://github.com/user-attachments/assets/54737749-8ec3-4413-8eb7-0b900fc25a8a" />


## Issue Link

Link the primary issue in the PR description using `#` (e.g. `Fixes #123`). This enables two‑way linking.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
