### PR TITLE
Fix CORS on local env: Do not send credentials if it's in local dev env

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useAgentAPI.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useAgentAPI.ts
@@ -7,7 +7,7 @@ import React, { useRef, useState, useEffect } from "react"
 import axios from "axios"
 import { v4 as uuid } from "uuid"
 import { Message } from "@/types/message"
-import { Role } from "@/utils/const"
+import {isLocalDev, Role} from "@/utils/const"
 import { withRetry, RETRY_CONFIG } from "@/utils/retryUtils"
 import { shouldEnableRetries, getApiUrlForPattern } from "@/utils/patternUtils"
 
@@ -79,7 +79,10 @@ export const useAgentAPI = (): UseAgentAPIReturn => {
         {
           prompt,
         },
-        { signal: controller.signal, withCredentials: true },
+        {
+          signal: controller.signal,
+          withCredentials: !isLocalDev  // do not send credentials if it's local dev env
+        },
       )
       return response.data.response
     }
@@ -152,7 +155,10 @@ export const useAgentAPI = (): UseAgentAPIReturn => {
         {
           prompt,
         },
-        { signal: controller.signal, withCredentials: true },
+        {
+          signal: controller.signal,
+          withCredentials: !isLocalDev  // do not send credentials if it's local dev env
+        },
       )
       return response.data.response
     }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/auctionStreamingStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/auctionStreamingStore.ts
@@ -6,6 +6,7 @@
 import { create } from "zustand"
 import { AuctionStreamingResponse } from "@/types/streaming"
 import { getStreamingEndpointForPattern, PATTERNS } from "@/utils/patternUtils"
+import {isLocalDev} from "@/utils/const.ts";
 
 const isValidAuctionStreamingResponse = (
   data: any,
@@ -60,7 +61,7 @@ export const useAuctionStreamingStore = create<StreamingState>((set) => ({
 
       const response = await fetch(streamingUrl, {
         method: "POST",
-        credentials: "include",
+        credentials: isLocalDev ? "omit" : "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ prompt }),
         signal: abortController.signal,

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/groupStreamingStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/groupStreamingStore.ts
@@ -5,6 +5,7 @@
 
 import { create } from "zustand"
 import { LogisticsStreamStep } from "@/types/streaming"
+import {isLocalDev} from "@/utils/const.ts";
 
 const DEFAULT_LOGISTICS_APP_API_URL = "http://127.0.0.1:9090"
 const LOGISTICS_APP_API_URL =
@@ -131,7 +132,7 @@ export const useGroupStreamingStore = create<
         `${LOGISTICS_APP_API_URL}/agent/prompt/stream`,
         {
           method: "POST",
-          credentials: "include",
+          credentials: isLocalDev ? "omit" : "include",
           headers: {
             "Content-Type": "application/json",
           },

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/const.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/const.ts
@@ -81,3 +81,9 @@ export type EdgeLabelType = (typeof EDGE_LABELS)[keyof typeof EDGE_LABELS]
 export type HandleTypeType = (typeof HANDLE_TYPES)[keyof typeof HANDLE_TYPES]
 export type VerificationStatusType =
   (typeof VERIFICATION_STATUS)[keyof typeof VERIFICATION_STATUS]
+
+
+export const isLocalDev =
+  import.meta.env?.DEV ||
+  window.location.hostname === "localhost" ||
+  window.location.hostname === "127.0.0.1"


### PR DESCRIPTION
# Description

Due to recent changes and existing agent implementation, developers would now see the following error on local dev env:

```
Access to XMLHttpRequest at 'http://127.0.0.1:8000/agent/prompt' from origin 'http://localhost:3000/' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```

To resolve this, we can simply introduce a check on UI so we **do not include** the credentials on the prompt requests when we are in local env.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
