### PR TITLE
release(helm,APIs): bump CORS helm charts

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.7"
 description: A Helm chart for the Corto Exchange Server
 name: corto-exchange
-version: 0.0.7
+version: 0.0.8

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/templates/configmap.tpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.appName }}-configmap
   namespace: {{ .Release.Namespace }}
 data:
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   FARM_AGENT_HOST: "{{ .Values.config.farmAgentHost }}"
   FARM_AGENT_PORT: "{{ .Values.config.farmAgentPort }}"
   AZURE_API_BASE: "{{ .Values.config.azureApiBase }}"

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/values.yaml
@@ -23,6 +23,7 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  corsAllowedOrigins: ""
 #  llmStreaming: False
 
 # You can use your own config here for service account
@@ -40,9 +41,6 @@ ingress:
   servicePort: ""
   tlsSecret: ""
   annotations: {}
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: corto-local-cluster
 description: A Helm chart for deploying Corto services in a local cluster
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0"
 dependencies:
   - name: slim
@@ -12,7 +12,7 @@ dependencies:
     version: "1.3.16"
     repository: "https://nats-io.github.io/k8s/helm/charts"
   - name: clickhouse
-    version: "9.4.3"         
+    version: "9.4.3"
     repository: "oci://registry-1.docker.io/bitnamicharts"
   - name: opentelemetry-collector
     version: "0.138.0"
@@ -21,7 +21,7 @@ dependencies:
     version: "10.1.2"
     repository: "oci://ghcr.io/grafana/helm-charts"
   - name: corto-exchange
-    version: "0.0.7"
+    version: "0.0.8"
     repository: "file://../exchange"
   - name: corto-farm
     version: "0.0.5"
@@ -29,5 +29,3 @@ dependencies:
   - name: corto-ui
     version: "0.0.2"
     repository: "file://../corto-ui"
-
-  

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/values.yaml
@@ -31,8 +31,8 @@ nats:
     failureThreshold: 6
 
 corto-exchange:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 corto-ui:
   environment: local

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Agentic Workflows HTTP API
 name: agentic-workflows-api
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/configmap.tpl.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.appName }}-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/deployment.tpl.yaml
@@ -31,8 +31,9 @@ spec:
         env:
         - name: PORT
           value: "{{ .Values.service.port }}"
-        - name: CORS_ALLOWED_ORIGINS
-          value: {{ .Values.cors.allowedOrigins | quote }}
+        envFrom:
+          - configMapRef:
+              name: {{ .Values.appName }}-configmap
         {{ if .Values.resources.enabled }}
         resources:
           requests:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/values.yaml
@@ -5,11 +5,6 @@ appName: agentic-workflows-api
 appVersion: v1
 replicaCount: 1
 
-# Comma-separated browser origins for Access-Control-Allow-Origin (credentialed CORS).
-# Empty uses application defaults (local UI origins). Set in production to your real UI origin(s).
-cors:
-  allowedOrigins: ""
-
 environment:
 
 image:
@@ -20,6 +15,9 @@ image:
 
 service:
   port: 9105
+
+config:
+  corsAllowedOrigins: ""
 
 probes:
   readinessProbeEnabled: true

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.3"
 description: A Helm chart for Auction Supervisor
 name: auction-supervisor
-version: 0.0.3
+version: 0.0.4

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/configmap.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   AZURE_API_BASE: "{{ .Values.config.azureApiBase }}"
   AZURE_API_VERSION: "{{ .Values.config.azureApiVersion }}"
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   LLM_MODEL: "{{ .Values.config.llmModel }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/values.yaml
@@ -32,6 +32,7 @@ config:
   # Identity TBAC Configuration
   identityServiceApiKey: ""
   identityAuthEnabled: "false"
+  corsAllowedOrigins: ""
 
 
 # You can use your own config here for service account
@@ -61,9 +62,6 @@ extraIngress:
     path: ""
     pathType: ""
     annotations: {}
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lungo-local-cluster
 description: A Helm chart for deploying Lungo services in a local cluster
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0"
 dependencies:
   - name: slim
@@ -12,7 +12,7 @@ dependencies:
     version: "1.3.16"
     repository: "https://nats-io.github.io/k8s/helm/charts"
   - name: clickhouse
-    version: "9.4.3"         
+    version: "9.4.3"
     repository: "oci://registry-1.docker.io/bitnamicharts"
   - name: opentelemetry-collector
     version: "0.138.0"
@@ -21,7 +21,7 @@ dependencies:
     version: "10.1.2"
     repository: "oci://ghcr.io/grafana/helm-charts"
   - name: auction-supervisor
-    version: "0.0.3"
+    version: "0.0.4"
     repository: "file://../auction-supervisor"
   - name: brazil-farm
     version: "0.0.6"
@@ -36,31 +36,29 @@ dependencies:
     version: "0.0.4"
     repository: "file://../weather-mcp-server"
   - name: logistics-farm
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../logistics-farm"
   - name: logistics-helpdesk
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../logistics-helpdesk"
   - name: logistics-supervisor
