### PR TITLE
fix(docs): Update lungo auction suggested prompts for Brazil identity verification 

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/suggested_prompts.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/suggested_prompts.json
@@ -10,7 +10,7 @@
     },
     {
       "prompt": "What is the current inventory for Brazil farm?",
-      "description": "Direct query to Brazil farm for inventory. Demonstrates identity verification failure - Brazil farm lacks verified identity badge and request will be rejected."
+      "description": "Direct query to Brazil farm for current inventory levels. Standard unicast communication without identity verification."
     },
     {
       "prompt": "What is the current inventory for Colombia farm?",
@@ -25,6 +25,10 @@
     {
       "prompt": "I'd like to buy 200 lbs quantity of coffee at USD 500 price from Colombia",
       "description": "Create order with Colombia farm for 200 lbs at $500. Validates tool-level identity policies via TBAC before executing order creation."
+    },
+    {
+      "prompt": "I'd like to buy 100 lbs of coffee at USD 250 price from Brazil",
+      "description": "Create order with Brazil farm for 100 lbs at $250. Demonstrates identity verification failure - Brazil farm lacks verified identity badge and request will be rejected."
     }
   ],
   "streaming_prompts": [


### PR DESCRIPTION
# Description                                                                                                                                    
  - Updated the Brazil farm inventory query description to accurately reflect that it's a standard unicast communication without identity verification                                                                                                                                    
  - Added a new suggested prompt for ordering from Brazil farm that correctly demonstrates the identity verification failure (Brazil farm lacks verified identity badge)                                                                                                                        
                                                                                                                                                 

## Issue Link

Fixes https://github.com/agntcy/coffeeAgntcy/issues/479

## Type of Change

- [ x Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
