### PR TITLE
Mark repo as independent evolution of agntcy/coffeeAgntcy

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,7 @@
+# kubeages/coffeeAgntcy
+
+This is an independent evolution of [agntcy/coffeeAgntcy](https://github.com/agntcy/coffeeAgntcy).
+Upstream is tracked as a remote for selective cherry-picks; commits and CI under this repo are not
+contributed back upstream by default.
+
+Container images for this fork are published to `ghcr.io/kubeages/coffee-agntcy/*`.


### PR DESCRIPTION
Adds FORK.md to declare independent evolution. Images target ghcr.io/kubeages/coffee-agntcy/*.