### PR TITLE
feat: move paths_have_changes logic to dedicated GH Action

### DIFF
--- a/.github/actions/check-paths-have-changes/action.yaml
+++ b/.github/actions/check-paths-have-changes/action.yaml
@@ -1,0 +1,59 @@
+name: Check filesystem paths for changes
+description: Check whether a list of filesystem paths have changes between two commits
+inputs:
+  base_sha:
+    description: The base SHA to compare against
+    required: true
+  head_sha:
+    description: The head SHA to compare against
+    required: true
+  paths_json_list:
+    description: The paths to check expressed as a string holding a JSON array of strings
+    required: false
+    default: "[]"
+outputs:
+  changed:
+    description: Whether the paths have changes. Result is expressed as a string of "true" or "false".
+    value: ${{ steps.check.outputs.changed }}
+runs:
+  using: composite
+  steps:
+    - name: Validate input paths JSON array
+      shell: bash
+      run: |
+        jq --compact-output --exit-status '., (type == "array" and all(.[] ; type == "string"))' <<< '${{ inputs.paths_json_list }}'
+
+    - name: Check whether paths have changes
+      id: check
+      shell: bash
+      run: |
+        # Returns 0 if there are changes, 1 if no changes
+        paths_have_changes() (
+          local base=$1 head=$2 paths_json_list=$3
+
+          # 1. Initialize an empty array
+          paths=()
+
+          # 2. Fill the array using a while loop
+          # We use IFS= to prevent trimming whitespace and -r to handle backslashes
+          while IFS= read -r line; do
+            paths+=("$line")
+          done < <(echo "$paths_json_list" | jq -r '.[]')
+
+          # This option only lives in the subshell of this function because the function is defined with () instead of {}.
+          set -x 
+
+          # 3. Use the array in the git diff command to detect changes
+          ! git diff --name-only --exit-code --ignore-blank-lines $base $head -- "${paths[@]}"
+        )
+
+        changed=false
+
+        # Note: We need the single quotes around `inputs.paths_json_list` to avoid Bash expansion of the JSON string resulting after Github substitutes the templated value.
+        # That would remove the double quotes within it and make the JSON string invalid.
+        # The error in that case would look like this: `jq: parse error: Invalid numeric literal at line 1, column 50`
+        paths_have_changes ${{ inputs.base_sha }} ${{ inputs.head_sha }} '${{ inputs.paths_json_list }}' \
+          && changed=true
+
+        echo "changed=$changed" | tee -a $GITHUB_OUTPUT
+

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -18,6 +18,7 @@ on:
       - '!coffeeAGNTCY/coffee_agents/recruiter/test/**'
       - '.github/workflows/docker-build-push.yaml'
       - '.github/workflows/docker-build-reusable.yaml'
+      - '.github/actions/check-paths-have-changes/**'
   workflow_dispatch:
     inputs:
       push:
@@ -55,14 +56,14 @@ jobs:
   subprojects-to-build:
     runs-on: ubuntu-latest
     outputs:
-      build_corto: ${{ steps.check-subprojects.outputs.build_corto }}
-      build_lungo: ${{ steps.check-subprojects.outputs.build_lungo }}
-      build_recruiter: ${{ steps.check-subprojects.outputs.build_recruiter }}
+      build_corto: ${{ steps.choose-subprojects.outputs.build_corto }}
+      build_lungo: ${{ steps.choose-subprojects.outputs.build_lungo }}
+      build_recruiter: ${{ steps.choose-subprojects.outputs.build_recruiter }}
     defaults:
       run:
         shell: bash
     env:
-      WORKFLOW_FILES_LIST_JSON: '[".github/workflows/docker-build-push.yaml", ".github/workflows/docker-build-reusable.yaml"]'
+      WORKFLOW_FILES_LIST_JSON: '[".github/workflows/docker-build-push.yaml", ".github/workflows/docker-build-reusable.yaml", ".github/actions/check-paths-have-changes"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -82,8 +83,48 @@ jobs:
           echo "build_lungo=${{ inputs.build_lungo }}"
           echo "build_recruiter=${{ inputs.build_recruiter }}"
 
-      - name: Detect changed paths for main sub-projects
-        id: check-subprojects
+      - name: Prepare subproject paths JSON lists
+        if: ${{ github.event_name == 'pull_request' }}
+        id: prepare-path-lists
+        run: |
+          paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
+          echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
+
+          paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
+          echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
+
+          paths_json_recruiter=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$RECRUITER_DIR" '[$new_val] + .')
+          echo "paths_json_recruiter=$paths_json_recruiter" | tee -a $GITHUB_OUTPUT
+
+      - name: Check paths have changes for Corto
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-corto
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_corto }}
+
+      - name: Check paths have changes for Lungo
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-lungo
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_lungo }}
+
+      - name: Check paths have changes for Recruiter
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-recruiter
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_recruiter }}
+
+      - name: Determine build choices for subprojects
+        id: choose-subprojects
         run: |
           build_corto=false
           build_lungo=false
