### PR TITLE
fix: align Lungo agent_records types with backend dictionary shape

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/types/agent.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/types/agent.ts
@@ -15,5 +15,5 @@ export type DiscoveryResponseEvent = {
   response: string
   ts: number
   sessionId?: string
-  agent_records?: AgentRecord[]
+  agent_records?: Record<string, AgentRecord>
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/types/api.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/types/api.ts
@@ -9,5 +9,5 @@ import type { AgentRecord } from "@/types/agent"
 export interface ApiResponse {
   response: string
   session_id?: string
-  agent_records?: AgentRecord[]
+  agent_records?: Record<string, AgentRecord>
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/useApp.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/useApp.ts
@@ -11,7 +11,7 @@ import { useAppChatState } from "@/hooks/useAppChatState"
 import { useAgentAPI } from "@/hooks/useAgentAPI"
 import { getGraphConfig } from "@/utils/graphConfigs"
 import { PATTERNS, PatternType } from "@/utils/patternUtils"
-import { DiscoveryResponseEvent, AgentRecord } from "@/types/agent"
+import { DiscoveryResponseEvent } from "@/types/agent"
 
 export type { ApiResponse } from "@/types/api"
 
@@ -133,9 +133,7 @@ export function useApp() {
           response: streaming.recruiterFinalMessage ?? "",
           ts: Date.now(),
           sessionId: streaming.recruiterSessionId ?? undefined,
-          agent_records: streaming.recruiterAgentRecords
-            ? (Object.values(streaming.recruiterAgentRecords) as AgentRecord[])
-            : undefined,
+          agent_records: streaming.recruiterAgentRecords ?? undefined,
         })
       }
     } else if (


### PR DESCRIPTION
## Summary
- **Fix type mismatch**: `agent_records` in `DiscoveryResponseEvent` and `ApiResponse` was typed as `AgentRecord[]` but the backend sends it as `Record<string, AgentRecord>` (keyed dictionary). Updated both types to match the actual backend shape.
- **Remove workaround**: Removed the `Object.values()` cast in `useApp.ts` that was papering over the mismatch, and cleaned up the now-unused `AgentRecord` import.
- All other consumers in the codebase (e.g. `recruiterStreaming.types.ts`, `useMainAreaDiscoveryGraph.ts`) already use the correct `Record<string, AgentRecord>` type.

Closes #481

## Test plan
- [x] Run TypeScript type check (`npm run typecheck`) — no new type errors introduced
- [x] Run the Lungo recruiter workflow and trigger a discovery/streaming response
- [x] Verify `agent_records` arrives as a dictionary and is consumed correctly downstream