### PR TITLE
feat(lungo): add Skill for jsonschema to pydanticv2 types

### DIFF
--- a/.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md
+++ b/.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: jsonschema-to-pydantic-lungo
+description: Generates Pydantic v2 model classes from the JSON Schema documents under `coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/` into `coffeeAGNTCY/coffee_agents/lungo/schema/types/*.py`. DO NOT TRIGGER AUTOMATICALLY. ASK THE USER IF THE SKILL SHOULD BE USED. Use when a `*_v*.json` schema under that folder is added or modified, when regenerating the lungo Pydantic types after a schema change, or when the user mentions regenerating schema types, lungo types, JSON Schema → Pydantic, or fixing drift between schema and types.
+---
+
+# JSON Schema → Pydantic v2 (lungo)
+
+## What this skill does
+
+Generates one Pydantic v2 module per JSON Schema in `coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/*.json`. Output goes to `coffeeAGNTCY/coffee_agents/lungo/schema/types/<schema_name>.py`. The package `__init__.py` is updated to re-export the public symbols.
+
+The generator is the schema. **Do not** read existing files in `schema/types/` to decide naming, layout, or behaviour — they may be missing, stale, or wrong. The only authoritative inputs are:
+
+1. The `.json` files under `schema/jsonschemas/` (excluding `examples/`).
+2. Cross-field validation logic that isn't expressible in JSON Schema, found in `coffeeAGNTCY/coffee_agents/lungo/schema/json_schema.py` (and any sibling modules under `schema/`).
+
+## Workflow
+
+Copy this checklist and tick items as you go:
+
+```
+- [ ] 1. Enumerate input schemas under schema/jsonschemas/*.json (skip examples/)
+- [ ] 2. Read each schema fully, including $defs, $ref, allOf, anyOf, propertyNames
+- [ ] 3. Read schema/json_schema.py for Python-only constraints (e.g. validate_version_specific_criteria)
+- [ ] 4. Generate one schema/types/<name>.py per schema, applying the mapping rules
+- [ ] 5. Update schema/types/__init__.py: re-export every public class, type alias, and `*_from_uuid` helper
+- [ ] 6. Run: cd coffeeAGNTCY/coffee_agents/lungo && uv run --frozen pytest tests/unit/schemas/ -x
+- [ ] 7. Run: cd coffeeAGNTCY/coffee_agents/lungo && uv run --frozen pytest tests/unit/ -x
+```
+
+If step 6 or 7 fails, identify which mapping rule(s) you applied incorrectly and **re-emit** the affected file(s) end-to-end — do not patch the failing portion in isolation. Do not edit tests or non-generated consumer code unless the user explicitly asks. If a rule itself seems wrong or insufficient to make the tests pass, surface that to the user instead of working around it.
+
+## Naming
+
+| Source artefact | Target Python identifier |
+|---|---|
+| `event_v1.json` | `event.py` (strip the `_v<N>` version suffix) |
+| `$defs.foo_bar` | `class FooBar` (snake_case → PascalCase, **no semantic renames**) |
+| Top-level object schema with `title: "Event (v1)"` | `class Event` (title without parenthesised version) |
+| Top-level schema with no root `type` (enum-only / `$defs`-only file, e.g. `event_type_v1.json`) | no root class — the module just contains the `$defs` outputs |
+| `$defs.<x>_id` referencing `<prefix>://<UUID>` strings | `class <X>Id(RootModel[str])` + helper `<x>_id_from_uuid` |
+| Cross-schema `$ref` (e.g. `event_type_v1.json#/$defs/event_type`) | `from schema.types.<other_module> import <Class>` |
+| Enum member name | SCREAMING_SNAKE_CASE of the value, even when the value itself is PascalCase. Example: `RECRUITER_NODE_SEARCH = "RecruiterNodeSearch"`. |
+
+The class name is derived **mechanically** from the `$defs` key. Do not shorten, expand, or reinterpret the name. You should, however, translate it from snake_case to PascalCase. For example, `stable_agent_id` becomes `StableAgentId`, never `AgentId`. If a consumer breaks because of a rename, that's the consumer's bug to fix, not the skill's.
+
+### Naming for *merged* classes (anyOf branches that compose ≥2 `$defs`)
+
+Whenever an `anyOf` branch is an `allOf` that references **two or more** `$defs`, that branch produces a *merged* leaf class with no `$def` name of its own. The rule applies regardless of where the branch sits in the `anyOf` (schemas are human-written; ordering is not a contract) and regardless of how many `$defs` are composed.
+
+For each unique composition, pick a name that:
+
+- Reads naturally as *base concept* "with" *extension(s)*, drawing the tokens from the composed `$def` keys.
+- PascalCase-joins the components, deduplicating any common prefix/suffix shared between the keys so the result does not stutter (prefer `PartialNodeWithAgentExtension` over `PartialNodeWithPartialNodeAgentExtension`).
+- Treats one of the composed `$defs` as the *base* and the rest as *extensions*. The base is most easily identified as the `$def` that another branch in the same `anyOf` references alone (or with fewer extensions). Falling back: pick the `$def` with the largest field set, or the one whose name does not look extension-shaped (e.g. lacks an `_extension` / `_ext` suffix).
+- For ≥2 extensions, chain them: `<Base>With<Ext1>And<Ext2>...`. If the chain becomes unreadable, pick a domain-meaningful umbrella token instead — record the choice in the class docstring.
+
+The merged class name must be a function of the *set* of composed `$defs`, not of the branch position. Two branches that compose the same set must resolve to the same class.
+
+A `$def` that is **only** ever referenced inside an `allOf` composing a merged class is **not** emitted as a standalone class: its fields appear directly on the merged class instead. If the same `$def` is also referenced standalone elsewhere in the schema, emit it standalone too.
+
+This rule applies whenever the composition is anonymous. If the schema gives the composition its own `$def` name (as `partial_agent_node` / `agent_node` do in `event_v1.json`), follow the standard naming rule and emit classes named after that key — see [`mapping-rules.md`](mapping-rules.md) §D for how the named-composition case interacts with sibling-key discrimination.
+
+## File header
+
+Every generated file starts with:
+
+```python
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generated from ``schema/jsonschemas/<source_file>.json``.
+
+Do not edit by hand: regenerate with the ``jsonschema-to-pydantic-lungo`` skill.
+
+<short paraphrase of the schema's `title` and `description`>
+"""
+```
+
+Use `from __future__ import annotations` and group imports stdlib → third-party → first-party (`schema.*`).
+
+## Mapping rules
+
+| Schema construct | Pydantic v2 emission |
+|---|---|
+| `type: string`, `pattern: P` | `Annotated[str, Field(pattern=P)]` |
+| `type: string`, `minLength: 1` | `Annotated[str, Field(min_length=1)]` |
+| `type: string`, `format: date-time` | `pydantic.AwareDatetime` |
+| `type: string`, `enum: [...]` | `class X(StrEnum): ...` (preserve string values verbatim) |
+| `type: number`, `default: V` | `float = V` |
+| `type: boolean`, `default: V` | `bool = V` |
+| `type: object`, `additionalProperties: false` | `model_config = ConfigDict(extra="forbid")` |
+| `type: object`, `additionalProperties: true` (or unspecified for an extensible object) | `model_config = ConfigDict(extra="allow")` |
+| Required field | bare type, no default |
+| Optional field, no default | `<Type> \| None = None` |
+| Optional field with `default: V` | `<Type> = V` (no `\| None`) |
+| `$ref: "#/$defs/foo"` | use the generated `Foo` class as the field type |
+| `$ref: "<other>_v<N>.json#/$defs/foo"` | import `Foo` from `schema.types.<other>` |
+| Top-level schema `additionalProperties: false` | `Event` (or equivalent root) gets `extra="forbid"` |
+
+### Rule A — Encode in-place schema constraints in the field type, preferably not in a validator
+
+Anything that constrains a single value in isolation — `pattern`, `minLength`, `maximum`, `format`, `enum`, `propertyNames` on a dict — must be expressed in the field's `Annotated[...]` type. Validators (`@field_validator`, `@model_validator`) are **only** for cross-field constraints.
+
+For `propertyNames: { $ref: "#/$defs/<id_def>" }` on a dict-shaped property, embed the constraint into the dict key annotation.
+For example:
+
+```python
+instances: dict[
+    Annotated[str, Field(pattern=_INSTANCE_ID_REGEX)], WorkflowInstance
+]
+```
+
+See [`mapping-rules.md`](mapping-rules.md) §A for the full example.
+
+### Rule B — `<prefix>://<UUID>` strings always pair `RootModel` with a `<def>_from_uuid` helper
+
+For every `$defs.<x>_id` whose `pattern` matches `^<prefix>://<UUID>$`:
+
+1. Emit `class <X>Id(RootModel[str])` with the `pattern=` constraint.
+2. Emit `def <x>_id_from_uuid(<x>_uuid: UUID) -> <X>Id:` immediately below the class. Use `f"<prefix>://{<x>_uuid!s}"` to build the string.
+
+Helper name is always `<schema_def_name>_from_uuid`, even if the prefix differs from the def name (e.g. `stable_agent_id` → prefix `agent://` → helper `stable_agent_id_from_uuid`).
+
+### Rule C — `allOf [partial, {required: [...]}]` → standalone full class, not a subclass
+
+When a `$def` is `allOf [partial_<X>, { required: [<all_fields>] }]`, generate **two unrelated** classes (`Partial<X>` and `<X>`) with their fields re-declared. Do not subclass: `Optional`/`| None` types from the partial would leak into the full form.
+
+```python
+class PartialThing(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    a: SomeType | None = None
+    b: SomeType | None = None
+
+class Thing(BaseModel):  # NOT (PartialThing) — fields are required here
+    model_config = ConfigDict(extra="allow")
+    a: SomeType
+    b: SomeType
+```
+
+### Rule D — `anyOf` discriminated by sibling-key presence → `Discriminator` callable
+
+When the `anyOf` branches differ by *which keys are present* (typically one branch has `not { anyOf: [{ required: [k1] }, { required: [k2] }, ...] }` and another `allOf`s in a sibling extension `$def` that requires those keys), encode the choice with a callable `pydantic.Discriminator` whose **only** job is to mirror that sibling-key presence test. Leave any *full vs. partial* sub-choice to Pydantic's smart union inside each branch.
+
+```python
+def _kind_discriminator(value: Any) -> str | None:
+    if isinstance(value, (FullExt, PartialExt)):
+        return "with_extension"
+    if isinstance(value, (FullPlain, PartialPlain)):
+        return "plain"
+    if not isinstance(value, dict):
+        return None
+    if "ext_required_key" in value or "ext_optional_key" in value:
+        return "with_extension"
+    return "plain"
+
+ItemUnion = Annotated[
+    Union[
+        Annotated[Union[FullPlain, PartialPlain], Tag("plain")],
+        Annotated[Union[FullExt, PartialExt], Tag("with_extension")],
+    ],
+    Discriminator(_kind_discriminator),
+]
+```
+
+Why this shape:
+
+- The discriminator does **one** thing: encode the schema's actual `anyOf` decision. Never put field-count or per-field validity checks in it.
+- Each tagged branch is a `Union[Full, Partial]`. Smart union picks `Full` when all the extra required fields are populated, else `Partial`.
+- Bad inputs surface clean errors from the chosen branch's own `Field` / `pattern` constraints (e.g. `String should match pattern '^agent://...'`) instead of a custom "extra fields not allowed" message.
+- Do **not** add an `@model_validator(mode="after")` that polices `__pydantic_extra__` for sibling-extension keys leaking into a non-extension variant. The discriminator already routes them to the right branch.
+
+See [`mapping-rules.md`](mapping-rules.md) §D for the full worked example covering schemas with `not { required }` clauses.
+
+### Rule E — Cross-field constraints from `schema/json_schema.py`
+
+JSON Schema can't express "dict key X must equal nested value's `id` field" or similar relationships. Look in `coffeeAGNTCY/coffee_agents/lungo/schema/json_schema.py` for functions called from `validate_version_specific_criteria` (and any equivalent module). Each schema-name-gated check there must be re-implemented as a Pydantic `@model_validator(mode="after")`.
+
+**Where to attach the validator**: place it on the *smallest* class that owns every field the check reads. Do not push it up to the root just because the source helper happens to start its traversal at the root.
+
+Example: `_enforce_workflow_instance_map_key_id_match` reads `workflow.instances` keys and `workflow_instance.id`. Both live inside the `Workflow` class (the dict is its `instances` field; each value is a `WorkflowInstance` whose `id` it can dereference). So the validator goes on `Workflow`, not on `Event` or `Data`.
+
+The validator's docstring must point back at the source helper, e.g.:
+
+```
+mirrors ``schema.json_schema._enforce_workflow_instance_map_key_id_match``
+```
+
+## `__init__.py` regeneration
+
+`schema/types/__init__.py` re-exports every public symbol from each generated module. Keep three groups, each alphabetised:
+
+1. Imports from each `schema.types.<module>`.
+2. The `__all__` tuple/list in the same order as the imports.
+3. A short module docstring noting that the modules under this package are generated by this skill and pointing at it.
+
+Public symbols include: every `class` declared at module level, every type alias (e.g. `TopologyNodeItem`, `Node`, `PartialNode`), and every `<name>_from_uuid` helper.
+
+## Verification
+
+After generating, both must pass:
+
+```
+cd coffeeAGNTCY/coffee_agents/lungo
+uv run --frozen pytest tests/unit/schemas/  # schema-types parity
+uv run --frozen pytest tests/unit/          # consumer compatibility
+```
+
+If a consumer fails because of a rename you introduced (e.g. it imported the old class name), report the failure to the user and ask before touching non-generated code.
+
+## Anti-patterns
+
+- ❌ Reading an existing `schema/types/<name>.py` to decide naming.
+- ❌ Subclassing `Partial<X>` from `<X>` (or vice versa) when `allOf` only adds required fields.
+- ❌ Using `@model_validator(mode="after")` to police `__pydantic_extra__` for fields that should belong to a sibling union variant.
+- ❌ Putting field-count or per-field validity checks inside a `Discriminator` callable. The discriminator answers exactly one question: which schema `anyOf` branch.
+- ❌ Adding `@field_validator` for a constraint that fits in `Annotated[..., Field(...)]`.
+- ❌ Inventing class names (`AgentId` for `stable_agent_id`, `Node` for `regular_node`). Names come straight from `$defs` keys.
+- ❌ Hand-editing a small portion of the generated file in response to a test failure or a request for a tweak. Re-emit the whole file end-to-end via the skill instead — partial patches drift from the rules over time.
+
+## Reference
+
+- [`mapping-rules.md`](mapping-rules.md) — full worked examples for the trickier rules (A, C, D), including the schema fragment and the corresponding emitted Pydantic code.

--- a/.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md
+++ b/.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: jsonschema-to-pydantic-lungo
-description: Generates Pydantic v2 model classes from the JSON Schema documents under `coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/` into `coffeeAGNTCY/coffee_agents/lungo/schema/types/*.py`. DO NOT TRIGGER AUTOMATICALLY. ASK THE USER IF THE SKILL SHOULD BE USED. Use when a `*_v*.json` schema under that folder is added or modified, when regenerating the lungo Pydantic types after a schema change, or when the user mentions regenerating schema types, lungo types, JSON Schema → Pydantic, or fixing drift between schema and types.
+description: Generates Pydantic v2 model classes from the JSON Schema documents under `coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/` into `coffeeAGNTCY/coffee_agents/lungo/schema/types/*.py`, and a matching pytest module per types module under `coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/types/test_<module>.py`. DO NOT TRIGGER AUTOMATICALLY. ASK THE USER IF THE SKILL SHOULD BE USED. Use when a `*_v*.json` schema under that folder is added or modified, when regenerating the lungo Pydantic types or their tests after a schema change, or when the user mentions regenerating schema types, JSON Schema → Pydantic, or fixing drift between schema and types.
 ---
 
 # JSON Schema → Pydantic v2 (lungo)
 
 ## What this skill does
 
-Generates one Pydantic v2 module per JSON Schema in `coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/*.json`. Output goes to `coffeeAGNTCY/coffee_agents/lungo/schema/types/<schema_name>.py`. The package `__init__.py` is updated to re-export the public symbols.
+Generates one Pydantic v2 module per JSON Schema in `coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/*.json` and one matching pytest module per generated types module. Output:
 
-The generator is the schema. **Do not** read existing files in `schema/types/` to decide naming, layout, or behaviour — they may be missing, stale, or wrong. The only authoritative inputs are:
+- Types: `coffeeAGNTCY/coffee_agents/lungo/schema/types/<schema_name>.py` (no `_v<N>` suffix).
+- Tests: `coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/types/test_<schema_name>.py` (same stem as the types module, prefixed with `test_`, parallel to the `schema/types/` layout).
+- The package `__init__.py` under `schema/types/` is updated to re-export the public symbols.
+
+The generator is the schema. **Do not** read existing files in `schema/types/` or `tests/unit/schemas/types/test_<module>.py` to decide naming, layout, or behaviour - they may be missing, stale, or wrong. The only authoritative inputs are:
 
 1. The `.json` files under `schema/jsonschemas/` (excluding `examples/`).
-2. Cross-field validation logic that isn't expressible in JSON Schema, found in `coffeeAGNTCY/coffee_agents/lungo/schema/json_schema.py` (and any sibling modules under `schema/`).
+2. The example payloads under `schema/jsonschemas/examples/` — used as round-trip baselines and as the source data that test mutations clone before invalidating.
+3. Cross-field validation logic that isn't expressible in JSON Schema, found in `coffeeAGNTCY/coffee_agents/lungo/schema/json_schema.py` (and any sibling modules under `schema/`).
 
 ## Workflow
 
@@ -24,17 +29,20 @@ Copy this checklist and tick items as you go:
 - [ ] 3. Read schema/json_schema.py for Python-only constraints (e.g. validate_version_specific_criteria)
 - [ ] 4. Generate one schema/types/<name>.py per schema, applying the mapping rules
 - [ ] 5. Update schema/types/__init__.py: re-export every public class, type alias, and `*_from_uuid` helper
-- [ ] 6. Run: cd coffeeAGNTCY/coffee_agents/lungo && uv run --frozen pytest tests/unit/schemas/ -x
-- [ ] 7. Run: cd coffeeAGNTCY/coffee_agents/lungo && uv run --frozen pytest tests/unit/ -x
+- [ ] 6. Generate one tests/unit/schemas/types/test_<name>.py per types module, applying the test-generation rules
+- [ ] 7. Look for possibly affected non-generated consumer code and update it
+- [ ] 8. Run: cd coffeeAGNTCY/coffee_agents/lungo && uv run --frozen pytest tests/unit/schemas/ -x
+- [ ] 9. Run: cd coffeeAGNTCY/coffee_agents/lungo && uv run --frozen pytest tests/unit/ -x
 ```
 
-If step 6 or 7 fails, identify which mapping rule(s) you applied incorrectly and **re-emit** the affected file(s) end-to-end — do not patch the failing portion in isolation. Do not edit tests or non-generated consumer code unless the user explicitly asks. If a rule itself seems wrong or insufficient to make the tests pass, surface that to the user instead of working around it.
+If step 8 or 9 fails, identify which mapping rule(s) or test-generation rule(s) you applied incorrectly and **re-emit** the affected file(s) end-to-end — do not patch the failing portion in isolation.  
+If a rule itself seems wrong or insufficient to make the tests pass, surface that to the user instead of working around it.
 
 ## Naming
 
 | Source artefact | Target Python identifier |
 |---|---|
-| `event_v1.json` | `event.py` (strip the `_v<N>` version suffix) |
+| `event_v1.json` | `schema/types/event.py` and `tests/unit/schemas/types/test_event.py` (strip the `_v<N>` version suffix) |
 | `$defs.foo_bar` | `class FooBar` (snake_case → PascalCase, **no semantic renames**) |
 | Top-level object schema with `title: "Event (v1)"` | `class Event` (title without parenthesised version) |
 | Top-level schema with no root `type` (enum-only / `$defs`-only file, e.g. `event_type_v1.json`) | no root class — the module just contains the `$defs` outputs |
@@ -196,13 +204,60 @@ mirrors ``schema.json_schema._enforce_workflow_instance_map_key_id_match``
 
 Public symbols include: every `class` declared at module level, every type alias (e.g. `TopologyNodeItem`, `Node`, `PartialNode`), and every `<name>_from_uuid` helper.
 
+## Test generation
+
+For every generated `schema/types/<name>.py` emit a matching pytest module at `tests/unit/schemas/types/test_<name>.py` (the `tests/unit/schemas/types/` directory mirrors `schema/types/`). Very short and not meaningful types files don't need to have tests generated for them unless instructed by the user.  
+These test files are owned by this skill: do not read the existing ones to decide layout; re-emit. However, if a file under `schema/types/<name>.py` has not changed, then don't generate a new test file for it, unless specifically instructed by the user.  
+The goal of every test in these modules is to verify that the generated Pydantic types agree with both (a) the JSON Schema layer (`schema.validation.validate_data_against_schema`) and (b) the Python validation logic in `coffeeAGNTCY/coffee_agents/lungo/schema/json_schema.py` (and any sibling modules) that doesn't fit into JSON Schema — Pydantic `Discriminator` callables, `@model_validator` cross-field checks, and `@field_validator` whole-value checks should usually all live alongside the schema-driven cases in the same tables, if possible, not in separate "discriminator-only" or "validator-only" tables.
+
+### File header and imports
+
+Same license header and `Generated from ...` docstring shape as the types module, pointing at the source `.json`. Use `from __future__ import annotations` and group imports stdlib → third-party → first-party (`schema.*`).
+
+Don't re-explain the rules from this SKILL used to generate the file. 
+
+### Test pattern (table-driven, NamedTuple-keyed)
+
+For every test function in the file:
+
+1. Define a top-level `Case = NamedTuple` with `case_id: str` and one or two sub-NamedTuples (`Inputs`, optional `Outputs`). The top-level tuple is always the `Case` shape; only add `Outputs` when the expected result needs more than one field (e.g. distinguishing "valid" from "raises type X"). For tests where the expected result is fully derivable from the inputs (e.g. an id helper that always builds `f"{prefix}://{uuid}"`), `Outputs` may be omitted and the assertion derived from `inputs` directly.
+2. Bring all parameters for that test into one `_<UPPERCASE>_CASES: tuple[<Case>, ...] = (...)` table. Multiple tables per file is the norm — one per concern (id helpers, id pattern enforcement, top-level model agreement, enum member values, parent-schema acceptance, etc.). Do not collapse heterogeneous concerns into a single table.
+3. Parametrize with `@pytest.mark.parametrize("case", [pytest.param(c, id=c.case_id) for c in _<UPPERCASE>_CASES])` so the case id is the pytest test id.
+4. Mutations on a loaded example can be named module-level functions, but if they are short and very simple they should be inline lambdas. If they are named functions, name them `_mutate_<case_id>` and declare them in a single block right above the table that references them. The test body deepcopies the example before invoking the mutation. (For round-trip cases, `inputs.mutate is None`; assert that in the test body so a future case can't accidentally combine "valid" with a mutation.)
+
+### What to cover per artefact kind
+
+The set of tables in a generated test module is a function of what the corresponding types module emits. Use the following recipe:
+
+- **For every `class <X>Id(RootModel[str])` plus `<x>_id_from_uuid` helper**: there's no need to generate dedicated tests for these. They should be covered by cases in other types that use them.
+- **For every `class <X>(StrEnum)`**: there's no need to generated dedicated tests for these. They should be covered by cases in other types that use them.
+- **For every top-level model class** (`Event` etc.): one `_<MODEL>_CASES` table whose rows are either round-trip rows (every packaged example file under `schema/jsonschemas/examples/`, with no mutation) or invalidation rows (same example, with a mutation that violates a single named invariant). Cases must collectively cover, at minimum:
+  - one case per packaged example (round-trip, no mutation),
+  - one case per `additionalProperties: false` boundary the schema declares,
+  - one case per `pattern` constraint reachable from the root (e.g. malformed `metadata.id`, malformed `metadata.correlation.id`),
+  - one case per `enum` constraint reachable from the root (assigning an unknown member),
+  - one case per top-level `required: [...]` field (deletion of the required key — this exercises both the JSON Schema `required` clause and Pydantic's "field required" error),
+  - one case per cross-field invariant in `schema/json_schema.py` that the validator-rule rule (Rule E) implements as a Pydantic `@model_validator` (e.g. `instances` map key vs. nested `id`),
+  - one case per `Discriminator` decision in the types module (input data that should route to each branch must already be exercised by the round-trip examples; if a packaged example doesn't cover both branches of a discriminator, add a focused round-trip row that does, using a deepcopy of an existing example mutated to flip the routing).
+
+Round-trip body: validate via `validate_data_against_schema(data, "<schema_name>")`, then `<Model>.model_validate(data)`, then `dumped = model.model_dump(mode="json", exclude_none=True)`, then re-validate `dumped` through both layers. Also assert `isinstance(dumped[...], str)` for any `format: date-time` fields and that the corresponding `model.<...>.tzinfo is not None`.
+
+Invalid body: assert that **both** `validate_data_against_schema` and `<Model>.model_validate` raise — typically `SchemaValidationError` and `pydantic.ValidationError` respectively. The `Outputs` sub-NamedTuple usually pins both exception types: `EventOutputs(schema_exc, model_exc)`. An invalid case where only one layer rejects the input is a bug in either the types module (Pydantic too lax/strict) or the schema (the JSON Schema doesn't encode the constraint and there's no Python `@model_validator` for it) — surface it to the user instead of writing a one-sided test.
+
+### Anti-patterns specific to test generation
+
+- ❌ Single table mixing id-helper rows with top-level-model rows. Tables are homogeneous; one table per test function.
+- ❌ Module-level helpers with names that don't match the case id they serve (it makes case ↔ mutator mapping a manual diff).
+- ❌ Asserting only one of the two validation layers. If a payload is invalid, both layers must reject it (use `pytest.raises` against each in sequence).
+- ❌ Building round-trip payloads inline as Python literals when a packaged example exists. Load examples from `schema/jsonschemas/examples/` and mutate copies for invalidation rows.
+
 ## Verification
 
 After generating, both must pass:
 
 ```
 cd coffeeAGNTCY/coffee_agents/lungo
-uv run --frozen pytest tests/unit/schemas/  # schema-types parity
+uv run --frozen pytest tests/unit/schemas/  # schema-layer tests + generated tests/unit/schemas/types/test_<module>.py
 uv run --frozen pytest tests/unit/          # consumer compatibility
 ```
 
@@ -211,6 +266,7 @@ If a consumer fails because of a rename you introduced (e.g. it imported the old
 ## Anti-patterns
 
 - ❌ Reading an existing `schema/types/<name>.py` to decide naming.
+- ❌ Reading an existing `tests/unit/schemas/types/test_<name>.py` to decide layout — generated tests are re-emitted end-to-end from the schema and the corresponding types module.
 - ❌ Subclassing `Partial<X>` from `<X>` (or vice versa) when `allOf` only adds required fields.
 - ❌ Using `@model_validator(mode="after")` to police `__pydantic_extra__` for fields that should belong to a sibling union variant.
 - ❌ Putting field-count or per-field validity checks inside a `Discriminator` callable. The discriminator answers exactly one question: which schema `anyOf` branch.

--- a/.agents/skills/jsonschema-to-pydantic-lungo/mapping-rules.md
+++ b/.agents/skills/jsonschema-to-pydantic-lungo/mapping-rules.md
@@ -1,0 +1,245 @@
+# Mapping rules — worked examples
+
+Worked examples for the rules in [`SKILL.md`](SKILL.md) that are easy to get wrong. Each section shows a JSON Schema fragment and the Pydantic v2 emission for it.
+
+## §A — Embed in-place constraints in the type, not in a validator
+
+### Pattern on a string
+
+Schema:
+
+```json
+"event_id": {
+  "type": "string",
+  "pattern": "^event://[0-9a-fA-F]{8}-...$",
+  "description": "Unique id for an event message."
+}
+```
+
+Emit:
+
+```python
+_EVENT_ID_REGEX = r"^event://[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+
+class EventId(RootModel[str]):
+    """Generated from ``$defs.event_id``: <description>."""
+
+    root: Annotated[
+        str,
+        Field(pattern=_EVENT_ID_REGEX, description="Unique id for an event message."),
+    ]
+```
+
+### `propertyNames` on a dict-shaped property
+
+Schema:
+
+```json
+"instances": {
+  "type": "object",
+  "propertyNames": { "$ref": "#/$defs/instance_id" },
+  "additionalProperties": { "$ref": "#/$defs/workflow_instance" }
+}
+```
+
+Emit (inside the parent class):
+
+```python
+instances: dict[
+    Annotated[str, Field(pattern=_INSTANCE_ID_REGEX)], WorkflowInstance
+]
+```
+
+Do not emit a separate `@field_validator` that loops the keys checking the pattern — the dict-key annotation is enforced by Pydantic on every validation pass.
+
+## §C — `allOf [partial, {required: [...]}]` → standalone full class
+
+Schema:
+
+```json
+"partial_regular_node": {
+  "type": "object",
+  "required": ["id", "operation"],
+  "properties": {
+    "id":          { "$ref": "#/$defs/node_id" },
+    "operation":   { "$ref": "#/$defs/operation" },
+    "type":        { "type": "string", "minLength": 1 },
+    "label":       { "type": "string", "minLength": 1 },
+    "size":        { "$ref": "#/$defs/size" },
+    "layer_index": { "type": "number", "default": 0 }
+  },
+  "additionalProperties": true
+},
+"regular_node": {
+  "allOf": [
+    { "$ref": "#/$defs/partial_regular_node" },
+    {
+      "type": "object",
+      "required": ["id", "operation", "type", "label", "size", "layer_index"]
+    }
+  ]
+}
+```
+
+Emit two unrelated classes (no inheritance):
+
+```python
+class PartialRegularNode(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: NodeId
+    operation: Operation
+    type: Annotated[str, Field(min_length=1)] | None = None
+    label: Annotated[str, Field(min_length=1)] | None = None
+    size: Size | None = None
+    layer_index: float = 0
+
+
+class RegularNode(BaseModel):  # NOT (PartialRegularNode)
+    model_config = ConfigDict(extra="allow")
+
+    id: NodeId
+    operation: Operation
+    type: Annotated[str, Field(min_length=1)]
+    label: Annotated[str, Field(min_length=1)]
+    size: Size
+    layer_index: float
+```
+
+Why no subclassing: `type: ... | None = None` from `PartialRegularNode` would leak into `RegularNode` and `RegularNode(id=..., operation=...)` would silently validate.
+
+## §D — `anyOf` discriminated by sibling-key presence
+
+Schema (the canonical lungo case for `partial_node` / `node`). The agent-flavoured shapes are themselves first-class `$defs` (`partial_agent_node`, `agent_node`), so the `anyOf` branches reference them by name rather than composing them inline:
+
+```json
+"partial_node_agent_extension": {
+  "type": "object",
+  "required": ["agent_record_uri"],
+  "properties": {
+    "agent_record_uri": { "type": "string", "minLength": 1 },
+    "stable_agent_id":  { "$ref": "#/$defs/stable_agent_id" }
+  }
+},
+"node_agent_extension": {
+  "allOf": [
+    { "$ref": "#/$defs/partial_node_agent_extension" },
+    { "type": "object", "required": ["agent_record_uri", "stable_agent_id"] }
+  ]
+},
+"partial_agent_node": {
+  "allOf": [
+    { "$ref": "#/$defs/partial_regular_node" },
+    { "$ref": "#/$defs/partial_node_agent_extension" }
+  ]
+},
+"agent_node": {
+  "allOf": [
+    { "$ref": "#/$defs/regular_node" },
+    { "$ref": "#/$defs/node_agent_extension" }
+  ]
+},
+"partial_node": {
+  "anyOf": [
+    {
+      "allOf": [
+        { "$ref": "#/$defs/partial_regular_node" },
+        { "not": { "anyOf": [
+          { "required": ["agent_record_uri"] },
+          { "required": ["stable_agent_id"] }
+        ]}}
+      ]
+    },
+    { "$ref": "#/$defs/partial_agent_node" }
+  ]
+},
+"node": { /* same shape: regular branch + $ref agent_node */ },
+"topology_node_item": {
+  "anyOf": [{ "$ref": "#/$defs/partial_node" }, { "$ref": "#/$defs/node" }]
+}
+```
+
+Step 1 — emit the four leaf classes. Names come straight from the `$defs` keys (no merged-class invention — see [`SKILL.md`](SKILL.md)). The agent variants subclass their regular counterparts because the extension is purely *additive* fields (no required-vs-optional drift, unlike §C):
+
+```python
+class PartialAgentNode(PartialRegularNode):
+    agent_record_uri: Annotated[str, Field(min_length=1)]
+    stable_agent_id: StableAgentId | None = None
+
+
+class AgentNode(RegularNode):
+    agent_record_uri: Annotated[str, Field(min_length=1)]
+    stable_agent_id: StableAgentId
+```
+
+`partial_node_agent_extension` and `node_agent_extension` are **not** emitted as standalone classes: they are only ever referenced inside the `allOf`s that build `partial_agent_node` / `agent_node`, so their fields appear directly on the agent classes.
+
+Step 2 — discriminator that mirrors **only** the sibling-key presence test that the regular branch's `not { anyOf: [...required...] }` clause is making:
+
+```python
+_REGULAR_TAG = "regular"
+_AGENT_TAG = "agent"
+
+
+def _node_kind_discriminator(value: Any) -> str | None:
+    if isinstance(value, (AgentNode, PartialAgentNode)):
+        return _AGENT_TAG
+    if isinstance(value, (RegularNode, PartialRegularNode)):
+        return _REGULAR_TAG
+    if not isinstance(value, dict):
+        return None
+    if "agent_record_uri" in value or "stable_agent_id" in value:
+        return _AGENT_TAG
+    return _REGULAR_TAG
+```
+
+Step 3 — emit each `anyOf`-shaped `$def` as an `Annotated[Union[...], Discriminator(...)]`. Inside each tagged branch use a plain `Union[Full, Partial]` and let smart-union pick the right one based on field population:
+
+```python
+TopologyNodeItem = Annotated[
+    Union[
+        Annotated[Union[RegularNode, PartialRegularNode], Tag(_REGULAR_TAG)],
+        Annotated[Union[AgentNode, PartialAgentNode], Tag(_AGENT_TAG)],
+    ],
+    Discriminator(_node_kind_discriminator),
+]
+
+PartialNode = Annotated[
+    Union[
+        Annotated[PartialRegularNode, Tag(_REGULAR_TAG)],
+        Annotated[PartialAgentNode, Tag(_AGENT_TAG)],
+    ],
+    Discriminator(_node_kind_discriminator),
+]
+
+Node = Annotated[
+    Union[
+        Annotated[RegularNode, Tag(_REGULAR_TAG)],
+        Annotated[AgentNode, Tag(_AGENT_TAG)],
+    ],
+    Discriminator(_node_kind_discriminator),
+]
+```
+
+### Validation outcomes this produces
+
+| Input | Routes to | Outcome |
+|---|---|---|
+| All regular fields, no extension keys | `RegularNode` | OK |
+| Only `id`+`operation` | `PartialRegularNode` | OK |
+| All fields + `agent_record_uri` + valid `stable_agent_id` | `AgentNode` | OK |
+| `agent_record_uri` only (partial) | `PartialAgentNode` | OK |
+| `stable_agent_id` only, no `agent_record_uri` | agent branch → `PartialAgentNode` | rejected: `agent_record_uri` is required |
+| Bogus `stable_agent_id` prefix (e.g. `"blabla://..."`) with `agent_record_uri` | `AgentNode` | rejected: `String should match pattern '^agent://...'` |
+
+The error messages come straight from each branch's own `Field` constraints — no custom "agent fields not allowed" message anywhere.
+
+### Anti-pattern this replaces
+
+The earlier (incorrect) approach was an `@model_validator(mode="after")` on `PartialRegularNode` / `RegularNode` that walked `__pydantic_extra__` and raised if `agent_record_uri` or `stable_agent_id` had leaked through `extra="allow"`. That approach:
+
+- Required a parallel `_AGENT_EXTENSION_FIELDS` allow-list.
+- Hid the schema's `pattern` / `min_length` errors behind a generic message.
+- Coupled `RegularNode` to knowledge of its sibling extension class.
+
+The discriminator solves all three problems at once: routing alone is sufficient because each variant's own field constraints handle the rest.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflows.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflows.py
@@ -19,13 +19,13 @@ import httpx
 from pydantic import ValidationError
 
 from schema.types import (
-    AgentId,
     AgentNode,
-    AgentPartialNode,
-    EdgeId,
-    NodeId,
+    PartialAgentNode,
     TopologyNodeItem,
     Workflow,
+    edge_id_from_uuid,
+    node_id_from_uuid,
+    stable_agent_id_from_uuid,
 )
 
 
@@ -102,13 +102,13 @@ def _load_and_validate_starting_workflows_from_file(target: Path) -> dict[str, W
             # Only agent nodes carry an agent_record_uri; attempt to load and validate the record,
             # and derive a stable agent id (uuid5) from the record's ``name`` field.
             for idx_nd, node in enumerate[TopologyNodeItem](validated_entry_initial.starting_topology.nodes):
-                if isinstance(node, (AgentNode, AgentPartialNode)):
+                if isinstance(node, (AgentNode, PartialAgentNode)):
                     # If the agent record cannot be loaded or is invalid we keep the workflow but leave stable_agent_id unset;
                     # in the future these should become grounds for invalidating the workflow entirely.
                     try:
                         record = _load_agent_record_from_uri(node.agent_record_uri, base_path=target.parent)
                         stable_agent_uuid = uuid5(_STABLE_AGENT_ID_NAMESPACE, record["name"])
-                        node.stable_agent_id = AgentId(f"agent://{stable_agent_uuid}")
+                        node.stable_agent_id = stable_agent_id_from_uuid(stable_agent_uuid)
                     # FileNotFoundError is a subclass of OSError.
                     except (FileNotFoundError, httpx.HTTPStatusError) as exc:
                         logger.warning("Failed to load agent record for node at index %d (id %s) in workflow at index %d (name %s) but will use the workflow anyhow: %s",
@@ -118,10 +118,10 @@ def _load_and_validate_starting_workflows_from_file(target: Path) -> dict[str, W
                                        idx_nd, node.id, idx_wf, validated_entry_initial.name, exc)
 
                 # Set the runtime/instance node id. This is not the same as the stable agent id.
-                node.id = NodeId(f"node://{uuid4()}")
+                node.id = node_id_from_uuid(uuid4())
             
             for edge in validated_entry_initial.starting_topology.edges:
-                edge.id = EdgeId(f"edge://{uuid4()}")
+                edge.id = edge_id_from_uuid(uuid4())
             
             # Validate the workflow again to ensure that modifications made are valid.
             # Note that model_validate() returns a new instance of the model.

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/store.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/store.py
@@ -31,6 +31,7 @@ import asyncio
 import copy
 import logging
 import queue
+from schema.types.event import Workflow
 import threading
 import time
 from collections import defaultdict
@@ -286,7 +287,7 @@ class WorkflowInstanceStateStore:
         self._dispatch = _DispatchHub(self._state_lock, n)
         self._merge = _MergeCoordinator(
             self._state_lock,
-            Data(),
+            Data(workflows=dict[str, Workflow]()),
             self._after_merge_enqueue_dispatch,
         )
 

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/store.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/store.py
@@ -31,13 +31,13 @@ import asyncio
 import copy
 import logging
 import queue
-from schema.types.event import Workflow
 import threading
 import time
 from collections import defaultdict
 from typing import Callable, Final
 
 from schema.types import Data, Event
+from schema.types.event import Workflow
 from schema.validation import validate_data_against_schema
 
 from common.workflow_instance_store.errors import WorkflowInstanceStoreClosedError

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/event_v1.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/event_v1.json
@@ -36,6 +36,11 @@
       "pattern": "^node://[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
       "description": "Graph node id. Used in topology definitions."
     },
+    "stable_agent_id": {
+      "type": "string",
+      "pattern": "^agent://[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "description": "Stable, agent-scoped identifier for a node, independent of its graph node id."
+    },
     "edge_id": {
       "type": "string",
       "pattern": "^edge://[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
@@ -50,9 +55,9 @@
       },
       "additionalProperties": false
     },
-    "partial_node": {
+    "partial_regular_node": {
       "type": "object",
-      "description": "Sparse node data (mainly for updates). Used in topology definitions.",
+      "description": "Sparse regular node data (mainly for updates). Used in topology definitions.",
       "required": ["id", "operation"],
       "properties": {
         "id": { "$ref": "#/$defs/node_id" },
@@ -64,14 +69,85 @@
       },
       "additionalProperties": true
     },
-    "node": {
+    "regular_node": {
       "allOf": [
-        { "$ref": "#/$defs/partial_node" },
+        { "$ref": "#/$defs/partial_regular_node" },
         {
           "type": "object",
-          "description": "Full node data (mainly for init/reset). Used in topology definitions.",
+          "description": "Full regular node data (mainly for init/reset). Used in topology definitions.",
           "required": ["id", "operation", "type", "label", "size", "layer_index"]
         }
+      ]
+    },
+    "partial_node_agent_extension": {
+      "type": "object",
+      "description": "Sparse agent extension fields for a node. agent_record_uri is required; stable_agent_id is optional.",
+      "required": ["agent_record_uri"],
+      "properties": {
+        "agent_record_uri": { "type": "string", "minLength": 1 },
+        "stable_agent_id": { "$ref": "#/$defs/stable_agent_id" }
+      }
+    },
+    "node_agent_extension": {
+      "allOf": [
+        { "$ref": "#/$defs/partial_node_agent_extension" },
+        {
+          "type": "object",
+          "description": "Full agent extension fields for a node. Both agent_record_uri and stable_agent_id are required.",
+          "required": ["agent_record_uri", "stable_agent_id"]
+        }
+      ]
+    },
+    "partial_agent_node": {
+      "description": "Sparse agent node data (mainly for updates): a partial_regular_node combined with a partial_node_agent_extension.",
+      "allOf": [
+        { "$ref": "#/$defs/partial_regular_node" },
+        { "$ref": "#/$defs/partial_node_agent_extension" }
+      ]
+    },
+    "agent_node": {
+      "description": "Full agent node data (mainly for init/reset): a regular_node combined with a node_agent_extension.",
+      "allOf": [
+        { "$ref": "#/$defs/regular_node" },
+        { "$ref": "#/$defs/node_agent_extension" }
+      ]
+    },
+    "partial_node": {
+      "description": "Sparse node data: either a partial_regular_node alone (without any agent extension fields), or a partial_agent_node.",
+      "anyOf": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/partial_regular_node" },
+            {
+              "not": {
+                "anyOf": [
+                  { "required": ["agent_record_uri"] },
+                  { "required": ["stable_agent_id"] }
+                ]
+              }
+            }
+          ]
+        },
+        { "$ref": "#/$defs/partial_agent_node" }
+      ]
+    },
+    "node": {
+      "description": "Full node data: either a regular_node alone (without any agent extension fields), or an agent_node.",
+      "anyOf": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/regular_node" },
+            {
+              "not": {
+                "anyOf": [
+                  { "required": ["agent_record_uri"] },
+                  { "required": ["stable_agent_id"] }
+                ]
+              }
+            }
+          ]
+        },
+        { "$ref": "#/$defs/agent_node" }
       ]
     },
     "topology_node_item": {

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_full.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_full.json
@@ -24,7 +24,9 @@
               "type": "customNode",
               "label": "Auction Agent",
               "size": { "width": 1.0, "height": 1.0 },
-              "layer_index": 0
+              "layer_index": 0,
+              "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json",
+              "stable_agent_id": "agent://470de4a0-a6bc-5e1b-82dd-e41de2af3f85"
             },
             {
               "id": "node://6ba7b813-9dad-11d1-80b4-00c04fd430c8",
@@ -40,7 +42,9 @@
               "type": "customNode",
               "label": "Brazil Farm",
               "size": { "width": 1.0, "height": 1.0 },
-              "layer_index": 2
+              "layer_index": 2,
+              "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json",
+              "stable_agent_id": "agent://aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
             }
           ],
           "edges": [
@@ -75,7 +79,9 @@
                   "type": "customNode",
                   "label": "Auction Agent",
                   "size": { "width": 1.0, "height": 1.0 },
-                  "layer_index": 0
+                  "layer_index": 0,
+                  "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json",
+                  "stable_agent_id": "agent://470de4a0-a6bc-5e1b-82dd-e41de2af3f85"
                 },
                 {
                   "id": "node://6ba7b813-9dad-11d1-80b4-00c04fd430c8",
@@ -91,7 +97,9 @@
                   "type": "customNode",
                   "label": "Brazil Farm",
                   "size": { "width": 1.0, "height": 1.0 },
-                  "layer_index": 2
+                  "layer_index": 2,
+                  "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json",
+                  "stable_agent_id": "agent://aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
                 }
               ],
               "edges": [

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_partial.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_partial.json
@@ -23,7 +23,9 @@
               "type": "customNode",
               "label": "Auction Agent",
               "size": { "width": 1.0, "height": 1.0 },
-              "layer_index": 0
+              "layer_index": 0,
+              "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json",
+              "stable_agent_id": "agent://470de4a0-a6bc-5e1b-82dd-e41de2af3f85"
             },
             {
               "id": "node://550e8400-e29b-41d4-a716-446655440011",
@@ -39,7 +41,9 @@
               "type": "customNode",
               "label": "Brazil Farm",
               "size": { "width": 1.0, "height": 1.0 },
-              "layer_index": 2
+              "layer_index": 2,
+              "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json",
+              "stable_agent_id": "agent://aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
             }
           ],
           "edges": [
@@ -72,7 +76,8 @@
                   "id": "node://550e8400-e29b-41d4-a716-446655440010",
                   "operation": "update",
                   "type": "customNode",
-                  "label": "Auction Agent (search)"
+                  "label": "Auction Agent (search)",
+                  "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json"
                 }
               ],
               "edges": []

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/types/__init__.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/types/__init__.py
@@ -1,9 +1,12 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hand-maintained Pydantic v2 types mirroring ``schema/jsonschemas`` (no version suffix on class names).
+"""Pydantic v2 types mirroring ``schema/jsonschemas`` (no version suffix on class
+names).
 
-Update these modules when ``event_v1.json`` or ``event_type_v1.json`` changes; they are not generated.
+The modules under this package are generated from the JSON schemas with the
+``jsonschema-to-pydantic-lungo`` skill. Regenerate them after every change to
+``event_v1.json`` or ``event_type_v1.json``.
 
 When re-validating dumped JSON against the JSON Schema, use ``model_dump(mode="json", exclude_none=True)``
 so optional object fields are omitted instead of serialized as JSON ``null`` (the schema uses ``type: string``,
@@ -11,9 +14,7 @@ not ``null``).
 """
 
 from schema.types.event import (
-    AgentId,
     AgentNode,
-    AgentPartialNode,
     Correlation,
     CorrelationId,
     Data,
@@ -23,26 +24,33 @@ from schema.types.event import (
     EventId,
     InstanceId,
     Metadata,
-    instance_id_from_uuid,
     Node,
     NodeId,
     Operation,
+    PartialAgentNode,
     PartialEdge,
     PartialNode,
+    PartialRegularNode,
     PartialTopology,
+    RegularNode,
     Size,
+    StableAgentId,
     Topology,
     TopologyEdgeItem,
     TopologyNodeItem,
     Workflow,
     WorkflowInstance,
+    correlation_id_from_uuid,
+    edge_id_from_uuid,
+    event_id_from_uuid,
+    instance_id_from_uuid,
+    node_id_from_uuid,
+    stable_agent_id_from_uuid,
 )
 from schema.types.event_type import EventType
 
 __all__ = [
-    "AgentId",
     "AgentNode",
-    "AgentPartialNode",
     "Correlation",
     "CorrelationId",
     "Data",
@@ -53,17 +61,26 @@ __all__ = [
     "EventType",
     "InstanceId",
     "Metadata",
-    "instance_id_from_uuid",
     "Node",
     "NodeId",
     "Operation",
+    "PartialAgentNode",
     "PartialEdge",
     "PartialNode",
+    "PartialRegularNode",
     "PartialTopology",
+    "RegularNode",
     "Size",
+    "StableAgentId",
     "Topology",
     "TopologyEdgeItem",
     "TopologyNodeItem",
     "Workflow",
     "WorkflowInstance",
+    "correlation_id_from_uuid",
+    "edge_id_from_uuid",
+    "event_id_from_uuid",
+    "instance_id_from_uuid",
+    "node_id_from_uuid",
+    "stable_agent_id_from_uuid",
 ]

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/types/event.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/types/event.py
@@ -1,34 +1,58 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pydantic v2 models for the event message contract (from ``event_v1.json``).
+"""Generated from ``schema/jsonschemas/event_v1.json``.
 
-``Node``, ``Edge``, and ``Topology`` are **not** subclasses of their partial counterparts:
-field declarations are repeated with required types so validation matches JSON Schema
-``allOf`` + ``required`` without inheriting optional ``| None`` fields.
+Do not edit by hand: regenerate with the ``jsonschema-to-pydantic-lungo`` skill.
 
-``AgentNode`` and ``AgentPartialNode`` *are* subclasses of ``Node`` and ``PartialNode``
-respectively, extending them with agent-specific fields. Only nodes representing agents carry
-these fields; other topology nodes (e.g. transport) do not.
+Source title and description:
+    Event (v1) - Message contract for workflow state progress used as an init
+    or reset when fully filled. Used by components capable of emitting any
+    kind of change event that needs to be communicated.
+
+The class hierarchy mirrors the ``$defs`` of the source schema:
+
+* ``RegularNode`` / ``Edge`` / ``Topology`` are **not** subclasses of their
+  partial counterparts: their fields are repeated as required so JSON Schema
+  ``allOf`` + ``required`` semantics are preserved without inheriting optional
+  ``| None`` fields (Rule C).
+* ``PartialAgentNode`` / ``AgentNode`` correspond to ``$defs.partial_agent_node``
+  / ``$defs.agent_node``. They subclass the regular node classes because the
+  ``partial_node_agent_extension`` / ``node_agent_extension`` composition only
+  *adds* fields (Rule D step 1).
+* ``$defs.partial_node`` / ``$defs.node`` are sibling-key-discriminated
+  ``anyOf`` unions (Rule D): a callable Pydantic ``Discriminator`` mirrors the
+  schema's ``not { required: [...] }`` test and routes inputs to the
+  ``regular`` or ``agent`` branch; smart-union picks ``Full`` over ``Partial``
+  inside each branch.
+* Cross-field constraints not expressible in JSON Schema (e.g.
+  ``workflow.instances`` map keys must equal the nested ``id``) are encoded as
+  Pydantic validators below.
 """
 
 from __future__ import annotations
 
-import re
 from enum import StrEnum
+from typing import Annotated, Any, Self, Union
 from uuid import UUID
-from typing import Annotated, Self, Union
 
 from pydantic import (
     AwareDatetime,
     BaseModel,
     ConfigDict,
+    Discriminator,
     Field,
     RootModel,
-    field_validator,
+    Tag,
     model_validator,
 )
+
 from schema.types.event_type import EventType
+
+
+# ---------------------------------------------------------------------------
+# ``<prefix>://<UUID>`` id types (one per ``$defs.*_id``)
+# ---------------------------------------------------------------------------
 
 _UUID_REGEX = (
     r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
@@ -37,18 +61,31 @@ _EVENT_ID_REGEX = rf"^event://{_UUID_REGEX}$"
 _CORRELATION_ID_REGEX = rf"^correlation://{_UUID_REGEX}$"
 _INSTANCE_ID_REGEX = rf"^instance://{_UUID_REGEX}$"
 _NODE_ID_REGEX = rf"^node://{_UUID_REGEX}$"
+_STABLE_AGENT_ID_REGEX = rf"^agent://{_UUID_REGEX}$"
 _EDGE_ID_REGEX = rf"^edge://{_UUID_REGEX}$"
-_AGENT_ID_REGEX = rf"^agent://{_UUID_REGEX}$"
 
 
 class EventId(RootModel[str]):
+    """Generated from ``$defs.event_id``: unique id for an event message."""
+
     root: Annotated[
         str,
-        Field(pattern=_EVENT_ID_REGEX, description="Unique id for an event message."),
+        Field(
+            pattern=_EVENT_ID_REGEX,
+            description="Unique id for an event message.",
+        ),
     ]
 
 
+def event_id_from_uuid(event_uuid: UUID) -> EventId:
+    """Build a canonical ``event://<uuid>`` id from a ``UUID`` value."""
+    return EventId(root=f"event://{event_uuid!s}")
+
+
 class CorrelationId(RootModel[str]):
+    """Generated from ``$defs.correlation_id``: correlation id for one user
+    action or API request."""
+
     root: Annotated[
         str,
         Field(
@@ -58,81 +95,136 @@ class CorrelationId(RootModel[str]):
     ]
 
 
+def correlation_id_from_uuid(correlation_uuid: UUID) -> CorrelationId:
+    """Build a canonical ``correlation://<uuid>`` id from a ``UUID`` value."""
+    return CorrelationId(root=f"correlation://{correlation_uuid!s}")
+
+
 class InstanceId(RootModel[str]):
+    """Generated from ``$defs.instance_id``: workflow instance id. Each key in
+    ``workflow.instances`` must use this same ``instance://...`` value as the
+    nested object ``id`` field."""
+
     root: Annotated[
         str,
         Field(
             pattern=_INSTANCE_ID_REGEX,
-            description="Workflow instance id; map keys under workflow.instances must match nested id.",
+            description=(
+                "Workflow instance id. Each key in workflow.instances must use this "
+                "same instance://... value as the nested object id field."
+            ),
         ),
     ]
 
 
 def instance_id_from_uuid(workflow_instance_uuid: UUID) -> InstanceId:
-    """Build canonical ``instance://`` id from a path-segment UUID (see agentic-workflows HTTP routes)."""
+    """Build a canonical ``instance://<uuid>`` id from a ``UUID`` value."""
     return InstanceId(root=f"instance://{workflow_instance_uuid!s}")
 
 
 class NodeId(RootModel[str]):
-    root: Annotated[str, Field(pattern=_NODE_ID_REGEX, description="Graph node id.")]
+    """Generated from ``$defs.node_id``: graph node id used in topology
+    definitions."""
+
+    root: Annotated[
+        str,
+        Field(
+            pattern=_NODE_ID_REGEX,
+            description="Graph node id. Used in topology definitions.",
+        ),
+    ]
+
+
+def node_id_from_uuid(node_uuid: UUID) -> NodeId:
+    """Build a canonical ``node://<uuid>`` id from a ``UUID`` value."""
+    return NodeId(root=f"node://{node_uuid!s}")
+
+
+class StableAgentId(RootModel[str]):
+    """Generated from ``$defs.stable_agent_id``: stable, agent-scoped
+    identifier for a node, independent of its graph node id."""
+
+    root: Annotated[
+        str,
+        Field(
+            pattern=_STABLE_AGENT_ID_REGEX,
+            description=(
+                "Stable, agent-scoped identifier for a node, independent of its "
+                "graph node id."
+            ),
+        ),
+    ]
+
+
+def stable_agent_id_from_uuid(stable_agent_uuid: UUID) -> StableAgentId:
+    """Build a canonical ``agent://<uuid>`` id from a ``UUID`` value."""
+    return StableAgentId(root=f"agent://{stable_agent_uuid!s}")
 
 
 class EdgeId(RootModel[str]):
-    root: Annotated[str, Field(pattern=_EDGE_ID_REGEX, description="Graph edge id.")]
+    """Generated from ``$defs.edge_id``: graph edge id used in topology
+    definitions."""
+
+    root: Annotated[
+        str,
+        Field(
+            pattern=_EDGE_ID_REGEX,
+            description="Graph edge id. Used in topology definitions.",
+        ),
+    ]
 
 
-class AgentId(RootModel[str]):
-    root: Annotated[str, Field(pattern=_AGENT_ID_REGEX, description="Stable agent id, invariant across runtime instances of the same agent.")]
+def edge_id_from_uuid(edge_uuid: UUID) -> EdgeId:
+    """Build a canonical ``edge://<uuid>`` id from a ``UUID`` value."""
+    return EdgeId(root=f"edge://{edge_uuid!s}")
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
 
 
 class Operation(StrEnum):
+    """Generated from ``$defs.operation``: entity operation kind."""
+
     CREATE = "create"
     READ = "read"
     UPDATE = "update"
     DELETE = "delete"
 
 
+# ---------------------------------------------------------------------------
+# ``$defs.size`` (object with ``additionalProperties: false``)
+# ---------------------------------------------------------------------------
+
+
 class Size(BaseModel):
+    """Generated from ``$defs.size``: relative layout size vs other nodes.
+    Used in topology drawing and layout algorithms."""
+
     model_config = ConfigDict(extra="forbid")
 
-    width: float = Field(
-        default=1.0, description="Relative layout width vs other nodes."
-    )
-    height: float = Field(
-        default=1.0, description="Relative layout height vs other nodes."
-    )
+    width: float = Field(default=1.0)
+    height: float = Field(default=1.0)
 
 
-_AGENT_SPECIFIC_FIELDS: tuple[str, ...] = ("agent_record_uri", "stable_agent_id")
+# ---------------------------------------------------------------------------
+# Node hierarchy (``$defs.partial_regular_node`` / ``regular_node`` /
+# ``partial_agent_node`` / ``agent_node`` / ``partial_node`` / ``node``).
+#
+# ``$defs.partial_node_agent_extension`` and ``$defs.node_agent_extension``
+# are not emitted as standalone classes: they are only ever referenced by the
+# agent-node compositions, so their fields appear directly on
+# ``PartialAgentNode`` / ``AgentNode`` (Rule D step 1 + standalone-emission
+# rule).
+# ---------------------------------------------------------------------------
 
 
-def _reject_agent_specific_extra_fields(instance: BaseModel) -> None:
-    """Reject agent-specific keys if they sneak in via ``extra="allow"``.
-
-    ``Node`` and ``PartialNode`` deliberately do not declare ``agent_record_uri`` or
-    ``stable_agent_id``; those belong to the ``AgentNode`` / ``AgentPartialNode``
-    subclasses. Because ``extra="allow"`` accepts any extra key with any value,
-    without this check an invalid input (e.g. ``agent_record_uri=""`` or
-    ``stable_agent_id="not-a-uri"``) would quietly validate as a non-agent node with
-    the bogus value in ``__pydantic_extra__``. Rejecting them here forces the
-    ``TopologyNodeItem`` union to validate such inputs against the agent subclasses,
-    which enforce the format constraints and raise if they are not met.
-
-    Because Agent subclasses declare these as real fields (not extras), this
-    validator is a no-op for them.
-    """
-    extras = instance.__pydantic_extra__
-    if extras is None:
-        return
-    for name in _AGENT_SPECIFIC_FIELDS:
-        if name in extras:
-            raise ValueError(
-                f"{name} is only valid in AgentNode / AgentPartialNode"
-            )
-
-
-class PartialNode(BaseModel):
-    """Sparse node (updates); only ``id`` and ``operation`` are required."""
+class PartialRegularNode(BaseModel):
+    """Generated from ``$defs.partial_regular_node``: sparse regular node data
+    (mainly for updates). ``additionalProperties: true``; agent-extension keys
+    live on the ``PartialAgentNode`` subclass and are routed there by the
+    ``$defs.partial_node`` / ``$defs.node`` discriminator."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -143,14 +235,12 @@ class PartialNode(BaseModel):
     size: Size | None = None
     layer_index: float = 0
 
-    @model_validator(mode="after")
-    def _no_agent_specific_fields(self) -> Self:
-        _reject_agent_specific_extra_fields(self)
-        return self
 
-
-class Node(BaseModel):
-    """Full node (init/reset); all listed fields are required (not a subclass of ``PartialNode``)."""
+class RegularNode(BaseModel):
+    """Generated from ``$defs.regular_node``: full regular node data (mainly
+    for init/reset). All listed fields are required. Standalone class (not a
+    subclass of ``PartialRegularNode``) so optional ``| None`` field types do
+    not leak into the required form."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -161,36 +251,92 @@ class Node(BaseModel):
     size: Size
     layer_index: float
 
-    @model_validator(mode="after")
-    def _no_agent_specific_fields(self) -> Self:
-        _reject_agent_specific_extra_fields(self)
-        return self
 
-
-class AgentPartialNode(PartialNode):
-    """Sparse node representing an agent; extends ``PartialNode``.
-    
-    At least some fields in this model class need to be required because otherwise
-    the validation would fall through to the PartialNode model class and possibly validate as a non-agent node.
-    """
+class PartialAgentNode(PartialRegularNode):
+    """Generated from ``$defs.partial_agent_node``: ``partial_regular_node``
+    combined with ``partial_node_agent_extension``. ``agent_record_uri`` is
+    required by the extension; ``stable_agent_id`` remains optional."""
 
     agent_record_uri: Annotated[str, Field(min_length=1)]
-    stable_agent_id: AgentId | None = None
+    stable_agent_id: StableAgentId | None = None
 
 
-class AgentNode(Node):
-    """Full node representing an agent; extends ``Node``.
-    
-    At least some fields in this model class need to be required because otherwise
-    the validation would fall through to the Node model class and possibly validate as a non-agent node.
-    """
+class AgentNode(RegularNode):
+    """Generated from ``$defs.agent_node``: ``regular_node`` combined with
+    ``node_agent_extension``. Both ``agent_record_uri`` and ``stable_agent_id``
+    are required."""
 
     agent_record_uri: Annotated[str, Field(min_length=1)]
-    stable_agent_id: AgentId
+    stable_agent_id: StableAgentId
+
+
+# ``$defs.partial_node`` and ``$defs.node`` are ``anyOf`` choices between a
+# *regular* shape and an *agent_node* shape, distinguished by the presence of
+# ``agent_record_uri`` / ``stable_agent_id``. We mirror exactly that single
+# decision with a callable Pydantic discriminator and let smart union handle
+# the *full vs. partial* sub-choice (which is a pure more-required-fields
+# question) inside each branch.
+
+_REGULAR_TAG = "regular"
+_AGENT_TAG = "agent"
+
+
+def _node_kind_discriminator(value: Any) -> str | None:
+    """Route to the *regular* or *agent* node branch.
+
+    Returns ``"agent"`` when the input carries any
+    ``$defs.partial_node_agent_extension`` key (``agent_record_uri`` or
+    ``stable_agent_id``); otherwise ``"regular"``.
+    """
+    if isinstance(value, (AgentNode, PartialAgentNode)):
+        return _AGENT_TAG
+    if isinstance(value, (RegularNode, PartialRegularNode)):
+        return _REGULAR_TAG
+    if not isinstance(value, dict):
+        return None
+    if "agent_record_uri" in value or "stable_agent_id" in value:
+        return _AGENT_TAG
+    return _REGULAR_TAG
+
+
+# Generated from ``$defs.topology_node_item`` (anyOf of partial_node and node).
+# Within each tagged branch, smart-union picks the full variant when its extra
+# required fields are populated and falls back to the partial variant otherwise.
+TopologyNodeItem = Annotated[
+    Union[
+        Annotated[Union[RegularNode, PartialRegularNode], Tag(_REGULAR_TAG)],
+        Annotated[Union[AgentNode, PartialAgentNode], Tag(_AGENT_TAG)],
+    ],
+    Discriminator(_node_kind_discriminator),
+]
+
+# Generated from ``$defs.partial_node`` (anyOf).
+PartialNode = Annotated[
+    Union[
+        Annotated[PartialRegularNode, Tag(_REGULAR_TAG)],
+        Annotated[PartialAgentNode, Tag(_AGENT_TAG)],
+    ],
+    Discriminator(_node_kind_discriminator),
+]
+
+# Generated from ``$defs.node`` (anyOf).
+Node = Annotated[
+    Union[
+        Annotated[RegularNode, Tag(_REGULAR_TAG)],
+        Annotated[AgentNode, Tag(_AGENT_TAG)],
+    ],
+    Discriminator(_node_kind_discriminator),
+]
+
+
+# ---------------------------------------------------------------------------
+# Edge hierarchy (``$defs.partial_edge`` / ``edge`` / ``topology_edge_item``)
+# ---------------------------------------------------------------------------
 
 
 class PartialEdge(BaseModel):
-    """Sparse edge (updates)."""
+    """Generated from ``$defs.partial_edge``: sparse edge data (mainly for
+    updates). ``additionalProperties: true``."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -204,7 +350,9 @@ class PartialEdge(BaseModel):
 
 
 class Edge(BaseModel):
-    """Full edge (init/reset); all fields required."""
+    """Generated from ``$defs.edge``: full edge data (mainly for init/reset);
+    all fields required. Standalone class (not a subclass of
+    ``PartialEdge``)."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -217,11 +365,20 @@ class Edge(BaseModel):
     weight: float
 
 
-TopologyNodeItem = Union[AgentNode, Node, AgentPartialNode, PartialNode]
+# Generated from ``$defs.topology_edge_item`` (anyOf).
 TopologyEdgeItem = Union[Edge, PartialEdge]
 
 
+# ---------------------------------------------------------------------------
+# Topology (``$defs.partial_topology`` / ``$defs.topology``)
+# ---------------------------------------------------------------------------
+
+
 class PartialTopology(BaseModel):
+    """Generated from ``$defs.partial_topology``: sparse topology under a
+    workflow instance, describing changes compared to starting or previous
+    state."""
+
     model_config = ConfigDict(extra="allow")
 
     nodes: list[TopologyNodeItem] | None = None
@@ -229,7 +386,10 @@ class PartialTopology(BaseModel):
 
 
 class Topology(BaseModel):
-    """Full topology; ``nodes`` and ``edges`` required (standalone, not a subclass of ``PartialTopology``)."""
+    """Generated from ``$defs.topology``: full topology data describing an
+    initial state. ``nodes`` and ``edges`` are required. Standalone class (not
+    a subclass of ``PartialTopology``) so the optional list types do not leak
+    into the required form."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -237,7 +397,15 @@ class Topology(BaseModel):
     edges: list[TopologyEdgeItem]
 
 
+# ---------------------------------------------------------------------------
+# Correlation, Metadata
+# ---------------------------------------------------------------------------
+
+
 class Correlation(BaseModel):
+    """Generated from ``$defs.correlation``: correlation data for an event
+    message, referencing another event that closely connects to this one."""
+
     model_config = ConfigDict(extra="allow")
 
     id: CorrelationId
@@ -245,6 +413,9 @@ class Correlation(BaseModel):
 
 
 class Metadata(BaseModel):
+    """Generated from ``$defs.metadata``: general metadata for an event
+    message, including fields for proper identification."""
+
     model_config = ConfigDict(extra="allow")
 
     timestamp: Annotated[
@@ -254,7 +425,8 @@ class Metadata(BaseModel):
     schema_version: Annotated[
         str,
         Field(
-            min_length=1, description="Semantic version of this contract (e.g. 1.0.0)."
+            min_length=1,
+            description="Semantic version of this contract (e.g. 1.0.0).",
         ),
     ]
     correlation: Correlation
@@ -269,7 +441,16 @@ class Metadata(BaseModel):
     ]
 
 
+# ---------------------------------------------------------------------------
+# Workflow tree (``workflow_instance`` / ``workflow`` / ``data`` / root event)
+# ---------------------------------------------------------------------------
+
+
 class WorkflowInstance(BaseModel):
+    """Generated from ``$defs.workflow_instance``: workflow instance data. The
+    parent object key under ``workflow.instances`` must be identical to ``id``
+    (same ``instance://...`` string)."""
+
     model_config = ConfigDict(extra="allow")
 
     id: InstanceId
@@ -277,40 +458,44 @@ class WorkflowInstance(BaseModel):
 
 
 class Workflow(BaseModel):
+    """Generated from ``$defs.workflow``: workflow data, describing common
+    configuration for a specific workflow, and tracking instances of that
+    workflow.
+
+    The ``propertyNames`` constraint on ``instances`` (each key must match
+    ``$defs.instance_id``) is encoded directly in the dict key annotation.
+
+    The cross-field constraint that each ``instances`` key must equal the
+    nested ``workflow_instance.id`` cannot be expressed in JSON Schema, so it
+    is enforced by a ``model_validator`` (mirrors
+    ``schema.json_schema._enforce_workflow_instance_map_key_id_match``).
+    """
+
     model_config = ConfigDict(extra="allow")
 
     pattern: Annotated[str, Field(min_length=1)]
     use_case: Annotated[str, Field(min_length=1)]
     name: Annotated[str, Field(min_length=1)]
     starting_topology: Topology
-    instances: dict[str, WorkflowInstance]
-
-    @field_validator("instances")
-    @classmethod
-    def _instance_keys_are_instance_ids(
-        cls, v: dict[str, WorkflowInstance]
-    ) -> dict[str, WorkflowInstance]:
-        key_re = re.compile(_INSTANCE_ID_REGEX)
-        for key in v:
-            if not key_re.match(key):
-                msg = f"instances map key must match instance id pattern: {key!r}"
-                raise ValueError(msg)
-        return v
+    instances: dict[
+        Annotated[str, Field(pattern=_INSTANCE_ID_REGEX)], WorkflowInstance
+    ]
 
     @model_validator(mode="after")
-    def _instance_keys_match_nested_id(self) -> Self:
+    def _instance_keys_equal_nested_id(self) -> Self:
         for key, inst in self.instances.items():
             if key != inst.id.root:
-                msg = (
-                    f"instances map key must equal workflow_instance.id: key={key!r} "
-                    f"id={inst.id.root!r}"
+                raise ValueError(
+                    "instances map key must equal workflow_instance.id: "
+                    f"key={key!r} id={inst.id.root!r}"
                 )
-                raise ValueError(msg)
         return self
 
 
 class Data(BaseModel):
-    """``data`` subtree on the wire and accumulated workflow-instance store state."""
+    """Generated from ``$defs.data``: payload data object containing workflow
+    configurations and the targeted instances. ``additionalProperties: true``
+    so unknown app-level keys are kept."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -318,7 +503,8 @@ class Data(BaseModel):
 
 
 class Event(BaseModel):
-    """Root event message: ``metadata`` and ``data`` required; no extra top-level properties."""
+    """Generated from the top-level ``event_v1`` schema. ``additionalProperties:
+    false`` so extra top-level keys are rejected."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/types/event.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/types/event.py
@@ -314,7 +314,7 @@ class Data(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    workflows: dict[str, Workflow] = Field(default_factory=dict)
+    workflows: dict[str, Workflow]
 
 
 class Event(BaseModel):

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/types/event_type.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/types/event_type.py
@@ -1,13 +1,26 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Business event type enum (from ``event_type_v1.json`` ``$defs.event_type``)."""
+"""Generated from ``schema/jsonschemas/event_type_v1.json``.
+
+Do not edit by hand: regenerate with the ``jsonschema-to-pydantic-lungo`` skill.
+
+Source description:
+    Known business event types. Can be extended as needed for emitters. Listed
+    values are validated by the event_v1 schema.
+"""
+
+from __future__ import annotations
 
 from enum import StrEnum
 
 
 class EventType(StrEnum):
-    """Known emitter event types; extend when adding emitters."""
+    """Generated from ``$defs.event_type``.
+
+    CURRENT VALUES ARE JUST PLACEHOLDERS. Need to be properly filled when
+    implementing emitters.
+    """
 
     RECRUITER_NODE_SEARCH = "RecruiterNodeSearch"
     STATE_PROGRESS_UPDATE = "StateProgressUpdate"

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/types/test_event.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/types/test_event.py
@@ -1,0 +1,261 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generated from ``schema/jsonschemas/event_v1.json``.
+
+Do not edit by hand: regenerate with the ``jsonschema-to-pydantic-lungo`` skill.
+
+Verifies that ``schema.types.event`` agrees with the JSON Schema layer
+(``schema.validation.validate_data_against_schema``) and with the Python-only
+constraint in ``schema.json_schema._enforce_workflow_instance_map_key_id_match``
+(mirrored on ``Workflow`` as ``_instance_keys_equal_nested_id``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from pydantic import ValidationError
+from schema.errors import SchemaValidationError
+from schema.json_schema import load_json_instance_file
+from schema.types import Event
+from schema.validation import validate_data_against_schema
+
+_KNOWN = "event_v1"
+_LUNGO_ROOT = Path(__file__).resolve().parents[4]
+_EXAMPLES = _LUNGO_ROOT / "schema" / "jsonschemas" / "examples"
+_INSTANCE_KEY = "instance://550e8400-e29b-41d4-a716-446655440003"
+
+
+class EventInputs(NamedTuple):
+    example_filename: str
+    mutate: Callable[[dict], None] | None = None
+
+
+class EventOutputs(NamedTuple):
+    schema_exc: type[BaseException] | None = None
+    model_exc: type[BaseException] | None = None
+
+
+class EventCase(NamedTuple):
+    case_id: str
+    inputs: EventInputs
+    outputs: EventOutputs
+
+
+def _mutate_instance_map_key_invalid_pattern(d: dict) -> None:
+    wf = d["data"]["workflows"]["recruiter"]
+    inst = next(iter(wf["instances"].values()))
+    wf["instances"] = {"not-an-instance-id": inst}
+
+
+_EVENT_CASES: tuple[EventCase, ...] = (
+    EventCase(
+        case_id="partial_example_round_trip",
+        inputs=EventInputs(example_filename="event_v1_partial.json"),
+        outputs=EventOutputs(),
+    ),
+    EventCase(
+        case_id="full_example_round_trip",
+        inputs=EventInputs(example_filename="event_v1_full.json"),
+        outputs=EventOutputs(),
+    ),
+    EventCase(
+        case_id="empty_workflows_example_round_trip",
+        inputs=EventInputs(example_filename="event_v1_empty_workflows.json"),
+        outputs=EventOutputs(),
+    ),
+    EventCase(
+        case_id="root_extra_property",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: d.update({"extra": 1}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="missing_required_metadata",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: d.pop("metadata"),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="missing_required_data",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: d.pop("data"),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="metadata_id_invalid_pattern",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: d["metadata"].update({"id": "not-a-valid-event-id"}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="metadata_correlation_id_invalid_pattern",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: d["metadata"]["correlation"].update(
+                {"id": "550e8400-e29b-41d4-a716-446655440001"},
+            ),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="metadata_type_unknown_member",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: d["metadata"].update({"type": "BrandNewEmitterEvent"}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="node_id_invalid_pattern",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: (
+                d["data"]["workflows"]["recruiter"]["starting_topology"]["nodes"][0]
+            ).update({"id": "node://not-a-uuid"}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="node_stable_agent_id_invalid_pattern",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: (
+                d["data"]["workflows"]["recruiter"]["starting_topology"]["nodes"][0]
+            ).update({"stable_agent_id": "agent://not-a-uuid"}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="node_operation_unknown_member",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: (
+                d["data"]["workflows"]["recruiter"]["starting_topology"]["nodes"][0]
+            ).update({"operation": "frobnicate"}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="edge_id_invalid_pattern",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: (
+                d["data"]["workflows"]["recruiter"]["starting_topology"]["edges"][0]
+            ).update({"id": "edge://not-a-uuid"}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="size_extra_property",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: (
+                d["data"]["workflows"]["recruiter"]["starting_topology"]["nodes"][0]
+            ).update({"size": {"width": 1.0, "height": 1.0, "depth": 1.0}}),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="instance_map_key_invalid_pattern",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=_mutate_instance_map_key_invalid_pattern,
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+    EventCase(
+        case_id="instances_map_key_mismatch_with_nested_id",
+        inputs=EventInputs(
+            example_filename="event_v1_partial.json",
+            mutate=lambda d: next(iter(d["data"]["workflows"].values())).update(
+                instances={
+                    "instance://00000000-0000-4000-8000-000000000001": {
+                        "id": _INSTANCE_KEY,
+                        "topology": {},
+                    },
+                },
+            ),
+        ),
+        outputs=EventOutputs(
+            schema_exc=SchemaValidationError,
+            model_exc=ValidationError,
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.case_id) for c in _EVENT_CASES])
+def test_event_payload_schema_and_model(case: EventCase) -> None:
+    data = load_json_instance_file(_EXAMPLES / case.inputs.example_filename)
+    if case.inputs.mutate is not None:
+        data = deepcopy(data)
+        case.inputs.mutate(data)
+
+    out = case.outputs
+    if out.schema_exc is not None:
+        assert out.model_exc is not None, "invalid cases must fail both layers"
+        with pytest.raises(out.schema_exc):
+            validate_data_against_schema(data, _KNOWN)
+        with pytest.raises(out.model_exc):
+            Event.model_validate(data)
+        return
+
+    assert case.inputs.mutate is None, "valid round-trip cases must not carry a mutation"
+    assert out.model_exc is None
+    validate_data_against_schema(data, _KNOWN)
+    event = Event.model_validate(data)
+    dumped = event.model_dump(mode="json", exclude_none=True)
+    validate_data_against_schema(dumped, _KNOWN)
+    Event.model_validate(dumped)
+    assert isinstance(dumped["metadata"]["timestamp"], str)
+    assert event.metadata.timestamp.tzinfo is not None


### PR DESCRIPTION
# Description

This PR aims to add a Skill specific to the Lungo subproject that can take the JSONSchema files and generate Pydantic v2 models from them.

The skill is more complicated than initially thought because there are paradigm differences between JSONSchema (and how it composes types) vs Python and Pydantic types/models (and how they treat and propagate settings like `extra` and type composition in general).   
Also with that in mind, the examples from `mapping-rules.md` should make the generation more reliable and closer to deterministic.

The first two commits are small fixes I brought along the way because the coding agents kept getting fixated on those things when trying to do the iterations that would eventually be the basis for the generation of the Skill itself. They are otherwise not related to the main goal of the ticket.


## Issue Link

#510 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