@@ -98,37 +139,9 @@ jobs:
             build_lungo=${{ inputs.build_lungo }}
             build_recruiter=${{ inputs.build_recruiter }}
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base="${{ github.event.pull_request.base.sha }}"
-            head="${{ github.event.pull_request.head.sha }}"
-
-            # Returns 0 if there are changes, 1 if no changes
-            paths_have_changes() (
-              local base=$1 head=$2 paths_json_list=$3
-
-              # 1. Initialize an empty array
-              paths=()
-
-              # 2. Fill the array using a while loop
-              # We use IFS= to prevent trimming whitespace and -r to handle backslashes
-              while IFS= read -r line; do
-                paths+=("$line")
-              done < <(echo "$paths_json_list" | jq -r '.[]')
-
-              # This option only lives in the subshell of this function because the function is defined with () instead of {}.
-              set -x 
-
-              # 3. Use the array in the git diff command to detect changes
-              ! git diff --name-only --exit-code --ignore-blank-lines $base $head -- "${paths[@]}"
-            )
-
-            paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_corto && build_corto=true
-
-            paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_lungo && build_lungo=true
-
-            paths_json_recruiter=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$RECRUITER_DIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_recruiter && build_recruiter=true
+            build_corto=${{ steps.check-paths-corto.outputs.changed }}
+            build_lungo=${{ steps.check-paths-lungo.outputs.changed }}
+            build_recruiter=${{ steps.check-paths-recruiter.outputs.changed }}
           fi
 
           echo "build_corto=$build_corto" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -14,6 +14,7 @@ on:
       - 'coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
       - '.github/workflows/helm-push.yaml'
       - '.github/workflows/helm-package-reusable.yaml'
+      - '.github/actions/check-paths-have-changes/**'
   workflow_dispatch:
     inputs:
       push:
@@ -41,13 +42,13 @@ jobs:
   subprojects-to-build:
     runs-on: ubuntu-latest
     outputs:
-      build_corto: ${{ steps.check-subprojects.outputs.build_corto }}
-      build_lungo: ${{ steps.check-subprojects.outputs.build_lungo }}
+      build_corto: ${{ steps.choose-subprojects.outputs.build_corto }}
+      build_lungo: ${{ steps.choose-subprojects.outputs.build_lungo }}
     defaults:
       run:
         shell: bash
     env:
-      WORKFLOW_FILES_LIST_JSON: '[".github/workflows/helm-push.yaml", ".github/workflows/helm-package-reusable.yaml"]'
+      WORKFLOW_FILES_LIST_JSON: '[".github/workflows/helm-push.yaml", ".github/workflows/helm-package-reusable.yaml", ".github/actions/check-paths-have-changes"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -67,8 +68,36 @@ jobs:
           echo "build_corto=${{ inputs.build_corto }}"
           echo "build_lungo=${{ inputs.build_lungo }}"
 
-      - name: Detect changed paths for main sub-projects
-        id: check-subprojects
+      - name: Prepare subproject paths JSON lists
+        if: ${{ github.event_name == 'pull_request' }}
+        id: prepare-path-lists
+        run: |
+          paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR/$HELM_SUBDIR" '[$new_val] + .')
+          echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
+          
+          paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR/$HELM_SUBDIR" '[$new_val] + .')
+          echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
+
+      - name: Check paths have changes for Corto
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-corto
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_corto }}
+
+      - name: Check paths have changes for Lungo
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-lungo
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_lungo }}
+
+      - name: Determine build choices for subprojects
+        id: choose-subprojects
         run: |
           build_corto=false
           build_lungo=false
@@ -80,34 +109,8 @@ jobs:
             build_corto=${{ inputs.build_corto }}
             build_lungo=${{ inputs.build_lungo }}
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base="${{ github.event.pull_request.base.sha }}"
-            head="${{ github.event.pull_request.head.sha }}"
-
-            # Returns 0 if there are changes, 1 if no changes
-            paths_have_changes() (
-              local base=$1 head=$2 paths_json_list=$3
-
-              # 1. Initialize an empty array
-              paths=()
-
-              # 2. Fill the array using a while loop
-              # We use IFS= to prevent trimming whitespace and -r to handle backslashes
-              while IFS= read -r line; do
-                paths+=("$line")
-              done < <(echo "$paths_json_list" | jq -r '.[]')
-
-              # This option only lives in the subshell of this function because the function is defined with () instead of {}.
-              set -x 
-
-              # 3. Use the array in the git diff command to detect changes
-              ! git diff --name-only --exit-code --ignore-blank-lines $base $head -- "${paths[@]}"
-            )
-
-            paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR/$HELM_SUBDIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_corto && build_corto=true
-
-            paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR/$HELM_SUBDIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_lungo && build_lungo=true
+            build_corto=${{ steps.check-paths-corto.outputs.changed }}
+            build_lungo=${{ steps.check-paths-lungo.outputs.changed }}
           fi
 
           echo "build_corto=$build_corto" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,7 @@ on:
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
       - '.github/workflows/test.yaml'
       - '.github/workflows/test-reusable.yaml'
+      - '.github/actions/check-paths-have-changes/**'
   workflow_call:
     inputs:
       pip_overrides:
@@ -79,13 +80,13 @@ jobs:
   subprojects-to-test:
     runs-on: ubuntu-latest
     outputs:
-      test_corto: ${{ steps.check-subprojects.outputs.test_corto }}
-      test_lungo: ${{ steps.check-subprojects.outputs.test_lungo }}
+      test_corto: ${{ steps.choose-subprojects.outputs.test_corto }}
+      test_lungo: ${{ steps.choose-subprojects.outputs.test_lungo }}
     defaults:
       run:
         shell: bash
     env:
-      WORKFLOW_FILES_LIST_JSON: '[".github/workflows/test.yaml", ".github/workflows/test-reusable.yaml"]'
+      WORKFLOW_FILES_LIST_JSON: '[".github/workflows/test.yaml", ".github/workflows/test-reusable.yaml", ".github/actions/check-paths-have-changes"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -107,8 +108,36 @@ jobs:
           echo "test_corto=${{ inputs.test_corto }}"
           echo "test_lungo=${{ inputs.test_lungo }}"
 
-      - name: Detect changed paths for main sub-projects
-        id: check-subprojects
+      - name: Prepare subproject paths JSON lists
+        if: ${{ github.event_name == 'pull_request' }}
+        id: prepare-path-lists
+        run: |
+          paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
+          echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
+          
+          paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
+          echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
+
+      - name: Check paths have changes for Corto
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-corto
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_corto }}
+
+      - name: Check paths have changes for Lungo
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-paths-lungo
+        uses: ./.github/actions/check-paths-have-changes
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          paths_json_list: ${{ steps.prepare-path-lists.outputs.paths_json_lungo }}
+
+      - name: Determine test choices for subprojects
+        id: choose-subprojects
         run: |
           test_corto=false
           test_lungo=false
@@ -120,34 +149,8 @@ jobs:
             test_corto=${{ inputs.test_corto }}
             test_lungo=${{ inputs.test_lungo }}
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base="${{ github.event.pull_request.base.sha }}"
-            head="${{ github.event.pull_request.head.sha }}"
-
-            # Returns 0 if there are changes, 1 if no changes
-            paths_have_changes() (
-              local base=$1 head=$2 paths_json_list=$3
-
-              # 1. Initialize an empty array
-              paths=()
-
-              # 2. Fill the array using a while loop
-              # We use IFS= to prevent trimming whitespace and -r to handle backslashes
-              while IFS= read -r line; do
-                paths+=("$line")
-              done < <(echo "$paths_json_list" | jq -r '.[]')
-
-              # This option only lives in the subshell of this function because the function is defined with () instead of {}.
-              set -x 
-
-              # 3. Use the array in the git diff command to detect changes
-              ! git diff --name-only --exit-code --ignore-blank-lines $base $head -- "${paths[@]}"
-            )
-
-            paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_corto && test_corto=true
-
-            paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
-            paths_have_changes $base $head $paths_json_lungo && test_lungo=true
+            test_corto=${{ steps.check-paths-corto.outputs.changed }}
+            test_lungo=${{ steps.check-paths-lungo.outputs.changed }}
           fi
 
           echo "test_corto=$test_corto" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
# Description

This PR aims to move into its own GH Action a bit of Bash that we are using to determine if there are changes inside a subproject (or more recently a set of paths, including folders).  
This Bash logic is very similar currently across 3 GH workflows and may be reused for other future GH workflows that want to use that condition for PRs to limit the number of workflows that get run.

The GH Action starts with a validation step that checks that the input paths are valid JSON and that it is an array of strings. Nothing else (including nesting) is allowed for that input to pass the validation.

The workflows that use this action follow the action folder as a trigger too.


## Issue Link

Didn't create one. This is a follow up of an idea from this thread https://github.com/agntcy/coffeeAgntcy/pull/396#discussion_r2889192787. The particular Bash changed a lot but the idea remained.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass