### PR TITLE
fix(lungo): add scenario field to event stream metadata

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/common/a2a_event_middleware/middleware.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/a2a_event_middleware/middleware.py
@@ -253,6 +253,7 @@ def _build_event(
 				metadata.workflow_name: Workflow(
 					pattern=metadata.pattern or metadata.workflow_name,
 					use_case=metadata.use_case,
+					scenario=metadata.scenario,
 					name=metadata.workflow_name,
 					starting_topology=_init_starting_topology(),
 					instances={
@@ -475,10 +476,11 @@ class EventEmittingInterceptor(ClientCallInterceptor):
 		workflow_name = metadata.workflow_name
 		instance_id = propagated_instance_id
 		logger.debug(
-			"workflow_name=%s pattern=%s use_case=%s tool=%s",
+			"workflow_name=%s pattern=%s use_case=%s scenario=%s tool=%s",
 			workflow_name,
 			metadata.pattern,
 			metadata.use_case,
+			metadata.scenario,
 			ctx_state.get("tool", "unknown"),
 		)
 

--- a/coffeeAGNTCY/coffee_agents/lungo/common/a2a_event_middleware/workflow_catalog.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/a2a_event_middleware/workflow_catalog.py
@@ -28,6 +28,7 @@ class WorkflowMetadata:
 	workflow_name: str
 	pattern: str
 	use_case: str
+	scenario: str
 
 
 _DEFAULT_WORKFLOWS_JSON = (
@@ -68,13 +69,15 @@ def _load_catalog() -> dict[str, WorkflowMetadata]:
 		name = entry.get("name")
 		pattern = entry.get("pattern")
 		use_case = entry.get("use_case")
+		scenario = entry.get("scenario")
 		if not (
 			isinstance(name, str)
 			and isinstance(pattern, str)
 			and isinstance(use_case, str)
+			and isinstance(scenario, str)
 		):
 			logger.warning(
-				"Skipping workflow at index %d: missing name/pattern/use_case",
+				"Skipping workflow at index %d: missing name/pattern/use_case/scenario",
 				idx,
 			)
 			continue
@@ -88,6 +91,7 @@ def _load_catalog() -> dict[str, WorkflowMetadata]:
 			workflow_name=name,
 			pattern=pattern,
 			use_case=use_case,
+			scenario=scenario,
 		)
 
 	if not catalog:

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/conftest.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/conftest.py
@@ -77,11 +77,13 @@ def _test_workflows_catalog(request, tmp_path_factory, monkeypatch) -> Iterator[
             "name": "Test Workflow Alpha",
             "pattern": "Supervisor-worker",
             "use_case": "Unit Test",
+            "scenario": "Alpha Scenario",
         },
         {
             "name": "Test Workflow Beta",
             "pattern": "Group-chat",
             "use_case": "Unit Test",
+            "scenario": "Beta Scenario",
         },
     ]))
     monkeypatch.setenv("LUNGO_WORKFLOWS_JSON", str(path))

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_workflow_catalog.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_workflow_catalog.py
@@ -28,6 +28,7 @@ class TestLookupWorkflow:
         assert wf.workflow_name == "Test Workflow Alpha"
         assert wf.pattern == "Supervisor-worker"
         assert wf.use_case == "Unit Test"
+        assert wf.scenario == "Alpha Scenario"
 
     def test_returns_none_for_unknown_name(self):
         assert wc.lookup_workflow("Nonexistent") is None
@@ -54,6 +55,7 @@ class TestLookupWorkflow:
                 "name": "Good Workflow",
                 "pattern": "Supervisor-worker",
                 "use_case": "Unit Test",
+                "scenario": "Good Scenario",
             },
         ]))
         monkeypatch.setenv("LUNGO_WORKFLOWS_JSON", str(path))


### PR DESCRIPTION
# Description

This PR aims to quickly address the errors in https://github.com/agntcy/coffeeAgntcy/actions/runs/25661065937/job/75353658488.

They are centered around missing the `scenario` field of a `Workflow` (introduced in https://github.com/agntcy/coffeeAgntcy/pull/549).  
Example command output (from just one test):
```bash
cd coffeeAGNTCY/coffee_agents/lungo
uv run pytest -v tests/unit/common/test_a2a_event_middleware.py -k TestBaggageCarrier
```
```
tests/unit/common/test_a2a_event_middleware.py:665:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
common/a2a_event_middleware/middleware.py:530: in intercept
    event = _build_event(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def _build_event(
    	*,
    	source: str,
    	workflow_name: str,
    	instance_id: str,
    	topology: PartialTopology,
    	correlation_id: str,
    	event_type: EventType = EventType.STATE_PROGRESS_UPDATE,
    	correlation_message: str | None = None,
    	trace_id: int | None = None,
    	span_id: int | None = None,
    ) -> Event:
    	"""Build an Event for one workflow-instance topology update.

    	Looks up descriptive metadata (pattern + use_case) from the catalog at
    	emission time so callers only need to carry the workflow name.
    	"""
    	metadata = lookup_workflow(workflow_name)
    	if metadata is None:
    		# This should never happen in practice — intercept() validates the
    		# name against the catalog before storing in-flight state. Log loudly
    		# so we don't silently emit malformed events if invariants slip.
    		raise RuntimeError(
    			f"_build_event: workflow_name {workflow_name!r} not in catalog; "
    			"intercept() should have rejected this earlier."
    		)
    	return Event(
    		metadata=_build_metadata(
    			source=source,
    			event_type=event_type,
    			correlation_id=correlation_id,
    			correlation_message=correlation_message,
    			trace_id=trace_id,
    			span_id=span_id,
    		),
    		data=Data(
    			workflows={
>   				metadata.workflow_name: Workflow(
    					pattern=metadata.pattern or metadata.workflow_name,
    					use_case=metadata.use_case,
    					name=metadata.workflow_name,
    					starting_topology=_init_starting_topology(),
    					instances={
    						instance_id: WorkflowInstance(
    							id=InstanceId(instance_id),
    							topology=topology,
    						)
    					},
    				)
    			}
    		),
    	)
E    pydantic_core._pydantic_core.ValidationError: 1 validation error for Workflow
E    scenario
E      Field required [type=missing, input_value={'pattern': 'Group-chat',...=False, weight=1.0)]))}}, input_type=dict]
E        For further information visit https://errors.pydantic.dev/2.12/v/missing

common/a2a_event_middleware/middleware.py:253: ValidationError
```


## Issue Link

Didn't open one.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
