### PR TITLE
fix: pin Python version to >=3.12,<3.14 across all subprojects

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/pyproject.toml
+++ b/coffeeAGNTCY/coffee_agents/corto/pyproject.toml
@@ -3,7 +3,7 @@ name = "corto"
 version = "0.1.0"
 description = ""
 authors = [{ name = "Shridhar Shah", email = "shridhsh@cisco.com" }]
-requires-python = ">=3.13,<4.0"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "a2a-sdk==0.3.2",
     "click>=8.1.8",

--- a/coffeeAGNTCY/coffee_agents/lungo/pyproject.toml
+++ b/coffeeAGNTCY/coffee_agents/lungo/pyproject.toml
@@ -3,7 +3,7 @@ name = "lungo"
 version = "0.1.0"
 description = ""
 authors = [{ name = "Shridhar Shah", email = "shridhsh@cisco.com" }]
-requires-python = ">=3.13,<4.0"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "a2a-sdk==0.3.2",
     "click>=8.1.8",

--- a/coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml
+++ b/coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml
@@ -3,7 +3,7 @@ name = "agent-recruiter"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "a2a-sdk==0.3.2",
     "mcp>=1.24.0",


### PR DESCRIPTION
## Description

Fixes #406

Python 3.14 breaks PyO3-based dependencies (e.g. `pydantic-core`) since PyO3's maximum supported version is 3.13. When running `uv sync --extra dev` on Python 3.14, the build fails with:

```
error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
```

This PR adds a strict upper bound (`<3.14`) to `requires-python` in all three agent `pyproject.toml` files to prevent build failures. The lower bound is also aligned to `>=3.12` across all subprojects for consistency.

## Issue Link

Fixes #406

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Changes

| File | Before | After |
|------|--------|-------|
| `corto/pyproject.toml` | `>=3.13,<4.0` | `>=3.12,<3.14` |
| `lungo/pyproject.toml` | `>=3.13,<4.0` | `>=3.12,<3.14` |
| `recruiter/pyproject.toml` | `>=3.12` | `>=3.12,<3.14` |

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass