### PR TITLE
Document proper docker compose down usage

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/README.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/README.md
@@ -307,6 +307,8 @@ docker compose --profile recruiter up
 docker compose --profile farms --profile logistics --profile recruiter up
 ```
 
+If you started services with one or more profiles, run `docker compose down` with the **same profile(s)** (e.g. `docker compose --profile farms down`) or tear everything down with `docker compose --profile '*' down`. Do not run a bare `docker compose down` (no profile): it only stops unprofiled services and the network removal will fail with "Network ... Resource is still in use."
+
 > **Note:** Shared infrastructure services (nats, ui, clickhouse, otel-collector, grafana, etc.) have no profile and will start with any profile.
 
 Once running:

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/agent_directory_integration.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/agent_directory_integration.md
@@ -21,6 +21,9 @@ This starts:
 - `dir-mcp-server`: The MCP server in front of the API service
 - `zot`: OCI-compliant registry for storing agent artifacts
 
+To stop, use the same format for down, e.g. `docker compose down dir-api-server dir-mcp-server zot` or run `docker compose --profile '*' down`.
+A plain `docker compose down` can fail with the "network still in use" message, if the started containers have profiles defined.
+
 ### 2. Install Development Dependencies
 
 Install the required development dependencies for the integration scripts:

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/group_conversation.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/group_conversation.md
@@ -71,6 +71,9 @@ docker compose up logistics-farm logistics-supervisor logistics-shipper logistic
 
 This will start the supervisor, shipper, accountant, farm, helpdesk,  and SLIM transport services.
 
+To stop, use list for `docker compose down` or run `docker compose --profile '*' down`.
+A plain `docker compose down` can fail with the "network still in use" message, if the started containers have profiles defined.
+
 ---
 
 ## Run Individually (one terminal per service)

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/identity_integration.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/identity_integration.md
@@ -97,6 +97,9 @@ Start the services:
 docker compose up exchange-server payment-mcp-server brazil-farm-server colombia-farm-server vietnam-farm-server weather-mcp-server
 ```
 
+To stop, use the same list for `docker compose down` as when starting, or run `docker compose --profile '*' down`.
+A plain `docker compose down` can fail with the "network still in use" message, if the started containers have profiles defined.
+
 Run without `.env` (inline key):
 
 ```sh


### PR DESCRIPTION
# Description

Docker compose down only tears down services with no profiles defined. All profiled containers must be stopped with the corresponding profile param attached to the down command, or the command should be instructed to stop all services from all profiles. Necessary clarifications added to readme and tutorial files.

## Issue Link

Addresses the issue #390

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
