### PR TITLE
chore: update github actions originated by the Docker org

### DIFF
--- a/.github/workflows/docker-build-reusable.yaml
+++ b/.github/workflows/docker-build-reusable.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Generate metadata
         id: metadata
@@ -61,14 +61,14 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: inputs.push == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and conditional push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/helm-package-reusable.yaml
+++ b/.github/workflows/helm-package-reusable.yaml
@@ -39,11 +39,11 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Log in to GitHub Container Registry
         if: inputs.push == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
# Description

Last week, the Docker org released major version updates to a number of their published GH Actions.

This PR bumps the version of the actions from Docker that I found had updates. Those are currently are version `x.0.0`.

This should also deal with some of the warnings we get in CI runs about some actions using NodeJS 20.
For example:
> docker-build-lungo (brazil-farm, coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm) / docker-build-and-push
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: docker/build-push-action@v6, docker/setup-buildx-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24.

The new releases mention at the top of their release notes:
> Node 24 as default runtime 


## Issue Link



## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe): bump GH action versions

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
