### PR TITLE
fix: remove 'uv lock --upgrade' from the integration tests workflow

### DIFF
--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -59,7 +59,6 @@ jobs:
 
       - name: Resolve & install
         run: |
-          uv lock --upgrade
           uv sync --extra dev
       
       - name: Create CI env file


### PR DESCRIPTION
# Description

The following information is copied over from the associated GH Issue #415 :

> Currently the CI workflow at [.github/workflows/test.yaml](https://github.com/agntcy/coffeeAgntcy/blob/3c68af99eb21c48b253fc347b32bd422ff7198f7/.github/workflows/test.yaml#L65) calls a `uv lock --upgrade` followed by a `uv sync --extra dev` which causes all dependencies to be upgraded to the latest constraint-allowed version.
> 
> This can generate an untracked dirty state after which we work during testing, but the subsequent sync also changes the executing environment to use the updated package versions which creates a discrepancy between local development environment dependency versions and CI tested dependency versions.

## Issue Link

Fixes #415 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
