### PR TITLE
fix(exchange): surface real backend errors, fix SLIM transport timeout

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/exchange/agent.py
+++ b/coffeeAGNTCY/coffee_agents/corto/exchange/agent.py
@@ -88,6 +88,24 @@ def _parse_a2a_response(response):
 
 _A2A_MAX_ATTEMPTS = 5
 _A2A_BACKOFF_BASE = 3
+_A2A_REQUEST_TIMEOUT_SECONDS = 60  # LLM calls on the farm can take 10–30s; the SDK default of 6s is too short
+
+
+def _patch_transport_timeout(transport, timeout_seconds: int = _A2A_REQUEST_TIMEOUT_SECONDS):
+    """
+    Override the default point-to-point request timeout on a SLIMTransport.
+
+    The SDK's factory calls transport.request() without an explicit timeout, so
+    the transport falls back to its hardcoded 6-second default — far too short for
+    an LLM-backed farm agent. Wrapping the method here changes the default so every
+    request through this transport uses `timeout_seconds` unless the caller overrides it.
+    """
+    original_request = transport.request
+
+    async def request_with_timeout(recipient, message, timeout=timeout_seconds, **kwargs):
+        return await original_request(recipient, message, timeout=timeout, **kwargs)
+
+    transport.request = request_with_timeout
 
 
 async def _send_a2a_with_retry(client, request):
@@ -191,6 +209,7 @@ class ExchangeAgent:
             endpoint=TRANSPORT_SERVER_ENDPOINT,
             name="default/default/exchange"  # SLIM transport requires a routable name (org/namespace/agent) to build the PyName used for request-reply routing
         )
+        _patch_transport_timeout(transport)
         client = await factory.create_client(
             "A2A",
             agent_topic=a2a_topic,

--- a/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/utils/const.ts
+++ b/coffeeAGNTCY/coffee_agents/corto/exchange/frontend/src/utils/const.ts
@@ -24,7 +24,7 @@ export const parseApiError = (error: any): ApiErrorInfo => {
       message:
         typeof data === "string"
           ? data
-          : data?.message || "Request failed",
+          : data?.detail || data?.message || "Request failed",
     }
   }
 


### PR DESCRIPTION
  - parse FastAPI's 'detail' field in parseApiError instead of 'message' so real error messages reach the UI instead of 'Request failed'
  - patch SLIMTransport.request() default timeout from 6s to 60s to accommodate LLM response times on the farm agent (~10-15s); the SDK's factory calls transport.request() without an explicit timeout, causing sessions to expire before the farm responds

# Description

#519 - SLIM transport times out before farm agent LLM call completes
#518 - Frontend always shows "Request failed" instead of real error message 

## Issue Link

Fixes #518 and #519

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
