### PR TITLE
feat(lungo): update left hand side menu to use agentic-workflows api

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/dtos.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/dtos.py
@@ -47,6 +47,7 @@ class WorkflowSummary(BaseModel):
     name: Annotated[str, Field(min_length=1)]
     pattern: Annotated[str, Field(min_length=1)]
     use_case: Annotated[str, Field(min_length=1)]
+    scenario: Annotated[str, Field(min_length=1, description="brief extra qualifier for the use-case")]
 
 
 class WorkflowSummaryMapResponse(RootModel[dict[str, WorkflowSummary]]):

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/instance_lifecycle.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/instance_lifecycle.py
@@ -55,9 +55,10 @@ def build_instantiate_seed_event(
         "data": {
             "workflows": {
                 workflow_name: {
+                    "name": wf.name,
                     "pattern": wf.pattern,
                     "use_case": wf.use_case,
-                    "name": wf.name,
+                    "scenario": wf.scenario,
                     "starting_topology": wf.starting_topology.model_dump(
                         mode="json",
                     ),

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/router.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/router.py
@@ -159,6 +159,7 @@ def create_agentic_workflows_router() -> APIRouter:
                 name=w.name,
                 pattern=w.pattern,
                 use_case=w.use_case,
+                scenario=w.scenario,
             )
             for w in filtered
         }

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/starting_workflows.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/starting_workflows.json
@@ -1,8 +1,9 @@
 [
   {
+    "name": "Publish Subscribe Coffee Farm Network",
     "pattern": "Supervisor-worker",
     "use_case": "Coffee Agntcy",
-    "name": "Publish Subscribe Coffee Farm Network",
+    "scenario": "Coffee Buying",
     "starting_topology": {
       "nodes": [
         {
@@ -128,9 +129,10 @@
     "instances": {}
   },
   {
+    "name": "Publish Subscribe Streaming Coffee Auction Network",
     "pattern": "Supervisor-worker",
     "use_case": "Coffee Agntcy",
-    "name": "Publish Subscribe Streaming Coffee Auction Network",
+    "scenario": "Coffee Buying",
     "starting_topology": {
       "nodes": [
         {
@@ -256,9 +258,10 @@
     "instances": {}
   },
   {
+    "name": "Secure Group Communication Logistics Network",
     "pattern": "Group chat",
     "use_case": "Coffee Agntcy",
-    "name": "Secure Group Communication Logistics Network",
+    "scenario": "Order Fulfilment",
     "starting_topology": {
       "nodes": [
         {
@@ -355,9 +358,10 @@
     "instances": {}
   },
   {
+    "name": "On-demand Discovery",
     "pattern": "Recruiter",
     "use_case": "Coffee Agntcy",
-    "name": "On-demand Discovery",
+    "scenario": "Capability Discovery",
     "starting_topology": {
       "nodes": [
         {

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/merge.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/merge.py
@@ -158,7 +158,7 @@ def _merge_workflow(
     snapshot_wf: dict,
     incoming_wf: dict,
 ) -> None:
-    for key in ("pattern", "use_case", "name"):
+    for key in ("pattern", "use_case", "name", "scenario"):
         if key in incoming_wf:
             snapshot_wf[key] = incoming_wf[key]
     if "starting_topology" in incoming_wf:

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/CatalogTree.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/CatalogTree.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import React from "react"
+import { PatternType } from "@/utils/patternUtils"
+import type { PatternNode } from "@/utils/sidebarHierarchy"
+import { cn } from "@/utils/cn"
+import SidebarItem from "./sidebarItem"
+import SidebarDropdown from "./SidebarDropdown"
+import UseCaseDropdown from "./UseCaseDropdown"
+import { makePatternKey, makeScenarioKey } from "./sidebarKeys"
+
+interface CatalogTreeProps {
+  tree: PatternNode[]
+  expanded: Set<string>
+  onToggle: (key: string) => void
+  selectedPattern: PatternType
+  onPatternChange: (pattern: PatternType) => void
+}
+
+/**
+ * Renders the `pattern -> use-case+scenario -> workflow` tree built from the
+ * agentic workflows catalog. Patterns and use-case rows are collapsible; leaf
+ * workflow rows are clickable when their slug maps to a known `PatternType`.
+ */
+const CatalogTree: React.FC<CatalogTreeProps> = ({
+  tree,
+  expanded,
+  onToggle,
+  selectedPattern,
+  onPatternChange,
+}) => {
+  if (tree.length === 0) {
+    return <SidebarItem title="No workflows available" className="opacity-60" />
+  }
+
+  return (
+    <>
+      {tree.map((pattern) => {
+        const pKey = makePatternKey(pattern.name)
+        return (
+          <SidebarDropdown
+            key={pKey}
+            title={pattern.name}
+            isExpanded={expanded.has(pKey)}
+            onToggle={() => onToggle(pKey)}
+            titleClassName="pl-2"
+          >
+            {pattern.useCaseScenarios.map((ucs) => {
+              const ucsKey = makeScenarioKey(
+                pattern.name,
+                ucs.useCase,
+                ucs.scenario,
+              )
+              return (
+                <UseCaseDropdown
+                  key={ucsKey}
+                  title={ucs.label}
+                  isExpanded={expanded.has(ucsKey)}
+                  onToggle={() => onToggle(ucsKey)}
+                >
+                  {ucs.workflows.map((workflow) => {
+                    const isUnknown = workflow.slug === null
+                    const isSelected =
+                      !isUnknown && selectedPattern === workflow.slug
+                    return (
+                      <SidebarItem
+                        key={workflow.name}
+                        title={workflow.name}
+                        isSelected={isSelected}
+                        onClick={
+                          isUnknown
+                            ? undefined
+                            : () => onPatternChange(workflow.slug!)
+                        }
+                        className={cn(
+                          "pl-10",
+                          isUnknown &&
+                            "pointer-events-none cursor-not-allowed opacity-50",
+                        )}
+                      />
+                    )
+                  })}
+                </UseCaseDropdown>
+              )
+            })}
+          </SidebarDropdown>
+        )
+      })}
+    </>
+  )
+}
+
+export default CatalogTree

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/utils/sidebarHierarchy"
 import { logger } from "@/utils/logger"
 import CatalogTree from "./CatalogTree"
+import SidebarItem from "./sidebarItem"
 import { makePatternKey, makeScenarioKey } from "./sidebarKeys"
 
 interface SidebarProps {
@@ -146,11 +147,15 @@ const Sidebar: React.FC<SidebarProps> = ({
 
         {summaries === null && error === null && (
           <div
-            className="flex w-full items-center justify-center py-4"
+            className="flex w-full items-center gap-3 px-5 py-2"
             role="status"
             aria-label="Loading workflows"
           >
-            <Spinner size={20} thickness={4} />
+            <Spinner size={16} thickness={4} />
+            <SidebarItem
+              title="Loading workflows..."
+              className="flex-1 px-0 py-0 opacity-60 hover:bg-transparent"
+            />
           </div>
         )}
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  **/
 
-import React, { useState, useEffect } from "react"
+import React, { useEffect, useMemo, useState } from "react"
+import { PATTERNS, PatternType } from "@/utils/patternUtils"
 import {
-  PatternType,
-  PATTERNS,
-  getApiUrlForPattern,
-} from "@/utils/patternUtils"
+  fetchWorkflowSummaries,
+  type WorkflowSummary,
+} from "@/utils/agenticWorkflowsApi"
+import {
+  groupWorkflowsByPatternAndUseCase,
+  type PatternNode,
+} from "@/utils/sidebarHierarchy"
 import { logger } from "@/utils/logger"
 import SidebarItem from "./sidebarItem"
 import SidebarDropdown from "./SidebarDropdown"
@@ -18,171 +22,299 @@ interface SidebarProps {
   onPatternChange: (pattern: PatternType) => void
 }
 
+const CATALOG_ENDPOINT = "/agentic-workflows/"
+
+const makePatternKey = (patternName: string) => `pattern:${patternName}`
+const makeUseCaseKey = (patternName: string, useCaseName: string) =>
+  `pattern:${patternName}|usecase:${useCaseName}`
+
+/**
+ * Initial expansion set: every pattern and every use-case open, mirroring the
+ * previous static sidebar UX where every dropdown was open by default.
+ */
+const buildInitialExpanded = (tree: PatternNode[]): Set<string> => {
+  const next = new Set<string>()
+  for (const pattern of tree) {
+    next.add(makePatternKey(pattern.name))
+    for (const useCase of pattern.useCases) {
+      next.add(makeUseCaseKey(pattern.name, useCase.name))
+    }
+  }
+  return next
+}
+
 const Sidebar: React.FC<SidebarProps> = ({
   selectedPattern,
   onPatternChange,
 }) => {
-  const [isPublishSubscribeExpanded, setIsPublishSubscribeExpanded] =
-    useState(true)
-  const [
-    isPublishSubscribeStreamingExpanded,
-    setIsPublishSubscribeStreamingExpanded,
-  ] = useState(true)
-  const [isGroupCommunicationExpanded, setIsGroupCommunicationExpanded] =
-    useState(true)
-  const [isOnDemandDiscoveryExpanded, setIsOnDemandDiscoveryExpanded] =
-    useState(true)
-  const [transport, setTransport] = useState<string>("")
+  const [summaries, setSummaries] = useState<WorkflowSummary[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
   useEffect(() => {
-    const fetchTransportConfig = async () => {
-      try {
-        const response = await fetch(
-          `${getApiUrlForPattern(PATTERNS.PUBLISH_SUBSCRIBE)}/transport/config`,
-        )
-        const data = await response.json()
-        if (data.transport) {
-          setTransport(data.transport)
-        }
-      } catch (error) {
-        logger.error("Error fetching transport config:", error)
-      }
-    }
-
-    fetchTransportConfig()
+    const controller = new AbortController()
+    fetchWorkflowSummaries(controller.signal)
+      .then((rows) => {
+        setSummaries(rows)
+        setError(null)
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return
+        logger.apiError(CATALOG_ENDPOINT, err)
+        setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => controller.abort()
   }, [])
 
-  const handlePublishSubscribeToggle = () => {
-    setIsPublishSubscribeExpanded(!isPublishSubscribeExpanded)
-  }
+  const tree = useMemo(
+    () => groupWorkflowsByPatternAndUseCase(summaries ?? []),
+    [summaries],
+  )
 
-  const handlePublishSubscribeStreamingToggle = () => {
-    setIsPublishSubscribeStreamingExpanded(!isPublishSubscribeStreamingExpanded)
-  }
+  useEffect(() => {
+    if (summaries === null) return
+    setExpanded(buildInitialExpanded(tree))
+  }, [tree, summaries])
 
-  const handleGroupCommunicationToggle = () => {
-    setIsGroupCommunicationExpanded(!isGroupCommunicationExpanded)
-  }
-
-  const handleOnDemandDiscoveryToggle = () => {
-    setIsOnDemandDiscoveryExpanded(!isOnDemandDiscoveryExpanded)
+  const toggle = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
   }
 
   return (
     <div className="flex h-full w-64 flex-none flex-col gap-5 border-r border-sidebar-border bg-sidebar-background font-inter lg:w-[320px]">
-      <div className="flex h-full flex-1 flex-col gap-5 p-4">
-        {/* Order Fulfilment Section */}
-        <div className="flex flex-col">
-          <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-2 pr-5">
-            <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
-              Conversation: Order Fulfilment
-            </span>
-          </div>
-
-          <div className="flex flex-col">
-            <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-5 pr-5">
-              <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
-                Agentic Patterns
-              </span>
-            </div>
-
-            <div>
-              <SidebarDropdown
-                title="Secure Group Communication"
-                isExpanded={isGroupCommunicationExpanded}
-                onToggle={handleGroupCommunicationToggle}
-              >
-                <SidebarItem
-                  title="A2A SLIM"
-                  isSelected={selectedPattern === PATTERNS.GROUP_COMMUNICATION}
-                  onClick={() => onPatternChange(PATTERNS.GROUP_COMMUNICATION)}
-                />
-              </SidebarDropdown>
-            </div>
-          </div>
+      <div className="flex h-full flex-1 flex-col gap-2 p-4">
+        <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-2 pr-5">
+          <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
+            Agentic Patterns
+          </span>
         </div>
 
-        {/* Coffee Buying Section */}
-        <div className="flex flex-col">
-          <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-2 pr-5">
-            <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
-              Conversation: Coffee Buying
-            </span>
-          </div>
+        {summaries === null && error === null && (
+          <SidebarItem title="Loading workflows..." className="opacity-60" />
+        )}
 
-          <div className="flex flex-col">
-            <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-5 pr-5">
-              <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
-                Agentic Patterns
-              </span>
+        {error !== null && (
+          <>
+            <div className="px-5 py-1 text-xs leading-4 text-sidebar-text opacity-70">
+              Couldn&apos;t load workflows from the catalog API. Showing the
+              built-in menu.
             </div>
+            <StaticFallbackTree
+              selectedPattern={selectedPattern}
+              onPatternChange={onPatternChange}
+            />
+          </>
+        )}
 
-            <div>
-              <SidebarDropdown
-                title="Publish Subscribe"
-                isExpanded={isPublishSubscribeExpanded}
-                onToggle={handlePublishSubscribeToggle}
-              >
-                <SidebarItem
-                  title={`A2A ${transport}`}
-                  isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE}
-                  onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE)}
-                />
-              </SidebarDropdown>
-            </div>
-
-            <div>
-              <SidebarDropdown
-                title="Publish Subscribe: Streaming"
-                isExpanded={isPublishSubscribeStreamingExpanded}
-                onToggle={handlePublishSubscribeStreamingToggle}
-              >
-                <SidebarItem
-                  title={`A2A ${transport}`}
-                  isSelected={
-                    selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE_STREAMING
-                  }
-                  onClick={() =>
-                    onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE_STREAMING)
-                  }
-                />
-              </SidebarDropdown>
-            </div>
-          </div>
-        </div>
-
-        {/* Generic Task Section */}
-        <div className="flex flex-col">
-          <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-2 pr-5">
-            <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
-              Conversation: Capability Discovery
-            </span>
-          </div>
-
-          <div className="flex flex-col">
-            <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-5 pr-5">
-              <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
-                Agentic Patterns
-              </span>
-            </div>
-
-            <div>
-              <SidebarDropdown
-                title="Recruiter"
-                isExpanded={isOnDemandDiscoveryExpanded}
-                onToggle={handleOnDemandDiscoveryToggle}
-              >
-                <SidebarItem
-                  title={`A2A HTTP`}
-                  isSelected={selectedPattern === PATTERNS.ON_DEMAND_DISCOVERY}
-                  onClick={() => onPatternChange(PATTERNS.ON_DEMAND_DISCOVERY)}
-                />
-              </SidebarDropdown>
-            </div>
-          </div>
-        </div>
+        {summaries !== null && error === null && (
+          <CatalogTree
+            tree={tree}
+            expanded={expanded}
+            onToggle={toggle}
+            selectedPattern={selectedPattern}
+            onPatternChange={onPatternChange}
+          />
+        )}
       </div>
     </div>
+  )
+}
+
+interface CatalogTreeProps {
+  tree: PatternNode[]
+  expanded: Set<string>
+  onToggle: (key: string) => void
+  selectedPattern: PatternType
+  onPatternChange: (pattern: PatternType) => void
+}
+
+const CatalogTree: React.FC<CatalogTreeProps> = ({
+  tree,
+  expanded,
+  onToggle,
+  selectedPattern,
+  onPatternChange,
+}) => {
+  if (tree.length === 0) {
+    return <SidebarItem title="No workflows available" className="opacity-60" />
+  }
+
+  return (
+    <>
+      {tree.map((pattern) => {
+        const pKey = makePatternKey(pattern.name)
+        const renderUseCaseAsDropdown = pattern.useCases.length > 1
+        return (
+          <SidebarDropdown
+            key={pKey}
+            title={pattern.name}
+            isExpanded={expanded.has(pKey)}
+            onToggle={() => onToggle(pKey)}
+          >
+            {pattern.useCases.map((useCase) => {
+              const ucKey = makeUseCaseKey(pattern.name, useCase.name)
+              const items = useCase.workflows.map((workflow) => {
+                const isUnknown = workflow.slug === null
+                const isSelected =
+                  !isUnknown && selectedPattern === workflow.slug
+                return (
+                  <SidebarItem
+                    key={workflow.name}
+                    title={workflow.name}
+                    isSelected={isSelected}
+                    onClick={
+                      isUnknown
+                        ? undefined
+                        : () => onPatternChange(workflow.slug!)
+                    }
+                    className={
+                      isUnknown
+                        ? "pointer-events-none cursor-not-allowed opacity-50"
+                        : renderUseCaseAsDropdown
+                          ? "pl-16"
+                          : ""
+                    }
+                  />
+                )
+              })
+
+              if (!renderUseCaseAsDropdown) {
+                return <React.Fragment key={ucKey}>{items}</React.Fragment>
+              }
+              return (
+                <UseCaseDropdown
+                  key={ucKey}
+                  title={useCase.name}
+                  isExpanded={expanded.has(ucKey)}
+                  onToggle={() => onToggle(ucKey)}
+                >
+                  {items}
+                </UseCaseDropdown>
+              )
+            })}
+          </SidebarDropdown>
+        )
+      })}
+    </>
+  )
+}
+
+interface UseCaseDropdownProps {
+  title: string
+  isExpanded: boolean
+  onToggle: () => void
+  children: React.ReactNode
+}
+
+/**
+ * Lightweight nested dropdown for the use-case level. Visually it matches
+ * `SidebarDropdown` but indents one extra step so the pattern -> use-case
+ * relationship reads clearly.
+ */
+const UseCaseDropdown: React.FC<UseCaseDropdownProps> = ({
+  title,
+  isExpanded,
+  onToggle,
+  children,
+}) => {
+  return (
+    <div className="flex w-full flex-col items-start p-0">
+      <div className="flex w-full items-start gap-2 bg-sidebar-background py-2 pl-12 pr-5 transition-colors hover:bg-sidebar-item-selected">
+        <span
+          className="flex-1 cursor-pointer font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text"
+          onClick={onToggle}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
+              onToggle()
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
+        >
+          {title}
+        </span>
+      </div>
+      {isExpanded && <div className="flex w-full flex-col">{children}</div>}
+    </div>
+  )
+}
+
+interface StaticFallbackTreeProps {
+  selectedPattern: PatternType
+  onPatternChange: (pattern: PatternType) => void
+}
+
+/**
+ * Fallback tree rendered when the catalog API is unreachable. Mirrors the
+ * pre-#540 static sidebar so the app stays usable even if the agentic
+ * workflows service is down.
+ */
+const StaticFallbackTree: React.FC<StaticFallbackTreeProps> = ({
+  selectedPattern,
+  onPatternChange,
+}) => {
+  const [groupExpanded, setGroupExpanded] = useState(true)
+  const [pubSubExpanded, setPubSubExpanded] = useState(true)
+  const [pubSubStreamExpanded, setPubSubStreamExpanded] = useState(true)
+  const [discoveryExpanded, setDiscoveryExpanded] = useState(true)
+
+  return (
+    <>
+      <SidebarDropdown
+        title="Secure Group Communication"
+        isExpanded={groupExpanded}
+        onToggle={() => setGroupExpanded((v) => !v)}
+      >
+        <SidebarItem
+          title="A2A SLIM"
+          isSelected={selectedPattern === PATTERNS.GROUP_COMMUNICATION}
+          onClick={() => onPatternChange(PATTERNS.GROUP_COMMUNICATION)}
+        />
+      </SidebarDropdown>
+      <SidebarDropdown
+        title="Publish Subscribe"
+        isExpanded={pubSubExpanded}
+        onToggle={() => setPubSubExpanded((v) => !v)}
+      >
+        <SidebarItem
+          title="A2A"
+          isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE}
+          onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE)}
+        />
+      </SidebarDropdown>
+      <SidebarDropdown
+        title="Publish Subscribe: Streaming"
+        isExpanded={pubSubStreamExpanded}
+        onToggle={() => setPubSubStreamExpanded((v) => !v)}
+      >
+        <SidebarItem
+          title="A2A"
+          isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE_STREAMING}
+          onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE_STREAMING)}
+        />
+      </SidebarDropdown>
+      <SidebarDropdown
+        title="Recruiter"
+        isExpanded={discoveryExpanded}
+        onToggle={() => setDiscoveryExpanded((v) => !v)}
+      >
+        <SidebarItem
+          title="A2A HTTP"
+          isSelected={selectedPattern === PATTERNS.ON_DEMAND_DISCOVERY}
+          onClick={() => onPatternChange(PATTERNS.ON_DEMAND_DISCOVERY)}
+        />
+      </SidebarDropdown>
+    </>
   )
 }
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  **/
 
-import React, { useEffect, useMemo, useState } from "react"
-import { PATTERNS, PatternType } from "@/utils/patternUtils"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+import { Spinner } from "@open-ui-kit/core"
+import ErrorOutline from "@mui/icons-material/ErrorOutline"
+import { PatternType } from "@/utils/patternUtils"
 import {
   fetchWorkflowSummaries,
   type WorkflowSummary,
@@ -14,9 +16,8 @@ import {
   type PatternNode,
 } from "@/utils/sidebarHierarchy"
 import { logger } from "@/utils/logger"
-import { cn } from "@/utils/cn"
-import SidebarItem from "./sidebarItem"
-import SidebarDropdown from "./SidebarDropdown"
+import CatalogTree from "./CatalogTree"
+import { makePatternKey, makeScenarioKey } from "./sidebarKeys"
 
 interface SidebarProps {
   selectedPattern: PatternType
@@ -24,13 +25,14 @@ interface SidebarProps {
 }
 
 const CATALOG_ENDPOINT = "/agentic-workflows/"
-
-const makePatternKey = (patternName: string) => `pattern:${patternName}`
-const makeScenarioKey = (
-  patternName: string,
-  useCase: string,
-  scenario: string,
-) => `pattern:${patternName}|usecase:${useCase}|scenario:${scenario}`
+/**
+ * Total number of attempts (one initial request + this many retries) before
+ * the catalog menu fetch is treated as failed. Mirrors common UX patterns
+ * where transient hiccups don't immediately surface an error to the user.
+ */
+const CATALOG_FETCH_MAX_RETRIES = 2
+/** Backoff (ms) between consecutive retry attempts. */
+const CATALOG_FETCH_RETRY_DELAY_MS = 750
 
 /**
  * Initial expansion set: every pattern and every use-case+scenario row open,
@@ -48,6 +50,46 @@ const buildInitialExpanded = (tree: PatternNode[]): Set<string> => {
   return next
 }
 
+const sleep = (ms: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"))
+      return
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new DOMException("Aborted", "AbortError"))
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
+
+/**
+ * Fetch the workflow catalog with a small retry budget so transient network
+ * blips don't immediately surface as an error to the user. Each retry uses
+ * the same `AbortSignal`, so unmount/cleanup short-circuits the loop.
+ */
+const fetchWorkflowSummariesWithRetry = async (
+  signal: AbortSignal,
+): Promise<WorkflowSummary[]> => {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= CATALOG_FETCH_MAX_RETRIES; attempt += 1) {
+    try {
+      return await fetchWorkflowSummaries(signal)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") throw err
+      lastError = err
+      if (attempt < CATALOG_FETCH_MAX_RETRIES) {
+        await sleep(CATALOG_FETCH_RETRY_DELAY_MS, signal)
+      }
+    }
+  }
+  throw lastError
+}
+
 const Sidebar: React.FC<SidebarProps> = ({
   selectedPattern,
   onPatternChange,
@@ -58,10 +100,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   useEffect(() => {
     const controller = new AbortController()
-    fetchWorkflowSummaries(controller.signal)
+    setError(null)
+    fetchWorkflowSummariesWithRetry(controller.signal)
       .then((rows) => {
         setSummaries(rows)
-        setError(null)
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return
@@ -81,7 +123,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     setExpanded(buildInitialExpanded(tree))
   }, [tree, summaries])
 
-  const toggle = (key: string) => {
+  const toggle = useCallback((key: string) => {
     setExpanded((prev) => {
       const next = new Set(prev)
       if (next.has(key)) {
@@ -91,7 +133,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       }
       return next
     })
-  }
+  }, [])
 
   return (
     <div className="flex h-full w-64 flex-none flex-col gap-5 border-r border-sidebar-border bg-sidebar-background font-inter lg:w-[320px]">
@@ -103,20 +145,23 @@ const Sidebar: React.FC<SidebarProps> = ({
         </div>
 
         {summaries === null && error === null && (
-          <SidebarItem title="Loading workflows..." className="opacity-60" />
+          <div
+            className="flex w-full items-center justify-center py-4"
+            role="status"
+            aria-label="Loading workflows"
+          >
+            <Spinner size={20} thickness={4} />
+          </div>
         )}
 
         {error !== null && (
-          <>
-            <div className="px-5 py-1 text-xs leading-4 text-sidebar-text opacity-70">
-              Couldn&apos;t load workflows from the catalog API. Showing the
-              built-in menu.
-            </div>
-            <StaticFallbackTree
-              selectedPattern={selectedPattern}
-              onPatternChange={onPatternChange}
-            />
-          </>
+          <div
+            className="flex w-full items-center gap-2 px-5 py-2 text-xs leading-4 text-sidebar-text opacity-80"
+            role="alert"
+          >
+            <ErrorOutline sx={{ fontSize: 16 }} />
+            <span>Menu is unavailable</span>
+          </div>
         )}
 
         {summaries !== null && error === null && (
@@ -130,201 +175,6 @@ const Sidebar: React.FC<SidebarProps> = ({
         )}
       </div>
     </div>
-  )
-}
-
-interface CatalogTreeProps {
-  tree: PatternNode[]
-  expanded: Set<string>
-  onToggle: (key: string) => void
-  selectedPattern: PatternType
-  onPatternChange: (pattern: PatternType) => void
-}
-
-const CatalogTree: React.FC<CatalogTreeProps> = ({
-  tree,
-  expanded,
-  onToggle,
-  selectedPattern,
-  onPatternChange,
-}) => {
-  if (tree.length === 0) {
-    return <SidebarItem title="No workflows available" className="opacity-60" />
-  }
-
-  return (
-    <>
-      {tree.map((pattern) => {
-        const pKey = makePatternKey(pattern.name)
-        return (
-          <SidebarDropdown
-            key={pKey}
-            title={pattern.name}
-            isExpanded={expanded.has(pKey)}
-            onToggle={() => onToggle(pKey)}
-            titleClassName="pl-2"
-          >
-            {pattern.useCaseScenarios.map((ucs) => {
-              const ucsKey = makeScenarioKey(
-                pattern.name,
-                ucs.useCase,
-                ucs.scenario,
-              )
-              return (
-                <UseCaseDropdown
-                  key={ucsKey}
-                  title={ucs.label}
-                  isExpanded={expanded.has(ucsKey)}
-                  onToggle={() => onToggle(ucsKey)}
-                >
-                  {ucs.workflows.map((workflow) => {
-                    const isUnknown = workflow.slug === null
-                    const isSelected =
-                      !isUnknown && selectedPattern === workflow.slug
-                    return (
-                      <SidebarItem
-                        key={workflow.name}
-                        title={workflow.name}
-                        isSelected={isSelected}
-                        onClick={
-                          isUnknown
-                            ? undefined
-                            : () => onPatternChange(workflow.slug!)
-                        }
-                        className={cn(
-                          "pl-10",
-                          isUnknown &&
-                            "pointer-events-none cursor-not-allowed opacity-50",
-                        )}
-                      />
-                    )
-                  })}
-                </UseCaseDropdown>
-              )
-            })}
-          </SidebarDropdown>
-        )
-      })}
-    </>
-  )
-}
-
-interface UseCaseDropdownProps {
-  title: string
-  isExpanded: boolean
-  onToggle: () => void
-  children: React.ReactNode
-}
-
-/**
- * Lightweight nested dropdown for the use-case level. Visually it matches
- * `SidebarDropdown` but indents one step further so the pattern -> use-case
- * relationship reads clearly.
- */
-const UseCaseDropdown: React.FC<UseCaseDropdownProps> = ({
-  title,
-  isExpanded,
-  onToggle,
-  children,
-}) => {
-  return (
-    <div className="flex w-full flex-col items-start p-0">
-      <div className="flex w-full items-start gap-2 bg-sidebar-background py-2 pl-6 pr-5 transition-colors hover:bg-sidebar-item-selected">
-        <span
-          className="flex-1 cursor-pointer font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text"
-          onClick={onToggle}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault()
-              onToggle()
-            }
-          }}
-          role="button"
-          tabIndex={0}
-          aria-expanded={isExpanded}
-        >
-          {title}
-        </span>
-      </div>
-      {isExpanded && <div className="flex w-full flex-col">{children}</div>}
-    </div>
-  )
-}
-
-interface StaticFallbackTreeProps {
-  selectedPattern: PatternType
-  onPatternChange: (pattern: PatternType) => void
-}
-
-/**
- * Fallback tree rendered when the catalog API is unreachable. Mirrors the
- * pre-#540 static sidebar so the app stays usable even if the agentic
- * workflows service is down.
- */
-const StaticFallbackTree: React.FC<StaticFallbackTreeProps> = ({
-  selectedPattern,
-  onPatternChange,
-}) => {
-  const [groupExpanded, setGroupExpanded] = useState(true)
-  const [pubSubExpanded, setPubSubExpanded] = useState(true)
-  const [pubSubStreamExpanded, setPubSubStreamExpanded] = useState(true)
-  const [discoveryExpanded, setDiscoveryExpanded] = useState(true)
-
-  return (
-    <>
-      <SidebarDropdown
-        title="Secure Group Communication"
-        isExpanded={groupExpanded}
-        onToggle={() => setGroupExpanded((v) => !v)}
-        titleClassName="pl-2"
-      >
-        <SidebarItem
-          title="A2A SLIM"
-          isSelected={selectedPattern === PATTERNS.GROUP_COMMUNICATION}
-          onClick={() => onPatternChange(PATTERNS.GROUP_COMMUNICATION)}
-          className="pl-6"
-        />
-      </SidebarDropdown>
-      <SidebarDropdown
-        title="Publish Subscribe"
-        isExpanded={pubSubExpanded}
-        onToggle={() => setPubSubExpanded((v) => !v)}
-        titleClassName="pl-2"
-      >
-        <SidebarItem
-          title="A2A"
-          isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE}
-          onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE)}
-          className="pl-6"
-        />
-      </SidebarDropdown>
-      <SidebarDropdown
-        title="Publish Subscribe: Streaming"
-        isExpanded={pubSubStreamExpanded}
-        onToggle={() => setPubSubStreamExpanded((v) => !v)}
-        titleClassName="pl-2"
-      >
-        <SidebarItem
-          title="A2A"
-          isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE_STREAMING}
-          onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE_STREAMING)}
-          className="pl-6"
-        />
-      </SidebarDropdown>
-      <SidebarDropdown
-        title="Recruiter"
-        isExpanded={discoveryExpanded}
-        onToggle={() => setDiscoveryExpanded((v) => !v)}
-        titleClassName="pl-2"
-      >
-        <SidebarItem
-          title="A2A HTTP"
-          isSelected={selectedPattern === PATTERNS.ON_DEMAND_DISCOVERY}
-          onClick={() => onPatternChange(PATTERNS.ON_DEMAND_DISCOVERY)}
-          className="pl-6"
-        />
-      </SidebarDropdown>
-    </>
   )
 }
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   type PatternNode,
 } from "@/utils/sidebarHierarchy"
 import { logger } from "@/utils/logger"
+import { cn } from "@/utils/cn"
 import SidebarItem from "./sidebarItem"
 import SidebarDropdown from "./SidebarDropdown"
 
@@ -92,7 +93,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     <div className="flex h-full w-64 flex-none flex-col gap-5 border-r border-sidebar-border bg-sidebar-background font-inter lg:w-[320px]">
       <div className="flex h-full flex-1 flex-col gap-2 p-4">
         <div className="flex min-h-[36px] w-full items-center gap-2 rounded py-2 pl-2 pr-5">
-          <span className="flex-1 font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text">
+          <span className="flex-1 font-inter text-base font-semibold leading-6 tracking-[0.15px] text-sidebar-text">
             Agentic Patterns
           </span>
         </div>
@@ -151,44 +152,16 @@ const CatalogTree: React.FC<CatalogTreeProps> = ({
     <>
       {tree.map((pattern) => {
         const pKey = makePatternKey(pattern.name)
-        const renderUseCaseAsDropdown = pattern.useCases.length > 1
         return (
           <SidebarDropdown
             key={pKey}
             title={pattern.name}
             isExpanded={expanded.has(pKey)}
             onToggle={() => onToggle(pKey)}
+            titleClassName="pl-2"
           >
             {pattern.useCases.map((useCase) => {
               const ucKey = makeUseCaseKey(pattern.name, useCase.name)
-              const items = useCase.workflows.map((workflow) => {
-                const isUnknown = workflow.slug === null
-                const isSelected =
-                  !isUnknown && selectedPattern === workflow.slug
-                return (
-                  <SidebarItem
-                    key={workflow.name}
-                    title={workflow.name}
-                    isSelected={isSelected}
-                    onClick={
-                      isUnknown
-                        ? undefined
-                        : () => onPatternChange(workflow.slug!)
-                    }
-                    className={
-                      isUnknown
-                        ? "pointer-events-none cursor-not-allowed opacity-50"
-                        : renderUseCaseAsDropdown
-                          ? "pl-16"
-                          : ""
-                    }
-                  />
-                )
-              })
-
-              if (!renderUseCaseAsDropdown) {
-                return <React.Fragment key={ucKey}>{items}</React.Fragment>
-              }
               return (
                 <UseCaseDropdown
                   key={ucKey}
@@ -196,7 +169,28 @@ const CatalogTree: React.FC<CatalogTreeProps> = ({
                   isExpanded={expanded.has(ucKey)}
                   onToggle={() => onToggle(ucKey)}
                 >
-                  {items}
+                  {useCase.workflows.map((workflow) => {
+                    const isUnknown = workflow.slug === null
+                    const isSelected =
+                      !isUnknown && selectedPattern === workflow.slug
+                    return (
+                      <SidebarItem
+                        key={workflow.name}
+                        title={workflow.name}
+                        isSelected={isSelected}
+                        onClick={
+                          isUnknown
+                            ? undefined
+                            : () => onPatternChange(workflow.slug!)
+                        }
+                        className={cn(
+                          "pl-10",
+                          isUnknown &&
+                            "pointer-events-none cursor-not-allowed opacity-50",
+                        )}
+                      />
+                    )
+                  })}
                 </UseCaseDropdown>
               )
             })}
@@ -216,7 +210,7 @@ interface UseCaseDropdownProps {
 
 /**
  * Lightweight nested dropdown for the use-case level. Visually it matches
- * `SidebarDropdown` but indents one extra step so the pattern -> use-case
+ * `SidebarDropdown` but indents one step further so the pattern -> use-case
  * relationship reads clearly.
  */
 const UseCaseDropdown: React.FC<UseCaseDropdownProps> = ({
@@ -227,7 +221,7 @@ const UseCaseDropdown: React.FC<UseCaseDropdownProps> = ({
 }) => {
   return (
     <div className="flex w-full flex-col items-start p-0">
-      <div className="flex w-full items-start gap-2 bg-sidebar-background py-2 pl-12 pr-5 transition-colors hover:bg-sidebar-item-selected">
+      <div className="flex w-full items-start gap-2 bg-sidebar-background py-2 pl-6 pr-5 transition-colors hover:bg-sidebar-item-selected">
         <span
           className="flex-1 cursor-pointer font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text"
           onClick={onToggle}
@@ -274,44 +268,52 @@ const StaticFallbackTree: React.FC<StaticFallbackTreeProps> = ({
         title="Secure Group Communication"
         isExpanded={groupExpanded}
         onToggle={() => setGroupExpanded((v) => !v)}
+        titleClassName="pl-2"
       >
         <SidebarItem
           title="A2A SLIM"
           isSelected={selectedPattern === PATTERNS.GROUP_COMMUNICATION}
           onClick={() => onPatternChange(PATTERNS.GROUP_COMMUNICATION)}
+          className="pl-6"
         />
       </SidebarDropdown>
       <SidebarDropdown
         title="Publish Subscribe"
         isExpanded={pubSubExpanded}
         onToggle={() => setPubSubExpanded((v) => !v)}
+        titleClassName="pl-2"
       >
         <SidebarItem
           title="A2A"
           isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE}
           onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE)}
+          className="pl-6"
         />
       </SidebarDropdown>
       <SidebarDropdown
         title="Publish Subscribe: Streaming"
         isExpanded={pubSubStreamExpanded}
         onToggle={() => setPubSubStreamExpanded((v) => !v)}
+        titleClassName="pl-2"
       >
         <SidebarItem
           title="A2A"
           isSelected={selectedPattern === PATTERNS.PUBLISH_SUBSCRIBE_STREAMING}
           onClick={() => onPatternChange(PATTERNS.PUBLISH_SUBSCRIBE_STREAMING)}
+          className="pl-6"
         />
       </SidebarDropdown>
       <SidebarDropdown
         title="Recruiter"
         isExpanded={discoveryExpanded}
         onToggle={() => setDiscoveryExpanded((v) => !v)}
+        titleClassName="pl-2"
       >
         <SidebarItem
           title="A2A HTTP"
           isSelected={selectedPattern === PATTERNS.ON_DEMAND_DISCOVERY}
           onClick={() => onPatternChange(PATTERNS.ON_DEMAND_DISCOVERY)}
+          className="pl-6"
         />
       </SidebarDropdown>
     </>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
@@ -26,19 +26,23 @@ interface SidebarProps {
 const CATALOG_ENDPOINT = "/agentic-workflows/"
 
 const makePatternKey = (patternName: string) => `pattern:${patternName}`
-const makeUseCaseKey = (patternName: string, useCaseName: string) =>
-  `pattern:${patternName}|usecase:${useCaseName}`
+const makeScenarioKey = (
+  patternName: string,
+  useCase: string,
+  scenario: string,
+) => `pattern:${patternName}|usecase:${useCase}|scenario:${scenario}`
 
 /**
- * Initial expansion set: every pattern and every use-case open, mirroring the
- * previous static sidebar UX where every dropdown was open by default.
+ * Initial expansion set: every pattern and every use-case+scenario row open,
+ * mirroring the previous static sidebar UX where every dropdown was open by
+ * default.
  */
 const buildInitialExpanded = (tree: PatternNode[]): Set<string> => {
   const next = new Set<string>()
   for (const pattern of tree) {
     next.add(makePatternKey(pattern.name))
-    for (const useCase of pattern.useCases) {
-      next.add(makeUseCaseKey(pattern.name, useCase.name))
+    for (const ucs of pattern.useCaseScenarios) {
+      next.add(makeScenarioKey(pattern.name, ucs.useCase, ucs.scenario))
     }
   }
   return next
@@ -160,16 +164,20 @@ const CatalogTree: React.FC<CatalogTreeProps> = ({
             onToggle={() => onToggle(pKey)}
             titleClassName="pl-2"
           >
-            {pattern.useCases.map((useCase) => {
-              const ucKey = makeUseCaseKey(pattern.name, useCase.name)
+            {pattern.useCaseScenarios.map((ucs) => {
+              const ucsKey = makeScenarioKey(
+                pattern.name,
+                ucs.useCase,
+                ucs.scenario,
+              )
               return (
                 <UseCaseDropdown
-                  key={ucKey}
-                  title={useCase.name}
-                  isExpanded={expanded.has(ucKey)}
-                  onToggle={() => onToggle(ucKey)}
+                  key={ucsKey}
+                  title={ucs.label}
+                  isExpanded={expanded.has(ucsKey)}
+                  onToggle={() => onToggle(ucsKey)}
                 >
-                  {useCase.workflows.map((workflow) => {
+                  {ucs.workflows.map((workflow) => {
                     const isUnknown = workflow.slug === null
                     const isSelected =
                       !isUnknown && selectedPattern === workflow.slug

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/SidebarDropdown.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/SidebarDropdown.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { IconButton } from "@open-ui-kit/core"
 import ExpandLess from "@mui/icons-material/ExpandLess"
+import { cn } from "@/utils/cn"
 
 interface SidebarDropdownProps {
   title: string
@@ -13,6 +14,7 @@ interface SidebarDropdownProps {
   onToggle: () => void
   children: React.ReactNode
   isNested?: boolean
+  titleClassName?: string
 }
 
 const SidebarDropdown: React.FC<SidebarDropdownProps> = ({
@@ -20,10 +22,16 @@ const SidebarDropdown: React.FC<SidebarDropdownProps> = ({
   isExpanded,
   onToggle,
   children,
+  titleClassName,
 }) => {
   return (
     <div className="flex w-full flex-col items-start p-0">
-      <div className="flex w-full items-start gap-2 bg-sidebar-background py-2 pl-8 pr-5 transition-colors hover:bg-sidebar-item-selected">
+      <div
+        className={cn(
+          "flex w-full items-start gap-2 bg-sidebar-background py-2 pl-8 pr-5 transition-colors hover:bg-sidebar-item-selected",
+          titleClassName,
+        )}
+      >
         <span
           className="flex-1 cursor-pointer font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text"
           onClick={onToggle}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/UseCaseDropdown.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/UseCaseDropdown.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import React from "react"
+
+interface UseCaseDropdownProps {
+  title: string
+  isExpanded: boolean
+  onToggle: () => void
+  children: React.ReactNode
+}
+
+/**
+ * Lightweight nested dropdown for the use-case level. Visually it matches
+ * `SidebarDropdown` but indents one step further so the pattern -> use-case
+ * relationship reads clearly.
+ */
+const UseCaseDropdown: React.FC<UseCaseDropdownProps> = ({
+  title,
+  isExpanded,
+  onToggle,
+  children,
+}) => {
+  return (
+    <div className="flex w-full flex-col items-start p-0">
+      <div className="flex w-full items-start gap-2 bg-sidebar-background py-2 pl-6 pr-5 transition-colors hover:bg-sidebar-item-selected">
+        <span
+          className="flex-1 cursor-pointer font-inter text-sm font-normal leading-5 tracking-[0.25px] text-sidebar-text"
+          onClick={onToggle}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
+              onToggle()
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
+        >
+          {title}
+        </span>
+      </div>
+      {isExpanded && <div className="flex w-full flex-col">{children}</div>}
+    </div>
+  )
+}
+
+export default UseCaseDropdown

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/sidebarItem.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/sidebarItem.tsx
@@ -4,6 +4,7 @@
  **/
 
 import React from "react"
+import { cn } from "@/utils/cn"
 
 interface SidebarItemProps {
   title: string
@@ -16,11 +17,15 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
   title,
   isSelected = false,
   onClick,
-  className = "",
+  className,
 }) => {
   return (
     <div
-      className={`flex w-full cursor-pointer items-start gap-2 py-2 pl-12 pr-5 font-inter text-sm font-normal leading-5 text-sidebar-text transition-colors hover:bg-sidebar-item-selected ${isSelected ? "bg-sidebar-item-selected" : "bg-sidebar-background"} ${className}`}
+      className={cn(
+        "flex w-full cursor-pointer items-start gap-2 py-2 pl-12 pr-5 font-inter text-sm font-normal leading-5 text-sidebar-text transition-colors hover:bg-sidebar-item-selected",
+        isSelected ? "bg-sidebar-item-selected" : "bg-sidebar-background",
+        className,
+      )}
       onClick={onClick}
     >
       <span className="flex-1">{title}</span>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/sidebarKeys.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/sidebarKeys.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Helpers that build the opaque keys used by the Sidebar to track which
+ * pattern and use-case+scenario rows are currently expanded.
+ */
+
+export const makePatternKey = (patternName: string): string =>
+  `pattern:${patternName}`
+
+export const makeScenarioKey = (
+  patternName: string,
+  useCase: string,
+  scenario: string,
+): string => `pattern:${patternName}|usecase:${useCase}|scenario:${scenario}`

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticWorkflowsApi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticWorkflowsApi.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Thin client for the Lungo Agentic Workflows API catalog endpoints.
+ * Today only the workflow-summary listing is consumed; patterns and use-cases
+ * are derived client-side from the distinct values seen across summaries.
+ */
+
+import { env } from "@/utils/env"
+
+const DEFAULT_AGENTIC_WORKFLOWS_API_URL = "http://127.0.0.1:9105"
+
+export const getAgenticWorkflowsApiUrl = (): string => {
+  return (
+    env.get("VITE_AGENTIC_WORKFLOWS_API_URL") ||
+    DEFAULT_AGENTIC_WORKFLOWS_API_URL
+  )
+}
+
+/** One row of `GET /agentic-workflows/` (matches backend `WorkflowSummary`). */
+export interface WorkflowSummary {
+  name: string
+  pattern: string
+  use_case: string
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0
+
+const isWorkflowSummary = (value: unknown): value is WorkflowSummary => {
+  if (value === null || typeof value !== "object") return false
+  const obj = value as Record<string, unknown>
+  return (
+    isNonEmptyString(obj.name) &&
+    isNonEmptyString(obj.pattern) &&
+    isNonEmptyString(obj.use_case)
+  )
+}
+
+/**
+ * Fetch the workflow summaries from `GET /agentic-workflows/`.
+ *
+ * The backend responds with a map keyed by workflow name (`WorkflowSummaryMapResponse`).
+ * This helper flattens the map into an array, dropping any entries that do not
+ * match the expected shape so a single bad row cannot break the sidebar.
+ */
+export const fetchWorkflowSummaries = async (
+  signal?: AbortSignal,
+): Promise<WorkflowSummary[]> => {
+  const url = `${getAgenticWorkflowsApiUrl()}/agentic-workflows/`
+  const response = await fetch(url, { signal })
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch agentic workflows: HTTP ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const body: unknown = await response.json()
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(
+      "Failed to fetch agentic workflows: unexpected response shape",
+    )
+  }
+
+  const summaries: WorkflowSummary[] = []
+  for (const value of Object.values(body as Record<string, unknown>)) {
+    if (isWorkflowSummary(value)) {
+      summaries.push(value)
+    }
+  }
+  return summaries
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticWorkflowsApi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticWorkflowsApi.ts
@@ -23,6 +23,7 @@ export interface WorkflowSummary {
   name: string
   pattern: string
   use_case: string
+  scenario: string
 }
 
 const isNonEmptyString = (value: unknown): value is string =>
@@ -34,7 +35,8 @@ const isWorkflowSummary = (value: unknown): value is WorkflowSummary => {
   return (
     isNonEmptyString(obj.name) &&
     isNonEmptyString(obj.pattern) &&
-    isNonEmptyString(obj.use_case)
+    isNonEmptyString(obj.use_case) &&
+    isNonEmptyString(obj.scenario)
   )
 }
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/sidebarHierarchy.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/sidebarHierarchy.ts
@@ -41,18 +41,39 @@ export interface WorkflowNode {
   slug: PatternType | null
 }
 
-export interface UseCaseNode {
-  name: string
+export interface UseCaseScenarioNode {
+  useCase: string
+  scenario: string
+  /** Display label rendered as the middle row of the LHS menu. */
+  label: string
   workflows: WorkflowNode[]
 }
 
 export interface PatternNode {
   name: string
-  useCases: UseCaseNode[]
+  useCaseScenarios: UseCaseScenarioNode[]
+}
+
+/** Build the display label for the middle (use-case + scenario) row. */
+export const formatUseCaseScenarioLabel = (
+  useCase: string,
+  scenario: string,
+): string => `${useCase}: ${scenario}`
+
+/** Composite key used to group workflows that share both use-case and scenario. */
+const makeUseCaseScenarioGroupKey = (
+  useCase: string,
+  scenario: string,
+): string => `${useCase}|${scenario}`
+
+interface GroupBucket {
+  useCase: string
+  scenario: string
+  workflows: WorkflowNode[]
 }
 
 /**
- * Group workflow summaries into the `pattern -> use-case -> workflow` tree.
+ * Group workflow summaries into the `pattern -> (use-case + scenario) -> workflow` tree.
  *
  * Ordering is alphabetical at every level so the menu is stable regardless of
  * the order the API happens to return rows in. Workflow names without a known
@@ -62,20 +83,28 @@ export interface PatternNode {
 export const groupWorkflowsByPatternAndUseCase = (
   summaries: readonly WorkflowSummary[],
 ): PatternNode[] => {
-  const byPattern = new Map<string, Map<string, WorkflowNode[]>>()
+  const byPattern = new Map<string, Map<string, GroupBucket>>()
 
   for (const summary of summaries) {
-    let useCaseMap = byPattern.get(summary.pattern)
-    if (useCaseMap === undefined) {
-      useCaseMap = new Map<string, WorkflowNode[]>()
-      byPattern.set(summary.pattern, useCaseMap)
+    let scenarioMap = byPattern.get(summary.pattern)
+    if (scenarioMap === undefined) {
+      scenarioMap = new Map<string, GroupBucket>()
+      byPattern.set(summary.pattern, scenarioMap)
     }
-    let workflows = useCaseMap.get(summary.use_case)
-    if (workflows === undefined) {
-      workflows = []
-      useCaseMap.set(summary.use_case, workflows)
+    const groupKey = makeUseCaseScenarioGroupKey(
+      summary.use_case,
+      summary.scenario,
+    )
+    let bucket = scenarioMap.get(groupKey)
+    if (bucket === undefined) {
+      bucket = {
+        useCase: summary.use_case,
+        scenario: summary.scenario,
+        workflows: [],
+      }
+      scenarioMap.set(groupKey, bucket)
     }
-    workflows.push({
+    bucket.workflows.push({
       name: summary.name,
       slug: mapWorkflowNameToSlug(summary.name),
     })
@@ -85,18 +114,20 @@ export const groupWorkflowsByPatternAndUseCase = (
     a.localeCompare(b),
   )
   return sortedPatternNames.map((patternName) => {
-    const useCaseMap = byPattern.get(patternName)!
-    const sortedUseCaseNames = [...useCaseMap.keys()].sort((a, b) =>
-      a.localeCompare(b),
-    )
-    return {
-      name: patternName,
-      useCases: sortedUseCaseNames.map((useCaseName) => ({
-        name: useCaseName,
-        workflows: [...useCaseMap.get(useCaseName)!].sort((a, b) =>
+    const scenarioMap = byPattern.get(patternName)!
+    const useCaseScenarios: UseCaseScenarioNode[] = [...scenarioMap.values()]
+      .map((bucket) => ({
+        useCase: bucket.useCase,
+        scenario: bucket.scenario,
+        label: formatUseCaseScenarioLabel(bucket.useCase, bucket.scenario),
+        workflows: [...bucket.workflows].sort((a, b) =>
           a.name.localeCompare(b.name),
         ),
-      })),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+    return {
+      name: patternName,
+      useCaseScenarios,
     }
   })
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/sidebarHierarchy.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/sidebarHierarchy.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Helpers to turn a flat list of catalog `WorkflowSummary` rows into the
+ * `pattern -> use-case -> workflow` tree the LHS sidebar renders, plus the
+ * mapping from a catalog workflow name to the internal `PatternType` slug
+ * that the rest of the frontend (graph configs, API URLs, streaming, ...)
+ * keys off of.
+ */
+
+import type { WorkflowSummary } from "@/utils/agenticWorkflowsApi"
+import { PATTERNS, type PatternType } from "@/utils/patternUtils"
+
+/**
+ * Maps a workflow `name` returned by the catalog to the internal `PatternType`
+ * slug expected by downstream code (see `patternUtils.ts`, `graphConfigs.ts`).
+ *
+ * Workflows whose name is not present here render disabled in the sidebar so
+ * the user is not silently denied access to anything the API advertises.
+ *
+ * If/when the backend grows a `frontend_pattern_id` (or similar) field on the
+ * workflow summary, the right place to consume it is this file.
+ */
+export const WORKFLOW_NAME_TO_PATTERN_SLUG: Readonly<
+  Record<string, PatternType>
+> = {
+  "Publish Subscribe Coffee Farm Network": PATTERNS.PUBLISH_SUBSCRIBE,
+  "Publish Subscribe Streaming Coffee Auction Network":
+    PATTERNS.PUBLISH_SUBSCRIBE_STREAMING,
+  "Secure Group Communication Logistics Network": PATTERNS.GROUP_COMMUNICATION,
+  "On-demand Discovery": PATTERNS.ON_DEMAND_DISCOVERY,
+}
+
+export const mapWorkflowNameToSlug = (name: string): PatternType | null => {
+  return WORKFLOW_NAME_TO_PATTERN_SLUG[name] ?? null
+}
+
+export interface WorkflowNode {
+  name: string
+  slug: PatternType | null
+}
+
+export interface UseCaseNode {
+  name: string
+  workflows: WorkflowNode[]
+}
+
+export interface PatternNode {
+  name: string
+  useCases: UseCaseNode[]
+}
+
+/**
+ * Group workflow summaries into the `pattern -> use-case -> workflow` tree.
+ *
+ * Ordering is alphabetical at every level so the menu is stable regardless of
+ * the order the API happens to return rows in. Workflow names without a known
+ * slug are kept in the tree (with `slug: null`) so the sidebar can render
+ * them disabled.
+ */
+export const groupWorkflowsByPatternAndUseCase = (
+  summaries: readonly WorkflowSummary[],
+): PatternNode[] => {
+  const byPattern = new Map<string, Map<string, WorkflowNode[]>>()
+
+  for (const summary of summaries) {
+    let useCaseMap = byPattern.get(summary.pattern)
+    if (useCaseMap === undefined) {
+      useCaseMap = new Map<string, WorkflowNode[]>()
+      byPattern.set(summary.pattern, useCaseMap)
+    }
+    let workflows = useCaseMap.get(summary.use_case)
+    if (workflows === undefined) {
+      workflows = []
+      useCaseMap.set(summary.use_case, workflows)
+    }
+    workflows.push({
+      name: summary.name,
+      slug: mapWorkflowNameToSlug(summary.name),
+    })
+  }
+
+  const sortedPatternNames = [...byPattern.keys()].sort((a, b) =>
+    a.localeCompare(b),
+  )
+  return sortedPatternNames.map((patternName) => {
+    const useCaseMap = byPattern.get(patternName)!
+    const sortedUseCaseNames = [...useCaseMap.keys()].sort((a, b) =>
+      a.localeCompare(b),
+    )
+    return {
+      name: patternName,
+      useCases: sortedUseCaseNames.map((useCaseName) => ({
+        name: useCaseName,
+        workflows: [...useCaseMap.get(useCaseName)!].sort((a, b) =>
+          a.name.localeCompare(b.name),
+        ),
+      })),
+    }
+  })
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/sidebarHierarchy.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/sidebarHierarchy.ts
@@ -66,7 +66,12 @@ const makeUseCaseScenarioGroupKey = (
   scenario: string,
 ): string => `${useCase}|${scenario}`
 
-interface GroupBucket {
+/**
+ * Internal accumulator used while grouping workflow rows by their
+ * `(use_case, scenario)` composite key. One bucket holds all the workflows
+ * that share that pair within a given pattern.
+ */
+interface UseCaseScenarioBucket {
   useCase: string
   scenario: string
   workflows: WorkflowNode[]
@@ -83,12 +88,12 @@ interface GroupBucket {
 export const groupWorkflowsByPatternAndUseCase = (
   summaries: readonly WorkflowSummary[],
 ): PatternNode[] => {
-  const byPattern = new Map<string, Map<string, GroupBucket>>()
+  const byPattern = new Map<string, Map<string, UseCaseScenarioBucket>>()
 
   for (const summary of summaries) {
     let scenarioMap = byPattern.get(summary.pattern)
     if (scenarioMap === undefined) {
-      scenarioMap = new Map<string, GroupBucket>()
+      scenarioMap = new Map<string, UseCaseScenarioBucket>()
       byPattern.set(summary.pattern, scenarioMap)
     }
     const groupKey = makeUseCaseScenarioGroupKey(

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/event_v1.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/event_v1.json
@@ -275,11 +275,12 @@
     "workflow": {
       "type": "object",
       "description": "Workflow data, describing common configuration for a specific workflow, and keep track of instances of that workflow.",
-      "required": ["pattern", "use_case", "name", "starting_topology", "instances"],
+      "required": ["name", "pattern", "use_case", "scenario", "starting_topology", "instances"],
       "properties": {
+        "name": { "type": "string", "minLength": 1 },
         "pattern": { "type": "string", "minLength": 1 },
         "use_case": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
+        "scenario": { "type": "string", "minLength": 1, "description": "brief extra qualifier for the use-case" },
         "starting_topology": { "$ref": "#/$defs/topology" },
         "instances": {
           "type": "object",

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_full.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_full.json
@@ -13,9 +13,10 @@
   "data": {
     "workflows": {
       "recruiter": {
+        "name": "Recruiter",
         "pattern": "recruiter_pattern",
         "use_case": "hiring",
-        "name": "Recruiter",
+        "scenario": "agent recruitment",
         "starting_topology": {
           "nodes": [
             {

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_partial.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas/examples/event_v1_partial.json
@@ -12,9 +12,10 @@
   "data": {
     "workflows": {
       "recruiter": {
+        "name": "Recruiter",
         "pattern": "recruiter_pattern",
         "use_case": "hiring",
-        "name": "Recruiter",
+        "scenario": "agent recruitment",
         "starting_topology": {
           "nodes": [
             {

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/openapi/components/schemas.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/openapi/components/schemas.yaml
@@ -66,7 +66,7 @@ components:
 
     WorkflowSummary:
       type: object
-      required: [name, pattern, use_case]
+      required: [name, pattern, use_case, scenario]
       additionalProperties: false
       properties:
         name:
@@ -76,6 +76,9 @@ components:
           type: string
           minLength: 1
         use_case:
+          type: string
+          minLength: 1
+        scenario:
           type: string
           minLength: 1
 

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/types/event.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/types/event.py
@@ -473,9 +473,10 @@ class Workflow(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    name: Annotated[str, Field(min_length=1)]
     pattern: Annotated[str, Field(min_length=1)]
     use_case: Annotated[str, Field(min_length=1)]
-    name: Annotated[str, Field(min_length=1)]
+    scenario: Annotated[str, Field(min_length=1, description="brief extra qualifier for the use-case")]
     starting_topology: Topology
     instances: dict[
         Annotated[str, Field(pattern=_INSTANCE_ID_REGEX)], WorkflowInstance

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/agentic_uvicorn_helpers.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/agentic_uvicorn_helpers.py
@@ -82,6 +82,7 @@ def minimal_event_v1_dict(
     *,
     pattern: str = "p",
     use_case: str = "u",
+    scenario: str = "s",
     workflow_display_name: str | None = None,
 ) -> dict:
     """Wire-shape ``event_v1`` for POST .../events/ (defaults match legacy SSE HTTP test)."""
@@ -98,9 +99,10 @@ def minimal_event_v1_dict(
         "data": {
             "workflows": {
                 workflow_name: {
+                    "name": name,
                     "pattern": pattern,
                     "use_case": use_case,
-                    "name": name,
+                    "scenario": scenario,
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         instance_uri: {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_endpoints.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_endpoints.py
@@ -21,6 +21,7 @@ _FAKE_WORKFLOWS: dict[str, Workflow] = {
             {
                 "pattern": "publish_subscribe",
                 "use_case": "Coffee Buying",
+                "scenario": "Pub Sub Coffee scenario",
                 "name": "Pub Sub Coffee",
                 "starting_topology": {
                     "nodes": [
@@ -42,6 +43,7 @@ _FAKE_WORKFLOWS: dict[str, Workflow] = {
             {
                 "pattern": "group_communication",
                 "use_case": "Order Fulfilment",
+                "scenario": "Group Logistics scenario",
                 "name": "Group Logistics",
                 "starting_topology": {
                     "nodes": [
@@ -63,6 +65,7 @@ _FAKE_WORKFLOWS: dict[str, Workflow] = {
             {
                 "pattern": "publish_subscribe",
                 "use_case": "Order Fulfilment",
+                "scenario": "Pub Sub Orders scenario",
                 "name": "Pub Sub Orders",
                 "starting_topology": {
                     "nodes": [
@@ -176,7 +179,7 @@ def test_list_agentic_workflows(case: ListCase, client: TestClient) -> None:
 
     for name, summary in data.items():
         assert summary["name"] == name
-        assert set(summary.keys()) == {"name", "pattern", "use_case"}
+        assert set(summary.keys()) == {"name", "pattern", "use_case", "scenario"}
 
 
 # ---------------------------------------------------------------------------

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_instance_events_sse.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_instance_events_sse.py
@@ -36,9 +36,10 @@ def _event_dict(workflow_name: str, instance_uri: str, event_id: str) -> dict:
         "data": {
             "workflows": {
                 workflow_name: {
+                    "name": workflow_name,
                     "pattern": "p",
                     "use_case": "u",
-                    "name": workflow_name,
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         instance_uri: {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_instance_state_endpoints.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_instance_state_endpoints.py
@@ -29,9 +29,10 @@ _PATCH_GET_WORKFLOWS = "api.agentic_workflows.router.get_workflows"
 _MINIMAL_WORKFLOWS: dict[str, Workflow] = {
     "InstTestWf": Workflow.model_validate(
         {
+            "name": "InstTestWf",
             "pattern": "test_pattern",
             "use_case": "test_uc",
-            "name": "InstTestWf",
+            "scenario": "test_scenario",
             "starting_topology": {
                 "nodes": [
                     {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/api/test_agentic_workflows_router_paths.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/api/test_agentic_workflows_router_paths.py
@@ -25,9 +25,10 @@ _BARE_UUID_PATH = "/agentic-workflows/W/instances/550e8400-e29b-41d4-a716-446655
 
 _WF_W = Workflow.model_validate(
     {
+        "name": "W",
         "pattern": "p",
         "use_case": "u",
-        "name": "W",
+        "scenario": "s",
         "starting_topology": {
             "nodes": [
                 {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_event_v1_examples.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_event_v1_examples.py
@@ -66,9 +66,10 @@ def test_chain_partial_then_delta() -> None:
             "data": {
                 "workflows": {
                     "recruiter": {
+                        "name": "Recruiter",
                         "pattern": "recruiter_pattern",
                         "use_case": "hiring",
-                        "name": "Recruiter",
+                        "scenario": "agent recruitment",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             "instance://550e8400-e29b-41d4-a716-446655440003": {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_merge.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_merge.py
@@ -39,9 +39,10 @@ def test_first_event_establishes_workflow_and_instance():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {"id": INST, "topology": {}},
@@ -67,9 +68,10 @@ def test_update_merges_fields_not_full_replace():
             {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             INST: {
@@ -98,9 +100,10 @@ def test_update_merges_fields_not_full_replace():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -133,9 +136,10 @@ def test_read_does_not_overwrite_existing_node():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -163,9 +167,10 @@ def test_read_does_not_overwrite_existing_node():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -203,9 +208,10 @@ def test_read_creates_node_when_absent():
             {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             INST: {"id": INST, "topology": {"nodes": [], "edges": []}},
@@ -219,9 +225,10 @@ def test_read_creates_node_when_absent():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -256,9 +263,10 @@ def test_topology_nodes_preserve_insertion_order_not_sorted_ids():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -305,9 +313,10 @@ def test_delete_idempotent():
             {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             INST: {
@@ -335,9 +344,10 @@ def test_delete_idempotent():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -364,9 +374,10 @@ def test_update_missing_node_is_noop():
             {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             INST: {"id": INST, "topology": {"nodes": [], "edges": []}},
@@ -380,9 +391,10 @@ def test_update_missing_node_is_noop():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -411,18 +423,20 @@ def test_two_workflow_keys_coexist():
         {
             "workflows": {
                 "w1": {
+                    "name": "n1",
                     "pattern": "p1",
                     "use_case": "u1",
-                    "name": "n1",
+                    "scenario": "s1",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {"id": INST, "topology": {}},
                     },
                 },
                 "w2": {
+                    "name": "n2",
                     "pattern": "p2",
                     "use_case": "u2",
-                    "name": "n2",
+                    "scenario": "s2",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {"id": INST, "topology": {}},
@@ -440,9 +454,10 @@ def test_starting_topology_preserved_when_followup_omits():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {
                         "nodes": [
                             {
@@ -468,9 +483,10 @@ def test_starting_topology_preserved_when_followup_omits():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {"id": INST, "topology": {}},
@@ -490,9 +506,10 @@ def test_node_delete_leaves_dangling_edge():
             {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             INST: {
@@ -539,9 +556,10 @@ def test_node_delete_leaves_dangling_edge():
         {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         INST: {
@@ -612,9 +630,10 @@ def test_merge_empty_workflows_preserves_existing_workflows_and_merges_extra():
             {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {INST: {"id": INST, "topology": {}}},
                     }

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_store.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_store.py
@@ -37,9 +37,10 @@ def _minimal_valid_event() -> dict:
         "data": {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         _INSTANCE_KEY: {
@@ -142,9 +143,10 @@ def test_notifier_fanout_two_instances():
             "data": {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             _INSTANCE_KEY: {
@@ -192,9 +194,10 @@ def test_subscribe_invoked_for_touching_instance_only():
             "data": {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             other: {"id": other, "topology": {}},
@@ -232,9 +235,10 @@ async def test_concurrent_submit_serializes_merges():
             "data": {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             _INSTANCE_KEY: {
@@ -273,9 +277,10 @@ async def test_concurrent_submit_serializes_merges():
                 "data": {
                     "workflows": {
                         "w": {
+                            "name": "n",
                             "pattern": "p",
                             "use_case": "u",
-                            "name": "n",
+                            "scenario": "s",
                             "starting_topology": {"nodes": [], "edges": []},
                             "instances": {
                                 _INSTANCE_KEY: {
@@ -326,9 +331,10 @@ def test_concurrent_sync_submits_fifo_merge_order():
             "data": {
                 "workflows": {
                     "w": {
+                        "name": "n",
                         "pattern": "p",
                         "use_case": "u",
-                        "name": "n",
+                        "scenario": "s",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             _INSTANCE_KEY: {
@@ -370,9 +376,10 @@ def test_concurrent_sync_submits_fifo_merge_order():
                 "data": {
                     "workflows": {
                         "w": {
+                            "name": "n",
                             "pattern": "p",
                             "use_case": "u",
-                            "name": "n",
+                            "scenario": "s",
                             "starting_topology": {"nodes": [], "edges": []},
                             "instances": {
                                 _INSTANCE_KEY: {
@@ -451,9 +458,10 @@ def test_slow_notifier_does_not_block_merge():
             "data": {
                 "workflows": {
                     "w": {
+                        "name": "n2",
                         "pattern": "p2",
                         "use_case": "u2",
-                        "name": "n2",
+                        "scenario": "s2",
                         "starting_topology": {"nodes": [], "edges": []},
                         "instances": {
                             _INSTANCE_KEY: {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_event_v1_instances.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_event_v1_instances.py
@@ -32,9 +32,10 @@ _VALID_MINIMAL = {
     "data": {
         "workflows": {
             "w": {
+                "name": "n",
                 "pattern": "p",
                 "use_case": "u",
-                "name": "n",
+                "scenario": "s",
                 "starting_topology": {"nodes": [], "edges": []},
                 "instances": {
                     _INSTANCE_KEY: {
@@ -99,8 +100,9 @@ def test_event_v1_valid_instances(source: str):
                 "data": {
                     "workflows": {
                         "w": {
-                            "use_case": "u",
                             "name": "n",
+                            "use_case": "u",
+                            "scenario": "s",
                             "starting_topology": {"nodes": [], "edges": []},
                             "instances": {
                                 _INSTANCE_KEY: {
@@ -129,9 +131,10 @@ def test_instance_map_key_must_match_workflow_instance_id():
         "data": {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         "instance://00000000-0000-4000-8000-000000000001": {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_json_schema.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_json_schema.py
@@ -375,9 +375,10 @@ def test_validate_json_instance_event_type_v1_corrupt_raises_schema_definition_e
         "data": {
             "workflows": {
                 "w": {
+                    "name": "n",
                     "pattern": "p",
                     "use_case": "u",
-                    "name": "n",
+                    "scenario": "s",
                     "starting_topology": {"nodes": [], "edges": []},
                     "instances": {
                         "instance://550e8400-e29b-41d4-a716-446655440003": {

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_validate_cli.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_validate_cli.py
@@ -17,7 +17,7 @@ _VALID_INSTANCE = (
     '{"metadata":{"timestamp":"2026-01-01T00:00:00Z","schema_version":"1.0.0",'
     '"correlation":{"id":"correlation://550e8400-e29b-41d4-a716-446655440001"},'
     '"id":"event://550e8400-e29b-41d4-a716-446655440002","type":"RecruiterNodeSearch",'
-    '"source":"cli"},"data":{"workflows":{"w":{"pattern":"p","use_case":"u","name":"n",'
+    '"source":"cli"},"data":{"workflows":{"w":{"name":"n","pattern":"p","use_case":"u","scenario":"s",'
     '"starting_topology":{"nodes":[],"edges":[]},'
     '"instances":{"instance://550e8400-e29b-41d4-a716-446655440003":{"id":"instance://550e8400-e29b-41d4-a716-446655440003","topology":{}}}}}}}'
 )

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_validation.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/schemas/test_validation.py
@@ -29,7 +29,7 @@ _VALID_JSON = (
     '{"metadata":{"timestamp":"2026-01-01T00:00:00Z","schema_version":"1.0.0",'
     '"correlation":{"id":"correlation://550e8400-e29b-41d4-a716-446655440001"},'
     '"id":"event://550e8400-e29b-41d4-a716-446655440002","type":"RecruiterNodeSearch",'
-    '"source":"test"},"data":{"workflows":{"w":{"pattern":"p","use_case":"u","name":"n",'
+    '"source":"test"},"data":{"workflows":{"w":{"name":"n","pattern":"p","use_case":"u","scenario":"s",'
     '"starting_topology":{"nodes":[],"edges":[]},'
     '"instances":{"instance://550e8400-e29b-41d4-a716-446655440003":{"id":"instance://550e8400-e29b-41d4-a716-446655440003","topology":{}}}}}}}'
 )


### PR DESCRIPTION
# Description

This PR aims to update the left hand side menu on the Lungo frontend to retrieve the data from the agentic workflow menu's catalog API endpoints to describe the patterns and workflows.

In order to dynamically construct the menu from the backend information we only need the `/agentic-workflows/` endpoint which gives us a summary of the existing workflows.  
In OpenAPI spec terms that is a:
```yaml
    WorkflowSummary:
      type: object
      required: [name, pattern, use_case, scenario]
      additionalProperties: false
      properties:
        name:
          type: string
          minLength: 1
        pattern:
          type: string
          minLength: 1
        use_case:
          type: string
          minLength: 1
        scenario:
          type: string
          minLength: 1
```
The `scenario` key is newly added in this PR (to relevant schemas, examples, code and tests) in order to preserve some bits of information from the former UI that weren't present yet in our schemas, namely the indications about the purpose of an instance of a use-case (previously found after the "Conversation: ..." title in the UI) like "Order Fulfilment", "Coffee Buying", "Capability Discovery".

The frontend code now reconstructs from the received map of workflows the structure of the menu based on groupings of `pattern`s and of `use-case`+`scenario` composites.

That means it would now look like this:
<img width="1498" height="822" alt="new screenshot" src="https://github.com/user-attachments/assets/f88d27c0-0f5b-4ea3-98b9-bcf0589721c0" />

If the `/agentic-workflows/` "summary" API is not available/not answering then (on Misi's general suggestion) we display this:
<img width="340" height="198" alt="Screenshot 2026-05-08 at 12 21 29" src="https://github.com/user-attachments/assets/ea138552-220f-4d6b-afb5-254b9dbc8260" />


Previoulsy it looked like this (statically defined in the frontend code):
<img width="1498" height="822" alt="old screenshot" src="https://github.com/user-attachments/assets/eb0306d5-e534-4a6d-a69f-31eaacd893d4" />


In this PR, I also reordered the fields in the `workflow` schema and resulting structs and uses to have "name" at the top, as opposed to "pattern". It felt more natural to read that way. 
Later edit:  it looks like I will have to revert this particular bit in a later PR. Not doing it now because it will affect some rebases others have made.



## Issue Link

#540 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
