### PR TITLE
Allow additional ingresses for lungo-ui helm chart

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.5"
+appVersion: "0.0.6"
 description: A Helm chart for Lungo UI
 name: lungo-ui
-version: 0.0.5
+version: 0.0.6

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/ingress.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/ingress.tpl.yaml
@@ -14,8 +14,8 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          - path: {{ .Values.ingress.path | default "/" | quote }}
+            pathType: {{ .Values.ingress.pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ .Values.ingress.serviceName }}
@@ -25,4 +25,38 @@ spec:
     - hosts:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecret }}
+{{- end }}
+
+{{- range $i, $x := .Values.ingress.extraIngresses }}
+{{- if $x.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $x.name | default (printf "%s-extra-%d" $.Values.ingress.name $i) }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- range $key, $value := $x.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ $x.className | default $.Values.ingress.className }}
+  rules:
+    - host: {{ $x.host | default $.Values.ingress.host }}
+      http:
+        paths:
+          {{- range $p := $x.paths }}
+          - path: {{ $p.path | quote }}
+            pathType: {{ $p.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $p.serviceName | default $x.serviceName | default $.Values.ingress.serviceName }}
+                port:
+                  number: {{ $p.servicePort | default $x.servicePort | default $.Values.ingress.servicePort }}
+          {{- end }}
+  tls:
+    - hosts:
+        - {{ $x.host | default $.Values.ingress.host }}
+      secretName: {{ $x.tlsSecret | default $.Values.ingress.tlsSecret }}
+{{- end }}
 {{- end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/values.yaml
@@ -36,6 +36,19 @@ ingress:
   tlsSecret: ""
   annotations: {}
 
+  extraIngresses:
+    - name: ""
+      enabled: false  # If set to true, configure the values below for the additional ingresses setup
+      paths:
+        - path: ""
+          pathType: ""
+      host: ""
+      className: ""
+      serviceName: ""
+      servicePort: ""
+      tlsSecret: ""
+      annotations: {}
+
 probes:
   livenessProbeEnabled: false
   readinessProbeEnabled: false


### PR DESCRIPTION
# Description

Similar to https://github.com/agntcy/coffeeAgntcy/pull/326, but this this PR is for Lungo UI.

This is useful for users to perform redirection to the UI from different hosts and/or subpaths.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
