### PR TITLE
feat(colombia-farm): use weather service mcp results in inventory prompt

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -165,15 +165,11 @@ class FarmAgent:
 
                 logger.info(f"Weather forecast result: {mcp_call_result}")
                 return {
-                    "weather_forecast_success": True,
-                    "weather_forecast": [AIMessage(mcp_call_result)],
-                }
+                    "weather_forecast_success": True, "weather_forecast": [AIMessage(mcp_call_result)]}
         except Exception as e:
             logger.error(f"Error during MCP tool call: {e}")
             return {
-                "weather_forecast_success": False,
-                "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")],
-            }
+                "weather_forecast_success": False, "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")]}
         finally:
             pass
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -164,12 +164,10 @@ class FarmAgent:
                         mcp_call_result = "No content returned from tool."
 
                 logger.info(f"Weather forecast result: {mcp_call_result}")
-                return {
-                    "weather_forecast_success": True, "weather_forecast": [AIMessage(mcp_call_result)]}
+                return {"weather_forecast_success": True, "weather_forecast": [AIMessage(mcp_call_result)]}
         except Exception as e:
             logger.error(f"Error during MCP tool call: {e}")
-            return {
-                "weather_forecast_success": False, "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")]}
+            return {"weather_forecast_success": False, "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")]}
         finally:
             pass
 

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -166,13 +166,13 @@ class FarmAgent:
                 logger.info(f"Weather forecast result: {mcp_call_result}")
                 return {
                     "weather_forecast_success": True,
-                    "weather_forecast": mcp_call_result,
+                    "weather_forecast": [AIMessage(mcp_call_result)],
                 }
         except Exception as e:
             logger.error(f"Error during MCP tool call: {e}")
             return {
                 "weather_forecast_success": False,
-                "weather_forecast": "",
+                "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")],
             }
         finally:
             pass

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -52,6 +52,7 @@ class GraphState(MessagesState):
     """
     next_node: str
     weather_forecast_success: bool
+    weather_forecast: str
 
 # --- 3. Implement the LangGraph Application Class ---
 @agent(name="colombia_farm_agent")
@@ -163,10 +164,16 @@ class FarmAgent:
                         mcp_call_result = "No content returned from tool."
 
                 logger.info(f"Weather forecast result: {mcp_call_result}")
-                return {"weather_forecast_success": True, "messages": [AIMessage(mcp_call_result)]}
+                return {
+                    "weather_forecast_success": True,
+                    "weather_forecast": mcp_call_result,
+                }
         except Exception as e:
             logger.error(f"Error during MCP tool call: {e}")
-            return {"weather_forecast_success": False, "messages": [AIMessage(f"Weather Forecast MCP Server was Unavailable")]}
+            return {
+                "weather_forecast_success": False,
+                "weather_forecast": "",
+            }
         finally:
             pass
 
@@ -182,22 +189,26 @@ class FarmAgent:
         if not self.inventory_llm:
             self.inventory_llm = get_llm()
 
-        user_message = state["messages"]
+        user_message = state["messages"][-1] if state.get("messages") else ""
+        weather_forecast = state.get("weather_forecast", "")
 
         prompt = PromptTemplate(
             template="""You are a helpful Colombian coffee farm manager.
                 You should estimate the seasonal coffee yield after checking the weather given.
                 Always return a numeric yield estimate with units (e.g. "5000 lbs").
+                This should contain the the basic yield for colombia (5000 lbs) plus an estimated bonus yield based on the weather forecast (e.g. + 100 lbs per temperature unit above 0).
                 No explanation needed.
 
+                Weather forecast: {weather_forecast}
                 User question: {user_message}
                 """,
-            input_variables=["user_message"]
+            input_variables=["user_message", "weather_forecast"]
         )
         chain = prompt | self.inventory_llm
 
         llm_response = chain.invoke({
             "user_message": user_message,
+            "weather_forecast": weather_forecast,
         }).content
 
         logger.info(f"Inventory response generated: {llm_response}")


### PR DESCRIPTION
Results of the weather service MCP invocation are now actually used in the inventory prompt of the colombia farm agent to influence the expected yield. That was not the case, at least from how I understood the code.

# Description

Previously the weather MCP service was called, but the result was not used afterward as it was not passed to any following prompts. This PR is changing this behavior by using it in the inventory node prompt. The yield is now estimated based on a given constant yield for Colombia (5000 lbs) plus an additional 100 lbs per one temperature unit above 0.
Therefore, at least somehow include the weather data in the workflow.

For e.g. a returned temperature of 29.6 °C the agent will now return 7960 lbs (5000 lbs + 2960 lbs)

## Issue Link

No Issue posted. Just saw this while playing around with it and noticed it.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
