### PR TITLE
revert(ci): remove Recruiter from CI integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,13 +4,15 @@ on:
     branches:
       - main
     paths:
-      - 'coffeeAGNTCY/coffee_agents/**'
+      - 'coffeeAGNTCY/coffee_agents/corto/**'
+      - 'coffeeAGNTCY/coffee_agents/lungo/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
   pull_request:
     branches:
       - main
     paths:
-      - 'coffeeAGNTCY/coffee_agents/**'
+      - 'coffeeAGNTCY/coffee_agents/corto/**'
+      - 'coffeeAGNTCY/coffee_agents/lungo/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
   workflow_call:
     inputs:
@@ -36,11 +38,6 @@ on:
         default: true
       test_lungo:
         description: 'Whether to test the Lungo project.'
-        required: false
-        type: boolean
-        default: true
-      test_recruiter:
-        description: 'Whether to test the Recruiter project.'
         required: false
         type: boolean
         default: true
@@ -71,16 +68,10 @@ on:
         required: false
         type: boolean
         default: true
-      test_recruiter:
-        description: 'Whether to test the Recruiter project.'
-        required: false
-        type: boolean
-        default: true
 
 env:
   CORTO_DIR: coffeeAGNTCY/coffee_agents/corto
   LUNGO_DIR: coffeeAGNTCY/coffee_agents/lungo
-  RECRUITER_DIR: coffeeAGNTCY/coffee_agents/recruiter
 
 jobs:
   subprojects-to-test:
@@ -88,7 +79,6 @@ jobs:
     outputs:
       test_corto: ${{ steps.check-subprojects.outputs.test_corto }}
       test_lungo: ${{ steps.check-subprojects.outputs.test_lungo }}
-      test_recruiter: ${{ steps.check-subprojects.outputs.test_recruiter }}
     defaults:
       run:
         shell: bash
@@ -118,16 +108,13 @@ jobs:
         run: |
           test_corto=false
           test_lungo=false
-          test_recruiter=false
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
             test_corto=true
             test_lungo=true
-            test_recruiter=true
           elif [[ "${{ github.event_name }}" == "workflow_call" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             test_corto=${{ inputs.test_corto }}
             test_lungo=${{ inputs.test_lungo }}
-            test_recruiter=${{ inputs.test_recruiter }}
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             base="${{ github.event.pull_request.base.sha }}"
             head="${{ github.event.pull_request.head.sha }}"
@@ -141,12 +128,10 @@ jobs:
             
             dir_has_changes $base $head "$CORTO_DIR" && test_corto=true || test_corto=false
             dir_has_changes $base $head "$LUNGO_DIR" && test_lungo=true || test_lungo=false
-            dir_has_changes $base $head "$RECRUITER_DIR" && test_recruiter=true || test_recruiter=false
           fi
 
           echo "test_corto=$test_corto" | tee -a $GITHUB_OUTPUT
           echo "test_lungo=$test_lungo" | tee -a $GITHUB_OUTPUT
-          echo "test_recruiter=$test_recruiter" | tee -a $GITHUB_OUTPUT
 
   integration-tests-corto:
     needs: subprojects-to-test
@@ -165,17 +150,6 @@ jobs:
     uses: ./.github/workflows/test-reusable.yaml
     with:
       project_dir: coffeeAGNTCY/coffee_agents/lungo # cannot access env context here
-      pip_overrides: ${{ inputs.pip_overrides }}
-      pip_constraints: ${{ inputs.pip_constraints }}
-      docker_overrides: ${{ inputs.docker_overrides }}
-    secrets: inherit
-
-  integration-tests-recruiter:
-    needs: subprojects-to-test
-    if: ${{ needs.subprojects-to-test.outputs.test_recruiter == 'true' }}
-    uses: ./.github/workflows/test-reusable.yaml
-    with:
-      project_dir: coffeeAGNTCY/coffee_agents/recruiter # cannot access env context here
       pip_overrides: ${{ inputs.pip_overrides }}
       pip_constraints: ${{ inputs.pip_constraints }}
       docker_overrides: ${{ inputs.docker_overrides }}


### PR DESCRIPTION
# Description

https://github.com/agntcy/coffeeAgntcy/pull/418 added `Recruiter` to the set of projects that have Integration Tests run in CI.  
Right now, the testing code for Recruiter is not plug-and-play into the current Integration Tests Workflow structure and is consistently failing with a number of errors.  

I am proposing we revert the `Recruiter` part of the aforementioned PR to unblock the other PRs and that we treat re-adding it (when it's ready) as its own task.

Example of an error summary:
```
=========================== short test summary info ============================
FAILED test/integration/test_a2a.py::test_recruiter_a2a_server - FileNotFoundError: [Errno 2] No such file or directory: 'dirctl'
FAILED test/integration/test_a2a.py::test_recruiter_a2a_server_streaming - FileNotFoundError: [Errno 2] No such file or directory: 'dirctl'
FAILED test/integration/test_a2a.py::test_recruiter_a2a_evaluation_flow - FileNotFoundError: [Errno 2] No such file or directory: 'dirctl'
ERROR test/integration/test_caching.py::TestToolCaching::test_tool_cache_hit_on_repeated_search - RuntimeError: Container 'dir-mcp-server' is not running
ERROR test/integration/test_caching.py::TestToolCaching::test_cache_hit_reduces_operation_time - RuntimeError: Container 'dir-mcp-server' is not running
ERROR test/integration/test_caching.py::TestCacheStatistics::test_cache_stats_structure - RuntimeError: Container 'dir-mcp-server' is not running
ERROR test/integration/test_caching.py::TestCacheStatistics::test_clear_cache - RuntimeError: Container 'dir-mcp-server' is not running
```

## Issue Link


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
