### PR TITLE
fix(ci): inherit secrets for integration tests reusable workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -157,6 +157,7 @@ jobs:
       pip_overrides: ${{ inputs.pip_overrides }}
       pip_constraints: ${{ inputs.pip_constraints }}
       docker_overrides: ${{ inputs.docker_overrides }}
+    secrets: inherit
 
   integration-tests-lungo:
     needs: subprojects-to-test
@@ -167,6 +168,7 @@ jobs:
       pip_overrides: ${{ inputs.pip_overrides }}
       pip_constraints: ${{ inputs.pip_constraints }}
       docker_overrides: ${{ inputs.docker_overrides }}
+    secrets: inherit
 
   integration-tests-recruiter:
     needs: subprojects-to-test
@@ -177,3 +179,4 @@ jobs:
       pip_overrides: ${{ inputs.pip_overrides }}
       pip_constraints: ${{ inputs.pip_constraints }}
       docker_overrides: ${{ inputs.docker_overrides }}
+    secrets: inherit


### PR DESCRIPTION
# Description

https://github.com/agntcy/coffeeAgntcy/pull/396 introduced a problem with the integration tests workflow.  
Turns out that the repository-level secrets can't be accessed from a reused workflow (I don't know what are the conditions that make a regular workflow have access to those secrets).

Core information is available at https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow.

Moving this snippet to a reusable workflow created the problem from what I understand:
```yaml
      - name: Create CI env file
        run: |
          cat > .env <<'EOF'
          LLM_MODEL=${{ secrets.LLM_MODEL }}
          AZURE_API_KEY=${{ secrets.AZURE_API_KEY }}
          AZURE_API_BASE=${{ secrets.AZURE_API_BASE }}
          AZURE_API_VERSION=${{ secrets.AZURE_API_VERSION }}
          EOF
```

In short:
  * prior to this PR, we'd see this when trying to build the `.env` file needed to run the Python integration tests
    ```
    cat > .env <<'EOF'
    LLM_MODEL=
    AZURE_API_KEY=
    AZURE_API_BASE=
    AZURE_API_VERSION=
    EOF
    ```
    and a lot of errors like:
    ```
    litellm.exceptions.BadRequestError: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=
    Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers
    ```
  * with this present PR:
    ```
    cat > .env <<'EOF'
    LLM_MODEL=***
    AZURE_API_KEY=***
    AZURE_API_BASE=***
    AZURE_API_VERSION=***
    EOF
    ```
    and the tests run ok at least for Corto and Lungo.
    Recruiter is a different thing altogether.

## Issue Link


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
