### PR TITLE
docs: add architecture details for Corto and Lungo

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/README.md
+++ b/coffeeAGNTCY/coffee_agents/corto/README.md
@@ -2,6 +2,9 @@
 <!-- TOC -->
 * [Corto Exchange, Farm Server, UI](#corto-exchange-farm-server-ui)
   * [Overview](#overview)
+  * [Architecture At A Glance](#architecture-at-a-glance)
+  * [Transport, Topics, and A2A Setup](#transport-topics-and-a2a-setup)
+  * [Where App SDK Fits](#where-app-sdk-fits)
   * [Running Corto Locally](#running-corto-locally)
     * [Prerequisites](#prerequisites)
     * [Setup Instructions](#setup-instructions)
@@ -33,6 +36,61 @@ The Farm Agent serves as a backend flavor profile generator, processing incoming
 
 The user interface forwards all prompts to the exchange’s API, which are then given to an A2A client. This A2A client connects to the farm’s A2A server. The underlying A2A transport layer is fully configurable. By default, the system uses AGNTCY's SLIM. 
 
+## Architecture At A Glance
+
+```mermaid
+flowchart LR
+    UI[React UI]
+    API[Exchange FastAPI API]
+    EX[Exchange agent and LangGraph]
+    SDK[AGNTCY App SDK transport bridge]
+    SLIM[SLIM gateway]
+    FARMHTTP[Farm A2A server]
+    FARM[Farm executor and flavor graph]
+
+    UI --> API
+    API --> EX
+    EX -->|A2A client call| SDK
+    SDK -->|DEFAULT_MESSAGE_TRANSPORT=SLIM| SLIM
+    SLIM -->|A2A agent topic| FARMHTTP
+    FARMHTTP --> FARM
+```
+
+The runtime path is intentionally small:
+
+1. The UI sends a prompt to the Exchange API.
+2. The Exchange agent decides whether the prompt is about coffee flavor and, if so, calls the farm over A2A.
+3. The App SDK binds that A2A client to the configured transport, which is `SLIM` by default in `docker-compose.yaml`.
+4. The farm server exposes the same A2A handler over the transport and hands execution to the farm executor.
+
+This keeps the business logic transport-agnostic: the Exchange and Farm code still speak A2A, while the App SDK handles how those messages are moved.
+
+## Transport, Topics, and A2A Setup
+
+Corto uses one point-to-point A2A route between the Exchange client and the Farm server.
+
+- The Exchange creates a transport with `DEFAULT_MESSAGE_TRANSPORT` and `TRANSPORT_SERVER_ENDPOINT`, then creates an A2A client for the farm topic.
+- The Farm server registers an App SDK session on that same A2A topic so transport messages can be forwarded into the local A2A server.
+- With the default Docker setup, both sides use `SLIM` and connect to `http://slim:46357`.
+
+The topic wiring comes from `A2AProtocol.create_agent_topic(...)` on both sides:
+
+- `exchange/agent.py` computes the farm topic from the farm `AGENT_CARD`.
+- `farm/farm_server.py` registers the farm server on that exact topic.
+- Both components also provide a routable transport name such as `default/default/exchange` or `default/default/<farm-topic>` because SLIM requires a routable PyName for request-reply delivery.
+
+There are two deployment modes:
+
+- `DEFAULT_MESSAGE_TRANSPORT=A2A`: the farm is served directly over local HTTP via `A2AStarletteApplication`.
+- Any other supported transport such as `SLIM`: the farm is wrapped in an App SDK session and exposed through the external transport endpoint.
+
+## Where App SDK Fits
+
+The App SDK is the glue layer between the A2A protocol objects and the underlying transport:
+
+- `exchange/agent.py` uses `AgntcyFactory.create_transport(...)` plus `create_client("A2A", ...)` to send a prompt to the farm.
+- `farm/farm_server.py` uses `create_transport(...)`, `create_app_session()`, and `add_app_container(...)` to expose the farm server on the transport.
+- The result is that Corto can preserve the same A2A interaction model while swapping the transport by configuration instead of rewriting the Exchange or Farm logic.
 
 ## Running Corto Locally
 

--- a/coffeeAGNTCY/coffee_agents/lungo/README.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/README.md
@@ -1,6 +1,10 @@
 <!-- TOC -->
   * [Lungo Demo Overview](#lungo-demo-overview)
     * [Overview](#overview)
+    * [Architecture At A Glance](#architecture-at-a-glance)
+      * [Auction Topology](#auction-topology)
+      * [Logistics Group Chat Topology](#logistics-group-chat-topology)
+    * [Transport, Topics, and App SDK Integration](#transport-topics-and-app-sdk-integration)
   * [Running Lungo Locally](#running-lungo-locally)
     * [Prerequisites](#prerequisites)
     * [Setup Instructions](#setup-instructions)
@@ -35,9 +39,110 @@ The current demo models a **supervisor-worker agent ecosystem**, where:
 
 All agents are implemented as **directed LangGraphs** with **Agent-to-Agent (A2A)** integration. The user interface communicates with the Supervisor’s API to submit prompts. These prompts are processed through the LangGraph and routed via an A2A client to the appropriate Farm’s A2A server.
 
-The underlying A2A transport is configurable. By default, it uses **SLIM**, supporting both broadcast and unicast messaging depending on the context and data requirements.
+The underlying A2A transport is configurable, but the demo intentionally uses two different defaults:
+
+- The **Auction** flow defaults to **NATS** for farm broadcast and unicast traffic.
+- The **Logistics** flow is **SLIM-only** because it relies on group chat primitives.
 
 One notable component is the **Colombia Farm**, which functions as an **MCP client**. It communicates with an MCP server (over SLIM) to retrieve real-time weather data used to calculate coffee yield.
+
+### Architecture At A Glance
+
+Lungo contains two distinct communication patterns in one reference app.
+
+#### Auction Topology
+
+```mermaid
+flowchart LR
+    UI[Frontend]
+    API[Auction Supervisor API]
+    GRAPH[Auction LangGraph]
+    SDK[App SDK transport bridge]
+    NATS[NATS broker]
+    BCAST[farm_broadcast topic]
+    BRAZIL[Brazil farm]
+    COLOMBIA[Colombia farm]
+    VIETNAM[Vietnam farm]
+    WEATHER[Weather MCP service]
+
+    UI --> API
+    API --> GRAPH
+    GRAPH --> SDK
+    SDK -->|broadcast or unicast| NATS
+    NATS --> BCAST
+    BCAST --> BRAZIL
+    BCAST --> COLOMBIA
+    BCAST --> VIETNAM
+    COLOMBIA -->|MCP client call| WEATHER
+```
+
+The auction supervisor decides whether a prompt should:
+
+- call one farm directly over its personal A2A topic,
+- broadcast to all farms over `farm_broadcast`, or
+- create an order with a single verified farm.
+
+Each farm server listens on two channels:
+
+- a private topic from `A2AProtocol.create_agent_topic(AGENT_CARD)` for direct requests,
+- the shared `FARM_BROADCAST_TOPIC` for inventory fan-out.
+
+This dual registration happens in each farm `farm_server.py` through two App SDK app containers.
+
+#### Logistics Group Chat Topology
+
+```mermaid
+flowchart LR
+    UI2[Frontend]
+    API2[Logistics Supervisor API]
+    GRAPH2[Logistics LangGraph]
+    SDK2[App SDK transport bridge]
+    SLIM[SLIM gateway]
+    GROUP[Dynamic group channel]
+    FARM[Tatooine farm]
+    SHIPPER[Shipper]
+    ACCOUNTANT[Accountant]
+    HELPDESK[Helpdesk optional]
+
+    UI2 --> API2
+    API2 --> GRAPH2
+    GRAPH2 --> SDK2
+    SDK2 --> SLIM
+    SLIM --> GROUP
+    GROUP --> FARM
+    GROUP --> SHIPPER
+    GROUP --> ACCOUNTANT
+    GROUP --> HELPDESK
+```
+
+The logistics supervisor seeds the workflow with `RECEIVED_ORDER`, then the agents advance the order through the shared conversation:
+
+1. Supervisor -> `RECEIVED_ORDER`
+2. Farm -> `HANDOVER_TO_SHIPPER`
+3. Shipper -> `CUSTOMS_CLEARANCE`
+4. Accountant -> `PAYMENT_COMPLETE`
+5. Shipper -> `DELIVERED`
+
+That workflow is documented in more detail in [Group Conversation Docs](./docs/group_conversation.md).
+
+### Transport, Topics, and App SDK Integration
+
+Lungo uses the same A2A protocol surface in both demos, but the App SDK is what maps that protocol onto the chosen transport.
+
+For the auction flow:
+
+- `agents/supervisors/auction/graph/tools.py` creates one transport instance with the configured `DEFAULT_MESSAGE_TRANSPORT` and `TRANSPORT_SERVER_ENDPOINT`.
+- Unicast calls use `create_client("A2A", agent_topic=<farm-topic>, ...)`.
+- Broadcast calls use `broadcast_message(...)` or `broadcast_message_streaming(...)` with `broadcast_topic=FARM_BROADCAST_TOPIC`.
+- The default Docker setup sets `DEFAULT_MESSAGE_TRANSPORT=${DEFAULT_MESSAGE_TRANSPORT:-NATS}` for the auction-side services.
+
+For the logistics flow:
+
+- `agents/supervisors/logistics/graph/tools.py` requires `DEFAULT_MESSAGE_TRANSPORT == "SLIM"`.
+- The supervisor creates a client using the shipper topic as the routable handshake, then starts a shared session with `start_groupchat(...)` or `start_streaming_groupchat(...)`.
+- Each logistics agent server registers itself on SLIM with an App SDK app session so it can join and respond on the shared conversation channel.
+
+In other words, the LangGraph nodes decide *when* to talk, A2A defines *what* the messages look like, and the App SDK decides *how* those messages move across NATS or SLIM.
 
 ## Running Lungo Locally
 

--- a/coffeeAGNTCY/coffee_agents/lungo/README.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/README.md
@@ -4,6 +4,7 @@
     * [Architecture At A Glance](#architecture-at-a-glance)
       * [Auction Topology](#auction-topology)
       * [Logistics Group Chat Topology](#logistics-group-chat-topology)
+      * [Recruiter Discovery and Delegation Topology](#recruiter-discovery-and-delegation-topology)
     * [Transport, Topics, and App SDK Integration](#transport-topics-and-app-sdk-integration)
   * [Running Lungo Locally](#running-lungo-locally)
     * [Prerequisites](#prerequisites)
@@ -44,11 +45,11 @@ The underlying A2A transport is configurable, but the demo intentionally uses tw
 - The **Auction** flow defaults to **NATS** for farm broadcast and unicast traffic.
 - The **Logistics** flow is **SLIM-only** because it relies on group chat primitives.
 
-One notable component is the **Colombia Farm**, which functions as an **MCP client**. It communicates with an MCP server (over SLIM) to retrieve real-time weather data used to calculate coffee yield.
+One notable component is the **Colombia Farm**, which functions as an **MCP client**. It communicates with the weather MCP service over the same configurable transport used by the farm runtime; in the default Docker Compose setup that path also uses **NATS**.
 
 ### Architecture At A Glance
 
-Lungo contains two distinct communication patterns in one reference app.
+Lungo contains three distinct communication patterns in one reference app.
 
 #### Auction Topology
 
@@ -63,17 +64,20 @@ flowchart LR
     BRAZIL[Brazil farm]
     COLOMBIA[Colombia farm]
     VIETNAM[Vietnam farm]
+    WXSVC[lungo_weather_service topic]
     WEATHER[Weather MCP service]
 
     UI --> API
     API --> GRAPH
     GRAPH --> SDK
-    SDK -->|broadcast or unicast| NATS
+    SDK -->|broadcast or unicast A2A| NATS
     NATS --> BCAST
     BCAST --> BRAZIL
     BCAST --> COLOMBIA
     BCAST --> VIETNAM
-    COLOMBIA -->|MCP client call| WEATHER
+    COLOMBIA -->|MCP tool call| NATS
+    NATS --> WXSVC
+    WXSVC --> WEATHER
 ```
 
 The auction supervisor decides whether a prompt should:
@@ -87,16 +91,16 @@ Each farm server listens on two channels:
 - a private topic from `A2AProtocol.create_agent_topic(AGENT_CARD)` for direct requests,
 - the shared `FARM_BROADCAST_TOPIC` for inventory fan-out.
 
-This dual registration happens in each farm `farm_server.py` through two App SDK app containers.
+This dual registration happens in each farm `farm_server.py` through two App SDK app containers. The Colombia farm also creates an MCP client for the `lungo_weather_service` topic, which follows the same configured transport as the auction services.
 
 #### Logistics Group Chat Topology
 
 ```mermaid
 flowchart LR
-    UI2[Frontend]
-    API2[Logistics Supervisor API]
-    GRAPH2[Logistics LangGraph]
-    SDK2[App SDK transport bridge]
+    UI[Frontend]
+    API[Logistics Supervisor API]
+    GRAPH[Logistics LangGraph]
+    SDK[App SDK transport bridge]
     SLIM[SLIM gateway]
     GROUP[Dynamic group channel]
     FARM[Tatooine farm]
@@ -104,10 +108,10 @@ flowchart LR
     ACCOUNTANT[Accountant]
     HELPDESK[Helpdesk optional]
 
-    UI2 --> API2
-    API2 --> GRAPH2
-    GRAPH2 --> SDK2
-    SDK2 --> SLIM
+    UI --> API
+    API --> GRAPH
+    GRAPH --> SDK
+    SDK --> SLIM
     SLIM --> GROUP
     GROUP --> FARM
     GROUP --> SHIPPER
@@ -125,9 +129,35 @@ The logistics supervisor seeds the workflow with `RECEIVED_ORDER`, then the agen
 
 That workflow is documented in more detail in [Group Conversation Docs](./docs/group_conversation.md).
 
+#### Recruiter Discovery and Delegation Topology
+
+```mermaid
+flowchart LR
+    UI[Frontend]
+    API[Recruiter Supervisor API]
+    ADK[Recruiter Supervisor ADK runner]
+    RECRUITER[Recruiter Agent A2A service]
+    DIR[dir-api-server]
+    ZOT[zot registry]
+    TARGET[Selected remote agent]
+
+    UI --> API
+    API --> ADK
+    ADK -->|A2A HTTP| RECRUITER
+    RECRUITER -->|directory search| DIR
+    DIR --> ZOT
+    ADK -->|delegated A2A call| TARGET
+```
+
+The recruiter supervisor uses a different pattern from the transport-bridged auction and logistics flows:
+
+- it talks to the recruiter service over a URL-based A2A client rather than App SDK topic routing,
+- the recruiter service queries the AGNTCY directory and returns agent cards plus evaluation results,
+- once a user selects an agent, the supervisor forwards subsequent prompts directly to that advertised A2A endpoint.
+
 ### Transport, Topics, and App SDK Integration
 
-Lungo uses the same A2A protocol surface in both demos, but the App SDK is what maps that protocol onto the chosen transport.
+Lungo uses the same A2A protocol surface across its demos, but the transport wiring differs by flow.
 
 For the auction flow:
 
@@ -142,7 +172,13 @@ For the logistics flow:
 - The supervisor creates a client using the shipper topic as the routable handshake, then starts a shared session with `start_groupchat(...)` or `start_streaming_groupchat(...)`.
 - Each logistics agent server registers itself on SLIM with an App SDK app session so it can join and respond on the shared conversation channel.
 
-In other words, the LangGraph nodes decide *when* to talk, A2A defines *what* the messages look like, and the App SDK decides *how* those messages move across NATS or SLIM.
+For the recruiter flow:
+
+- `agents/supervisors/recruiter/recruiter_client.py` uses the A2A client directly against `RECRUITER_AGENT_CARD.url`.
+- That supervisor-to-recruiter hop is URL-based A2A rather than App SDK topic routing.
+- After agent selection, the dynamic workflow forwards the user task to the chosen remote A2A endpoint advertised by the recruited agent.
+
+In other words, the LangGraph or ADK nodes decide *when* to talk, A2A defines *what* the messages look like, the App SDK decides *how* messages move across NATS or SLIM for auction and logistics, and the recruiter path uses direct A2A HTTP to discovered agents.
 
 ## Running Lungo Locally
 


### PR DESCRIPTION
## Summary
- add architecture-overview sections to the Corto and Lungo READMEs
- document how A2A, topics, transports, and the AGNTCY App SDK fit together
- clarify that Lungo auction defaults to NATS while logistics group chat requires SLIM

## Verification
- ran \git diff --check\

Closes #77