### PR TITLE
chore(codeowners): set to coffee-agntcy-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 # the repository. Unless a later match takes precedence,
 # the following users/teams will be requested for
 # review when someone opens a pull request.
-* @therealaditigupta @codyhartsook @shanchunyang0919 @Shridhar-2205
+* @agntcy/coffee-agntcy-reviewers


### PR DESCRIPTION
# Description

Set up reviewer team and changed codeowners to that, to

-  automate notifications sent on PRs,
- reducing both the noise to former maintainers and
- also making it easier to manage the reviewer team on repository access updates at the admin settings repo.

## Issue Link

-

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe): chore, development, codeowners update

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
