### PR TITLE
fix(frontend): fix duplicate graph nodes on discovery

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/App.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/App.tsx
@@ -93,6 +93,7 @@ const App: React.FC = () => {
   const streamCompleteRef = useRef<boolean>(false)
   const [discoveryResponseEvent, setDiscoveryResponseEvent] =
       useState<DiscoveryResponseEvent | null>(null)
+  const lastDiscoveryKeyRef = useRef<string | null>(null)
 
   const handleDiscoveryResponse = useCallback((evt: DiscoveryResponseEvent) => {
     setDiscoveryResponseEvent(evt)
@@ -116,6 +117,7 @@ const App: React.FC = () => {
         setButtonClicked(false)
         setAiReplied(false)
         setSelectedPattern(pattern)
+        lastDiscoveryKeyRef.current = null
       },
       [reset, resetGroup, resetRecruiter],
   )
@@ -239,12 +241,22 @@ const App: React.FC = () => {
 
       // Dispatch discovery response event to update the graph with discovered agents
       // Always dispatch, even when agent_records is empty (e.g. "clear all"), to trigger graph cleanup
-      handleDiscoveryResponse({
-        response: recruiterFinalMessage ?? "",
-        ts: Date.now(),
-        sessionId: recruiterSessionId ?? undefined,
-        agent_records: (recruiterAgentRecords ?? {}) as any,
-      })
+      // Use a stable fingerprint (session + sorted agent record keys) instead of Date.now()
+      // so that re-renders with the same data don't create duplicate graph nodes
+      const agentKeys = recruiterAgentRecords
+          ? Object.keys(recruiterAgentRecords).sort().join(",")
+          : ""
+      const discoveryKey = `${recruiterSessionId ?? ""}:${agentKeys}`
+
+      if (lastDiscoveryKeyRef.current !== discoveryKey) {
+        lastDiscoveryKeyRef.current = discoveryKey
+        handleDiscoveryResponse({
+          response: recruiterFinalMessage ?? "",
+          ts: Date.now(),
+          sessionId: recruiterSessionId ?? undefined,
+          agent_records: (recruiterAgentRecords ?? {}) as any,
+        })
+      }
     } else if (recruiterStatus === "error" && recruiterError) {
       setIsAgentLoading(false)
       setShowFinalResponse(true)
@@ -344,6 +356,7 @@ const App: React.FC = () => {
     setPendingResponse("")
     resetGroup()
     resetRecruiter()
+    lastDiscoveryKeyRef.current = null
   }
 
   const handleNodeHighlightSetup = useCallback(

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/MainArea.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/MainArea.tsx
@@ -209,6 +209,12 @@ const MainArea: React.FC<MainAreaProps> = ({
                   )
                   .filter(Boolean),
           )
+          // Also track existing agentCid values to prevent duplicates from different IDs
+          const existingCids = new Set(
+              prevNodes
+                  .map((n: any) => n?.data?.agentCid)
+                  .filter(Boolean),
+          )
 
           const recruiterNode = prevNodes.find((n) => n.id === recruiterNodeId)
           const recruiterIcons = recruiterNode?.data
@@ -221,7 +227,16 @@ const MainArea: React.FC<MainAreaProps> = ({
 
           const templateKeywordsToAdd: Keyword[] = KEYWORDS.filter((kw) =>
               entries.some((e) => hasKeyword(e.name, kw)),
-          )
+          ).filter((kw) => {
+            // Skip if a discovery node with this keyword already exists
+            // (existingNames catches label1, but also check for keyword in existing discovery node labels)
+            const alreadyExists = prevNodes.some(
+                (n) =>
+                    n.id.startsWith("discovery-") &&
+                    hasKeyword(String((n.data as any)?.label1 ?? ""), kw),
+            )
+            return !alreadyExists
+          })
 
           const generatedEntriesToAdd = (() => {
             const seen = new Set<string>()
@@ -231,6 +246,8 @@ const MainArea: React.FC<MainAreaProps> = ({
               const key = e.name.toLowerCase()
               if (existingNames.has(key)) return false
               if (seen.has(key)) return false
+              // Skip if a node with this agentCid already exists
+              if (existingCids.has(e.id)) return false
 
               seen.add(key)
               return true
@@ -255,6 +272,9 @@ const MainArea: React.FC<MainAreaProps> = ({
 
             // Find the matching entry to get its CID
             const matchedEntry = entries.find((e) => hasKeyword(e.name, kind))
+
+            // Skip if a node with this agentCid already exists (prevents duplicates across different seqRef values)
+            if (matchedEntry?.id && existingCids.has(matchedEntry.id)) continue
 
             const x =
                 recruiterPos.x + (startCol + col) * (NODE_WIDTH + HORIZONTAL_GAP)

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/const.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/const.ts
@@ -17,7 +17,7 @@ export const EDGE_LABELS = {
   A2A: "A2A",
   MCP: "MCP: ",
   A2A_OVER_HTTP: "A2A: HTTP",
-  MCP_WITH_STDIO: "MCP: stdio",
+  MCP_WITH_STDIO: "MCP: stdio -> grpc",
 } as const
 
 export const FarmName = {

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/graphConfigs.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/graphConfigs.tsx
@@ -398,8 +398,8 @@ const DISCOVERY_CONFIG: GraphConfig = {
                 className="dark-icon h-4 w-4 object-contain"
             />
         ),
-        label1: "Recruiter",
-        label2: "Discovery Node",
+        label1: "Agentic Recruiter",
+        label2: "Discovery and delegation",
         handles: HANDLE_TYPES.ALL,
         extraHandles: [
           { id: "target-right", type: "target", position: "right" },


### PR DESCRIPTION
# Description

Provide hot fix for duplicate graph nodes when agents are discovered and selected for direct speaking.

## Issue Link

Link the primary issue in the PR description using `#` (e.g. `Fixes #123`). This enables two‑way linking.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
