### PR TITLE
fix: adjust GH workflow triggers for PRs - remove branch filter

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -5,12 +5,7 @@ on:
     tags: ["*"]
     branches:
       - main
-    paths:
-      - 'coffeeAGNTCY/coffee_agents/**'
-      - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'coffeeAGNTCY/coffee_agents/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -8,8 +8,6 @@ on:
     paths:
       - 'coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
       - '.github/workflows/helm-push.yaml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,6 @@ on:
       - 'coffeeAGNTCY/coffee_agents/lungo/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'coffeeAGNTCY/coffee_agents/corto/**'
       - 'coffeeAGNTCY/coffee_agents/lungo/**'


### PR DESCRIPTION
# Description

This PR does 2 things:
1. for the Docker GH workflow -> removes the "push" trigger `paths` filters in order to maintain the relationship between the `main` branch and the `latest` tag for docker images
2. for all top level GH workflows (docker, helm, tests) ->  removes the `branches` (`main`) filter for the `pull_request` trigger so that we can run the CI on all PRs, not just the ones targetting `main`.  This turned out to be a problem with PRs that target stacked branches when they're opened and when the underlying intial target branch gets merged into main the PR for the branch above it gets automatically retargeted towards `main` but that event is not caught by the `pull_request` GH workflow trigger (because the initial PR was targeting a non-`main` branch) so we end up with no CI checks running.

The problem from point 2 is also described in  https://github.com/agntcy/coffeeAgntcy/pull/476 .

## Issue Link

None

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
