### PR TITLE
test(lungo,be): fix A2A SLIM timeout mock

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/tests/integration/test_auction.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/integration/test_auction.py
@@ -6,7 +6,7 @@ import logging
 import re
 import ssl
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -104,8 +104,16 @@ AUCTION_PROMPT_CASES = load_auction_prompt_cases()
     indirect=True,
 )
 def test_auction_a2a_timeout_returns_user_visible_error(auction_supervisor_client):
-    """When send_a2a_with_retry raises TransportTimeoutError, graph returns 200 with error message in body."""
+    """When send_a2a_with_retry raises TransportTimeoutError, graph returns 200 with error message in body.
+
+    Stub factory.create_client so execution reaches send_a2a_with_retry: without it, SLIM/agent-card
+    handshake can fail before A2A send (mock would never be called).
+    """
     with patch(
+        "agents.supervisors.auction.graph.tools.factory.create_client",
+        new_callable=AsyncMock,
+        return_value=MagicMock(),
+    ), patch(
         "agents.supervisors.auction.graph.tools.send_a2a_with_retry",
         new_callable=AsyncMock,
         side_effect=TransportTimeoutError("timeout", cause=None),


### PR DESCRIPTION
# Description

Fixed a persistently failing test that was missing one mock to function correctly, it wasn't caught by the CI workflows, because the PR was targeting a non-main branch and the CI workflows on PRs only run when targeting non-main branch currently. The latter issue will be remediated separately in the coming day.

## Issue Link

Link the primary issue in the PR description using `#` (e.g. `Fixes #123`). This enables two‑way linking.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe): test bug

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