-    version: "0.0.3"
+    version: "0.0.2"
     repository: "file://../logistics-supervisor"
   - name: logistics-shipper
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../logistics-shipper"
   - name: logistics-accountant
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../logistics-accountant"
   - name: recruiter
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../recruiter"
   - name: recruiter-supervisor
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../recruiter-supervisor"
   - name: lungo-ui
-    version: "0.0.5"
+    version: "0.0.6"
     repository: "file://../ui"
   - name: agentic-workflows-api
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../agentic-workflows-api"
-
-  

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/values.yaml
@@ -37,36 +37,36 @@ weather-mcp-server:
 
 agentic-workflows-api:
   environment: local
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 auction-supervisor:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 logistics-accountant:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 logistics-farm:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 logistics-helpdesk:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 logistics-shipper:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 logistics-supervisor:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 recruiter-supervisor:
-  cors:
-    allowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
+  config:
+    corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
 
 lungo-ui:
   environment: local

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics Accountant agent
 name: logistics-accountant
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/templates/configmap.tpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.appName }}-configmap
   namespace: {{ .Release.Namespace }}
 data:
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/values.yaml
@@ -18,14 +18,12 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  corsAllowedOrigins: ""
 
 # You can use your own config here for service account
 serviceaccount:
   annotations:
     eks.amazonaws.com/role-arn: REPLACE_WITH_ROLE_ARN
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics Farm agent
 name: logistics-farm
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/templates/configmap.tpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.appName }}-configmap
   namespace: {{ .Release.Namespace }}
 data:
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/values.yaml
@@ -18,14 +18,12 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  corsAllowedOrigins: ""
 
 # You can use your own config here for service account
 serviceaccount:
   annotations:
     eks.amazonaws.com/role-arn: REPLACE_WITH_ROLE_ARN
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics HelpDesk agent
 name: logistics-helpdesk
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/templates/configmap.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   AZURE_API_BASE: "{{ .Values.config.azureApiBase }}"
   AZURE_API_VERSION: "{{ .Values.config.azureApiVersion }}"
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   LLM_MODEL: "{{ .Values.config.llmModel }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/values.yaml
@@ -21,6 +21,7 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  corsAllowedOrigins: ""
 #  llmStreaming: False
 
 # You can use your own config here for service account
@@ -38,9 +39,6 @@ ingress:
   servicePort: ""
   tlsSecret: ""
   annotations: {}
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics Shipper agent
 name: logistics-shipper
-version: 0.0.1
+version: 0.0.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/templates/configmap.tpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.appName }}-configmap
   namespace: {{ .Release.Namespace }}
 data:
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/values.yaml
@@ -18,14 +18,12 @@ config:
   transportServerEndpoint: ""
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
+  corsAllowedOrigins: ""
 
 # You can use your own config here for service account
 serviceaccount:
   annotations:
     eks.amazonaws.com/role-arn: REPLACE_WITH_ROLE_ARN
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.3"
 description: A Helm chart for the Logistics Supervisor agent
 name: logistics-supervisor
-version: 0.0.3
+version: 0.0.4

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/configmap.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   AZURE_API_BASE: "{{ .Values.config.azureApiBase }}"
   AZURE_API_VERSION: "{{ .Values.config.azureApiVersion }}"
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   LLM_MODEL: "{{ .Values.config.llmModel }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/values.yaml
@@ -22,6 +22,7 @@ config:
   defaultMessageTransport: ""
   otlpHttpEndpoint: ""
   experimentalFeature: "true"
+  corsAllowedOrigins: ""
 #  llmStreaming: False
 
 # You can use your own config here for service account
@@ -51,9 +52,6 @@ extraIngress:
   path: ""
   pathType: ""
   annotations: {}
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Helm chart for Recruiter Supervisor
 name: recruiter-supervisor
-version: 0.0.2
+version: 0.0.3

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/templates/configmap.tpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.appName }}-configmap
   namespace: {{ .Release.Namespace }}
 data:
-  CORS_ALLOWED_ORIGINS: "{{ .Values.cors.allowedOrigins }}"
+  CORS_ALLOWED_ORIGINS: "{{ .Values.config.corsAllowedOrigins }}"
   RECRUITER_AGENT_URL: "{{ .Values.config.recruiterAgentUrl }}"
   LLM_MODEL: "{{ .Values.config.llmModel }}"
   AZURE_API_BASE: "{{ .Values.config.azureApiBase }}"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/values.yaml
@@ -30,6 +30,7 @@ config:
   # Identity TBAC Configuration
   identityServiceApiKey: ""
   identityAuthEnabled: "false"
+  corsAllowedOrigins: ""
 
 # You can use your own config here for service account
 serviceaccount:
@@ -58,9 +59,6 @@ extraIngress:
   path: ""
   pathType: ""
   annotations: {}
-
-cors:
-  allowedOrigins: ""
 
 probes:
   livenessProbeEnabled: false


### PR DESCRIPTION
# Description

- Harmonized the CORS config to match earlier config approaches with env var through the configmap and also updated the agentic-workflows-api to use a similar configmap.
- Bumped all the CORS related charts so I can properly release them.

## Issue Link

Link the primary issue in the PR description using `#` (e.g. `Fixes #123`). This enables two‑way linking.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe): release, chart patch/BREAKING CHANGE (unreleased)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
