### PR TITLE
feat(fe,graph): dynamic animations from live workflow events

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/main.py
@@ -80,6 +80,7 @@ app.include_router(create_apps_router())
 
 class PromptRequest(BaseModel):
   prompt: str
+  workflow_instance_id: str | None = None
 
 @app.get("/.well-known/agent.json")
 async def get_capabilities():
@@ -139,7 +140,10 @@ async def handle_prompt(request: PromptRequest, req: Request):
   try:
     with session_start() as session_id:
       # Execute the graph synchronously - blocks until completion
-      result = await exchange_graph.serve(request.prompt)
+      result = await exchange_graph.serve(
+        request.prompt,
+        workflow_instance_id=request.workflow_instance_id,
+      )
       logger.info(f"Final result from LangGraph: {result}")
       return {"response": result, "session_id": session_id["executionID"]}
   except ValueError as ve:
@@ -179,7 +183,10 @@ async def handle_stream_prompt(request: PromptRequest, req: Request):
               """
               try:
                   # Stream chunks from the graph as nodes complete execution
-                  async for chunk in exchange_graph.streaming_serve(request.prompt):
+                  async for chunk in exchange_graph.streaming_serve(
+                      request.prompt,
+                      workflow_instance_id=request.workflow_instance_id,
+                  ):
                       yield json.dumps({"response": chunk, "session_id": session_id["executionID"]}) + "\n"
               except Exception as e:
                   logger.error(f"Error in stream: {e}")

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/main.py
@@ -75,6 +75,7 @@ app.add_middleware(
 
 class PromptRequest(BaseModel):
   prompt: str
+  workflow_instance_id: str | None = None
 
 @app.post("/agent/prompt")
 async def handle_prompt(request: PromptRequest, req: Request):
@@ -85,7 +86,7 @@ async def handle_prompt(request: PromptRequest, req: Request):
     with session_start() as session_id:
       timeout_val = int(os.getenv("LOGISTIC_TIMEOUT", "200"))
       result = await asyncio.wait_for(
-        logistic_graph.serve(request.prompt),
+        logistic_graph.serve(request.prompt, workflow_instance_id=request.workflow_instance_id),
         timeout=timeout_val
       )
       logger.info(f"Final result from LangGraph: {result}")
@@ -168,7 +169,7 @@ async def handle_stream_prompt(request: PromptRequest, req: Request):
 
           async def stream_generator():
               try:
-                  async for chunk in logistic_graph.streaming_serve(request.prompt):
+                  async for chunk in logistic_graph.streaming_serve(request.prompt, workflow_instance_id=request.workflow_instance_id):
                       yield json.dumps({"response": chunk, "session_id": session_id["executionID"]}) + "\n"
               except Exception as e:
                   logger.error(f"Error in stream: {e}")

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/recruiter/main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/recruiter/main.py
@@ -85,6 +85,7 @@ app.add_middleware(
 class PromptRequest(BaseModel):
     prompt: str
     session_id: Optional[str] = None
+    workflow_instance_id: Optional[str] = None
 
 
 @app.post("/agent/prompt")
@@ -100,6 +101,7 @@ async def handle_prompt(request: PromptRequest, req: Request):
         result = await agent_module.call_agent(
             query=request.prompt,
             session_id=session_id,
+            workflow_instance_id=request.workflow_instance_id,
         )
         # Build response matching original API format
         response: dict = {
@@ -153,6 +155,7 @@ async def handle_stream_prompt(request: PromptRequest, req: Request):
                         async for event, sid in agent_module.stream_agent(
                             query=request.prompt,
                             session_id=session_id,
+                            workflow_instance_id=request.workflow_instance_id,
                         ):
                             final_sid = sid
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/starting_workflows.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/starting_workflows.json
@@ -13,6 +13,7 @@
           "label": "Auction Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 0,
+          "position": { "x": 527.13, "y": 76.48 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json"
         },
         {
@@ -21,7 +22,8 @@
           "type": "transportNode",
           "label": "Transport",
           "size": { "width": 1.0, "height": 1.0 },
-          "layer_index": 1
+          "layer_index": 1,
+          "position": { "x": 229.02, "y": 284.69 }
         },
         {
           "id": "node://1a000001-0001-4000-a001-000000000003",
@@ -30,6 +32,7 @@
           "label": "Brazil Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 2,
+          "position": { "x": 232.09, "y": 503.93 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json"
         },
         {
@@ -39,6 +42,7 @@
           "label": "Colombia Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 2,
+          "position": { "x": 521.27, "y": 505.39 },
           "agent_record_uri": "https://raw.githubusercontent.com/agntcy/coffeeAgntcy/refs/heads/main/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/colombia-coffee-farm.json"
         },
         {
@@ -48,6 +52,7 @@
           "label": "Vietnam Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 2,
+          "position": { "x": 832.98, "y": 505.08 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json"
         },
         {
@@ -57,6 +62,7 @@
           "label": "Weather MCP Server",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 3,
+          "position": { "x": 371.27, "y": 731.91 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/weather-mcp-server.json"
         },
         {
@@ -66,6 +72,7 @@
           "label": "Payment MCP Server",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 3,
+          "position": { "x": 671.27, "y": 731.91 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/payment-mcp-server.json"
         }
       ],
@@ -142,6 +149,7 @@
           "label": "Auction Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 0,
+          "position": { "x": 527.13, "y": 76.48 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json"
         },
         {
@@ -150,7 +158,8 @@
           "type": "transportNode",
           "label": "Transport",
           "size": { "width": 1.0, "height": 1.0 },
-          "layer_index": 1
+          "layer_index": 1,
+          "position": { "x": 229.02, "y": 284.69 }
         },
         {
           "id": "node://2a000001-0001-4000-a001-000000000003",
@@ -159,6 +168,7 @@
           "label": "Brazil Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 2,
+          "position": { "x": 232.09, "y": 503.93 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json"
         },
         {
@@ -168,6 +178,7 @@
           "label": "Colombia Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 2,
+          "position": { "x": 521.27, "y": 505.39 },
           "agent_record_uri": "https://raw.githubusercontent.com/agntcy/coffeeAgntcy/refs/heads/main/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/colombia-coffee-farm.json"
         },
         {
@@ -177,6 +188,7 @@
           "label": "Vietnam Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 2,
+          "position": { "x": 832.98, "y": 505.08 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json"
         },
         {
@@ -186,6 +198,7 @@
           "label": "Weather MCP Server",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 3,
+          "position": { "x": 371.27, "y": 731.91 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/weather-mcp-server.json"
         },
         {
@@ -195,6 +208,7 @@
           "label": "Payment MCP Server",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 3,
+          "position": { "x": 671.27, "y": 731.91 },
           "agent_record_uri": "../../agents/supervisors/auction/oasf/agents/payment-mcp-server.json"
         }
       ],
@@ -270,7 +284,8 @@
           "type": "group",
           "label": "Logistics Group",
           "size": { "width": 3.0, "height": 2.0 },
-          "layer_index": 0
+          "layer_index": 0,
+          "position": { "x": 50, "y": 50 }
         },
         {
           "id": "node://3a000001-0001-4000-a001-000000000002",
@@ -279,6 +294,7 @@
           "label": "Buyer Logistics Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 1,
+          "position": { "x": 150, "y": 100 },
           "agent_record_uri": "../../agents/supervisors/logistics/oasf/agents/logistics-supervisor-agent.json"
         },
         {
@@ -287,7 +303,8 @@
           "type": "transportNode",
           "label": "Transport",
           "size": { "width": 1.0, "height": 1.0 },
-          "layer_index": 2
+          "layer_index": 2,
+          "position": { "x": 380, "y": 270 }
         },
         {
           "id": "node://3a000001-0001-4000-a001-000000000004",
@@ -296,6 +313,7 @@
           "label": "Tatooine Coffee Farm Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 1,
+          "position": { "x": 550, "y": 100 },
           "agent_record_uri": "../../agents/supervisors/logistics/oasf/agents/tatooine-farm-agent.json"
         },
         {
@@ -305,6 +323,7 @@
           "label": "Shipper Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 3,
+          "position": { "x": 150, "y": 500 },
           "agent_record_uri": "../../agents/supervisors/logistics/oasf/agents/shipping-agent.json"
         },
         {
@@ -314,6 +333,7 @@
           "label": "Accountant Agent",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 3,
+          "position": { "x": 500, "y": 500 },
           "agent_record_uri": "../../agents/supervisors/logistics/oasf/agents/accountant-agent.json"
         }
       ],
@@ -372,6 +392,7 @@
           "label": "Agentic Recruiter",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 0,
+          "position": { "x": 400, "y": 300 },
           "agent_record_uri": "../../agents/supervisors/recruiter/oasf/agents/recruiter.json"
         },
         {
@@ -380,7 +401,8 @@
           "type": "customNode",
           "label": "AGNTCY Agent Directory",
           "size": { "width": 1.0, "height": 1.0 },
-          "layer_index": 1
+          "layer_index": 1,
+          "position": { "x": 800, "y": 100 }
         }
       ],
       "edges": [

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflows.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflows.py
@@ -13,11 +13,12 @@ import json
 import logging
 from pathlib import Path
 from threading import Lock
-from uuid import NAMESPACE_DNS, uuid4, uuid5
+from uuid import uuid4
 
 import httpx
 from pydantic import ValidationError
 
+from common.stable_agent_id import stable_agent_uuid_for_name
 from schema.types import (
     AgentNode,
     Edge,
@@ -37,11 +38,6 @@ logger = logging.getLogger(__name__)
 
 _DATA_DIR = Path(__file__).resolve().parent
 _STARTING_WORKFLOWS_FILE = _DATA_DIR / "starting_workflows.json"
-
-# Namespace used to derive deterministic stable agent ids (uuid5) from agent record
-# names. Built once at import time as uuid5(NAMESPACE_DNS, <dns-like label>) so that
-# the same agent name always maps to the same stable id across runs and processes.
-_STABLE_AGENT_ID_NAMESPACE = uuid5(NAMESPACE_DNS, "agent.workflow.lungo.coffeeAGNTCY.com")
 
 # Mapping of workflow name to validated Workflow model.
 _STARTING_WORKFLOWS: dict[str, Workflow] | None = None
@@ -219,8 +215,9 @@ def _load_and_validate_starting_workflows_from_file(target: Path) -> dict[str, W
                     # in the future these should become grounds for invalidating the workflow entirely.
                     try:
                         record = _load_agent_record_from_uri(node.agent_record_uri, base_path=target.parent)
-                        stable_agent_uuid = uuid5(_STABLE_AGENT_ID_NAMESPACE, record["name"])
-                        node.stable_agent_id = stable_agent_id_from_uuid(stable_agent_uuid)
+                        node.stable_agent_id = stable_agent_id_from_uuid(
+                            stable_agent_uuid_for_name(record["name"])
+                        )
                     # FileNotFoundError is a subclass of OSError.
                     except (FileNotFoundError, httpx.RequestError) as exc:
                         logger.warning("Failed to load agent record for node at index %d (id %s) in workflow at index %d (name %s) but will use the workflow anyhow: %s",

--- a/coffeeAGNTCY/coffee_agents/lungo/common/a2a_event_middleware/middleware.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/a2a_event_middleware/middleware.py
@@ -22,6 +22,7 @@ from a2a.client.middleware import ClientCallContext, ClientCallInterceptor
 from a2a.types import AgentCard, Message, Task, TaskState
 from opentelemetry import trace as _otel_trace
 
+from common.stable_agent_id import stable_agent_id_for_name as _stable_agent_id
 from config.config import EMIT_WORKFLOW_EVENTS
 from schema.types import (
 	Correlation,
@@ -117,8 +118,14 @@ def _make_node(
 	label: str,
 	layer_index: int,
 	include_size: bool = True,
+	stable_agent_id: str | None = None,
 ) -> PartialNode:
 	"""Create a PartialNode with standard defaults."""
+	extras: dict[str, Any] = {}
+	if stable_agent_id is not None:
+		extras["stable_agent_id"] = stable_agent_id
+		# Schema requires agent_record_uri on any node with stable_agent_id.
+		extras["agent_record_uri"] = f"agent-card://{stable_agent_id.removeprefix('agent://')}"
 	return PartialRegularNode(
 		id=NodeId(node_id),
 		operation=operation,
@@ -126,6 +133,7 @@ def _make_node(
 		label=label,
 		layer_index=layer_index,
 		**(dict(size=_DEFAULT_NODE_SIZE) if include_size else {}),
+		**extras,
 	)
 
 
@@ -287,6 +295,7 @@ async def _outbound_topology(
 			node_type="customNode",
 			label=caller_agent_id,
 			layer_index=layer_index,
+			stable_agent_id=_stable_agent_id(caller_agent_id),
 		),
 		_make_node(
 			transport_node,
@@ -314,6 +323,7 @@ async def _outbound_topology(
 				node_type="customNode",
 				label=agent_id,
 				layer_index=layer_index + 2,
+				stable_agent_id=_stable_agent_id(agent_id),
 			),
 		)
 		edges.append(
@@ -350,6 +360,7 @@ async def _inbound_topology(
 				label=remote_agent_id,
 				layer_index=layer_index + 2,
 				include_size=False,
+				stable_agent_id=_stable_agent_id(remote_agent_id),
 			),
 			_make_node(
 				transport_node,
@@ -366,6 +377,7 @@ async def _inbound_topology(
 				label=caller_agent_id,
 				layer_index=layer_index,
 				include_size=False,
+				stable_agent_id=_stable_agent_id(caller_agent_id),
 			),
 		],
 		edges=[
@@ -523,6 +535,9 @@ class EventEmittingInterceptor(ClientCallInterceptor):
 						node_type="customNode",
 						label=self._caller_agent_id,
 						layer_index=self._agent_call_graph_layer,
+						stable_agent_id=_stable_agent_id(
+							self._caller_agent_id
+						),
 					)
 				],
 				edges=[],

--- a/coffeeAGNTCY/coffee_agents/lungo/common/stable_agent_id.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/stable_agent_id.py
@@ -1,0 +1,27 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared derivation of ``stable_agent_id`` from an agent name.
+
+Imported by both the seed-topology loader and the A2A middleware so the same
+agent name always yields the same ``agent://<uuid5>`` regardless of which
+side emits the node.
+"""
+
+from __future__ import annotations
+
+from uuid import NAMESPACE_DNS, UUID, uuid5
+
+STABLE_AGENT_ID_NAMESPACE: UUID = uuid5(
+    NAMESPACE_DNS, "agent.workflow.lungo"
+)
+
+
+def stable_agent_uuid_for_name(agent_name: str) -> UUID:
+    """Deterministic UUID for an agent name."""
+    return uuid5(STABLE_AGENT_ID_NAMESPACE, agent_name)
+
+
+def stable_agent_id_for_name(agent_name: str) -> str:
+    """Deterministic ``agent://<uuid>`` for an agent name."""
+    return f"agent://{stable_agent_uuid_for_name(agent_name)!s}"

--- a/coffeeAGNTCY/coffee_agents/lungo/docker-compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker-compose.yaml
@@ -13,6 +13,11 @@ services:
       - FARM_AGENT_PORT=9999
       - OTLP_HTTP_ENDPOINT=${OTLP_HTTP_ENDPOINT:-http://otel-collector:4318}
       - IDENTITY_AUTH_ENABLED=disabled
+      - DEFAULT_MESSAGE_TRANSPORT=${DEFAULT_MESSAGE_TRANSPORT}
+      - TRANSPORT_SERVER_ENDPOINT=${TRANSPORT_SERVER_ENDPOINT:-http://slim:46357}
+      - SLIM_SERVER=${SLIM_SERVER}
+      - NATS_SERVER=${NATS_SERVER}
+      - SLIM_SHARED_SECRET=${SLIM_SHARED_SECRET}
       - ENABLE_HTTP=true
     ports:
       - "9999:9999"
@@ -129,6 +134,7 @@ services:
       - OTLP_HTTP_ENDPOINT=${OTLP_HTTP_ENDPOINT:-http://otel-collector:4318}
       - IDENTITY_AUTH_ENABLED=${IDENTITY_AUTH_ENABLED:-} # Disabled by default
       - IDENTITY_SERVICE_API_KEY=${IDENTITY_SERVICE_API_KEY_AUCTION_SUPERVISOR:-dummy_api_key}
+      - WORKFLOW_API_URL=${WORKFLOW_API_URL:-http://agentic-workflows-api:9105}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-}
     ports:
       - "8000:8000"
@@ -401,6 +407,7 @@ services:
       - NATS_SERVER=${NATS_SERVER}
       - SLIM_SHARED_SECRET=${SLIM_SHARED_SECRET}
       - OTLP_HTTP_ENDPOINT=${OTLP_HTTP_ENDPOINT:-http://otel-collector:4318}
+      - WORKFLOW_API_URL=${WORKFLOW_API_URL:-http://agentic-workflows-api:9105}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-}
     ports:
       - "9090:9090"
@@ -580,6 +587,7 @@ services:
       - NATS_SERVER=${NATS_SERVER}
       - SLIM_SHARED_SECRET=${SLIM_SHARED_SECRET}
       - OTLP_HTTP_ENDPOINT=${OTLP_HTTP_ENDPOINT:-http://otel-collector:4318}
+      - WORKFLOW_API_URL=${WORKFLOW_API_URL:-http://agentic-workflows-api:9105}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-}
     ports:
       - "8882:8882"

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/api/agenticWorkflowsTypes.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/api/agenticWorkflowsTypes.ts
@@ -10,6 +10,11 @@ export interface TopologySize {
   height?: number
 }
 
+export interface TopologyPosition {
+  x: number
+  y: number
+}
+
 export interface TopologyNodeWire {
   id: string
   operation?: string
@@ -17,6 +22,8 @@ export interface TopologyNodeWire {
   label?: string
   size?: TopologySize
   layer_index?: number
+  /** Optional absolute layout hint; when present the renderer skips auto-layout for this node. */
+  position?: TopologyPosition
   agent_record_uri?: string
   stable_agent_id?: string | { root: string }
   [key: string]: unknown

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/useMainArea.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/useMainArea.ts
@@ -96,19 +96,20 @@ export function useMainArea({
   const [edges, setEdges, onEdgesChange] = useEdgesState(config.edges)
   const animationLock = useRef<boolean>(false)
 
-  const { agenticMode, agenticError } = useWorkflowGraphFromAgenticApi({
-    pattern,
-    selectedWorkflowSummary,
-    setNodes,
-    setEdges,
-    handleOpenIdentityModal,
-    handleOpenOasfModal,
-    onTopologyApplied: () => {
-      setTimeout(() => {
-        fitViewWithViewport({ chatHeight: 0, isExpanded: false })
-      }, 200)
-    },
-  })
+  const { agenticMode, agenticError, staticIdMapActive, restoreEdgeAnimation } =
+    useWorkflowGraphFromAgenticApi({
+      pattern,
+      selectedWorkflowSummary,
+      setNodes,
+      setEdges,
+      handleOpenIdentityModal,
+      handleOpenOasfModal,
+      onTopologyApplied: () => {
+        setTimeout(() => {
+          fitViewWithViewport({ chatHeight: 0, isExpanded: false })
+        }, 200)
+      },
+    })
 
   useEffect(() => {
     if (!agenticError) return
@@ -163,7 +164,8 @@ export function useMainArea({
 
   useMainAreaGraphEffects({
     pattern,
-    skipStaticGraphSync: agenticMode,
+    skipStaticGraphSync: agenticMode && !staticIdMapActive,
+    restoreEdgeAnimation: staticIdMapActive ? restoreEdgeAnimation : undefined,
     isGroupCommConnected,
     setNodes,
     setEdges,

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/useMainAreaGraphEffects.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/useMainAreaGraphEffects.ts
@@ -45,6 +45,8 @@ export interface UseMainAreaGraphEffectsParams {
   nodesConnectable: boolean
   handleCloseModals: () => void
   setOasfModalOpen: (open: boolean) => void
+  /** Restore edge animation after a static-config rebuild wipes it. */
+  restoreEdgeAnimation?: () => void
 }
 
 /** Runs effects that sync graph config, viewport, transport labels, tooltips, and edge checks. */
@@ -67,6 +69,7 @@ export function useMainAreaGraphEffects({
   nodesConnectable,
   handleCloseModals,
   setOasfModalOpen,
+  restoreEdgeAnimation,
 }: UseMainAreaGraphEffectsParams) {
   useEffect(() => {
     animationLockRef.current = false
@@ -86,7 +89,9 @@ export function useMainAreaGraphEffects({
       })),
     )
     setEdges([])
-  }, [pattern, setNodes, setEdges, skipStaticGraphSync])
+    // Restore SSE-driven edge animation in the same batch as the wipe.
+    if (restoreEdgeAnimation) restoreEdgeAnimation()
+  }, [pattern, setNodes, setEdges, skipStaticGraphSync, restoreEdgeAnimation])
 
   useEffect(() => {
     if (!skipStaticGraphSync) return
@@ -138,6 +143,8 @@ export function useMainAreaGraphEffects({
         pattern,
         isStreamingPattern(pattern),
       )
+      // Rebuild above wiped active/animated; restore in the same batch.
+      if (restoreEdgeAnimation) restoreEdgeAnimation()
       setTimeout(() => {
         fitViewWithViewport({ chatHeight: 0, isExpanded: false })
       }, 200)
@@ -154,6 +161,7 @@ export function useMainAreaGraphEffects({
     activeNodeData,
     handleOpenOasfModal,
     skipStaticGraphSync,
+    restoreEdgeAnimation,
   ])
 
   useEffect(() => {

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useWorkflowGraphFromAgenticApi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useWorkflowGraphFromAgenticApi.ts
@@ -31,9 +31,9 @@ import {
 } from "@/utils/topologyStaticIdMap"
 import {
   extractInstanceTopologyFromEvent,
-  highlightIdsFromTopologyWithOverlay,
   messagingHighlightIdsFromTopology,
   patchGraphActiveHighlight,
+  staticGraphHighlightIdsFromTopology,
   type MessagingHighlightIds,
 } from "@/utils/workflowEventMessagingHighlight"
 
@@ -346,16 +346,11 @@ export function useWorkflowGraphFromAgenticApi({
       const idMap = staticIdMapRef.current
       let ids: MessagingHighlightIds
       if (idMap) {
-        ids = highlightIdsFromTopologyWithOverlay(partial, idMap)
+        ids = staticGraphHighlightIdsFromTopology(partial, idMap)
       } else {
         ids = messagingHighlightIdsFromTopology(partial)
       }
       const hasAny = ids.nodeIds.size > 0 || ids.edgeIds.size > 0
-      const graphIds = lastAppliedGraphNodeIdsRef.current
-      let hlNodesOnGraph = 0
-      for (const id of ids.nodeIds) {
-        if (graphIds.has(id)) hlNodesOnGraph++
-      }
       if (hasAny) {
         lastMessagingHighlightRef.current = {
           nodeIds: new Set(ids.nodeIds),

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useWorkflowGraphFromAgenticApi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useWorkflowGraphFromAgenticApi.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  **/
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Edge, Node } from "@xyflow/react"
 import {
   createClient,
@@ -22,10 +22,24 @@ import {
 } from "@/utils/agenticWorkflowsApi"
 import { logger } from "@/utils/logger"
 import type { PatternType } from "@/utils/patternUtils"
+import { useActiveWorkflowInstanceStore } from "@/stores/activeWorkflowInstanceStore"
 import { identityUiVariantForPattern } from "@/utils/agenticTopologyIdentityUiMap"
 import { topologyWireToReactFlow } from "@/utils/topologyToReactFlow"
+import {
+  staticIdMapForPattern,
+  type StaticIdMap,
+} from "@/utils/topologyStaticIdMap"
+import {
+  extractInstanceTopologyFromEvent,
+  highlightIdsFromTopologyWithOverlay,
+  messagingHighlightIdsFromTopology,
+  patchGraphActiveHighlight,
+  type MessagingHighlightIds,
+} from "@/utils/workflowEventMessagingHighlight"
 
 const REFETCH_DEBOUNCE_MS = 80
+/** Auto-clear messaging highlights if no newer event refreshes them. */
+const MESSAGING_HIGHLIGHT_TTL_MS = 2_500
 
 function mergeDiscoveryNodes(base: Node[], prev: Node[]): Node[] {
   const overlay = prev.filter((n) => n.id.startsWith("discovery-"))
@@ -66,6 +80,17 @@ export interface UseWorkflowGraphFromAgenticApiResult {
   /** True when the pattern maps to a catalog workflow (uses same API base as LHS menu). */
   agenticMode: boolean
   agenticError: string | null
+  /** Active workflow instance id (e.g. ``instance://<uuid>``) once instantiated. */
+  workflowInstanceId: string | null
+  /**
+   * True when this pattern has a static graph in `graphConfigsData` and the
+   * hook is deferring all positioning to it. Callers should still run their
+   * normal static-graph reconciliation (config sync on pattern change) even
+   * though `agenticMode` is true.
+   */
+  staticIdMapActive: boolean
+  /** Restore edge animation after a static-config rebuild wipes it. */
+  restoreEdgeAnimation: () => void
 }
 
 export function useWorkflowGraphFromAgenticApi({
@@ -77,7 +102,11 @@ export function useWorkflowGraphFromAgenticApi({
   handleOpenOasfModal,
   onTopologyApplied,
 }: UseWorkflowGraphFromAgenticApiParams): UseWorkflowGraphFromAgenticApiResult {
-  const baseUrl = getAgenticWorkflowsApiUrl().replace(/\/$/, "")
+  const baseUrl = useMemo(
+    () => getAgenticWorkflowsApiUrl().replace(/\/$/, ""),
+
+    [],
+  )
   const workflowName = selectedWorkflowSummary?.name ?? null
   const agenticMode = Boolean(
     selectedWorkflowSummary &&
@@ -85,18 +114,53 @@ export function useWorkflowGraphFromAgenticApi({
     mapWorkflowNameToSlug(workflowName) === pattern,
   )
 
+  /**
+   * When a pattern ships with a static graph in `graphConfigsData.tsx`
+   * (P/S, GroupComm, Discovery), an id map routes dynamic event ids onto
+   * the static NODE_IDS. In that mode we keep the static graph's
+   * hand-tuned positions, icons, and data intact; only the live-event
+   * highlight/animation pipeline runs.
+   */
+  const staticIdMap: StaticIdMap | null = useMemo(
+    () => staticIdMapForPattern(pattern),
+    [pattern],
+  )
+  const staticIdMapRef = useRef(staticIdMap)
+  staticIdMapRef.current = staticIdMap
+
   const [agenticError, setAgenticError] = useState<string | null>(null)
+  const workflowInstanceId = useActiveWorkflowInstanceStore(
+    (s) => s.workflowInstanceId,
+  )
+  const setWorkflowInstanceId = useActiveWorkflowInstanceStore(
+    (s) => s.setWorkflowInstanceId,
+  )
   type Session = {
     client: ReturnType<typeof createClient>
     baseUrl: string
     workflowName: string
     instanceId: string
+    pathUuid: string
     closeSse: (() => void) | null
     debounceTimer: ReturnType<typeof setTimeout> | null
     retryTimer: ReturnType<typeof setTimeout> | null
     refetchSeq: number
+    sseReconnectAttempts: number
   }
   const sessionRef = useRef<Session | null>(null)
+  /** Latest graph node ids after topology merge (for highlight id overlap checks). */
+  const lastAppliedGraphNodeIdsRef = useRef<Set<string>>(new Set())
+  const lastMessagingHighlightRef = useRef<MessagingHighlightIds>({
+    nodeIds: new Set(),
+    edgeIds: new Set(),
+    edgePairs: new Set(),
+  })
+  const highlightTtlTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+
+  const patternRef = useRef(pattern)
+  patternRef.current = pattern
 
   const identityRef = useRef(handleOpenIdentityModal)
   const oasfRef = useRef(handleOpenOasfModal)
@@ -117,21 +181,77 @@ export function useWorkflowGraphFromAgenticApi({
     }
   }, [])
 
+  const restoreEdgeAnimation = useCallback(() => {
+    const h = lastMessagingHighlightRef.current
+    setNodes((prev) => patchGraphActiveHighlight(prev, [], h).nodes)
+    setEdges((prev) => {
+      const { edges } = patchGraphActiveHighlight([], prev, h)
+      return edges
+    })
+  }, [setNodes, setEdges])
+
+  const clearMessagingHighlightTtl = useCallback(() => {
+    if (highlightTtlTimerRef.current !== null) {
+      clearTimeout(highlightTtlTimerRef.current)
+      highlightTtlTimerRef.current = null
+    }
+  }, [])
+
+  const clearMessagingHighlightVisual = useCallback(() => {
+    lastMessagingHighlightRef.current = {
+      nodeIds: new Set(),
+      edgeIds: new Set(),
+      edgePairs: new Set(),
+    }
+    const h = lastMessagingHighlightRef.current
+    setNodes((prev) => patchGraphActiveHighlight(prev, [], h).nodes)
+    setEdges((prev) => patchGraphActiveHighlight([], prev, h).edges)
+  }, [setNodes, setEdges])
+
+  const scheduleMessagingHighlightTtl = useCallback(() => {
+    clearMessagingHighlightTtl()
+    highlightTtlTimerRef.current = setTimeout(() => {
+      highlightTtlTimerRef.current = null
+      clearMessagingHighlightVisual()
+    }, MESSAGING_HIGHLIGHT_TTL_MS)
+  }, [clearMessagingHighlightTtl, clearMessagingHighlightVisual])
+
   const applyInstanceTopology = useCallback(
     (
       topology: import("@/api/agenticWorkflowsTypes").TopologyWire | undefined,
     ) => {
+      // When a static id map governs the current pattern, we leave the
+      // graphConfigsData-sourced nodes/edges alone — positions, icons, and
+      // node data are authored statically. The SSE pipeline still runs and
+      // patches highlights/animation on top.
+      if (staticIdMapRef.current) {
+        onAppliedRef.current?.()
+        queueMicrotask(() => {
+          restoreEdgeAnimation()
+        })
+        return
+      }
       const { nodes: mappedNodes, edges: mappedEdges } =
         topologyWireToReactFlow(topology, {
-          identityUiVariant: identityUiVariantForPattern(pattern),
+          identityUiVariant: identityUiVariantForPattern(patternRef.current),
         })
       const withHandlers = mappedNodes.map(attachHandlers)
-      setNodes((prev) => mergeDiscoveryNodes(withHandlers, prev))
+      setNodes((prev) => {
+        const merged = mergeDiscoveryNodes(withHandlers, prev)
+        lastAppliedGraphNodeIdsRef.current = new Set(merged.map((n) => n.id))
+        return merged
+      })
       setEdges((prev) => mergeDiscoveryEdges(mappedEdges, prev))
       onAppliedRef.current?.()
+      queueMicrotask(() => {
+        restoreEdgeAnimation()
+      })
     },
-    [attachHandlers, setNodes, setEdges, pattern],
+    [attachHandlers, setNodes, setEdges, restoreEdgeAnimation],
   )
+
+  const applyInstanceTopologyRef = useRef(applyInstanceTopology)
+  applyInstanceTopologyRef.current = applyInstanceTopology
 
   const clearSession = useCallback(() => {
     const s = sessionRef.current
@@ -140,7 +260,17 @@ export function useWorkflowGraphFromAgenticApi({
     if (s.debounceTimer) clearTimeout(s.debounceTimer)
     if (s.retryTimer) clearTimeout(s.retryTimer)
     sessionRef.current = null
-  }, [])
+    setWorkflowInstanceId(null)
+    clearMessagingHighlightTtl()
+    lastMessagingHighlightRef.current = {
+      nodeIds: new Set(),
+      edgeIds: new Set(),
+      edgePairs: new Set(),
+    }
+  }, [clearMessagingHighlightTtl])
+
+  const clearSessionRef = useRef(clearSession)
+  clearSessionRef.current = clearSession
 
   const refetchAndApplyTopology = useCallback(
     async (seq: number, attempt: number) => {
@@ -156,7 +286,7 @@ export function useWorkflowGraphFromAgenticApi({
         )
         const stillLatest = sessionRef.current
         if (!stillLatest || stillLatest.refetchSeq !== seq) return
-        applyInstanceTopology(fresh.topology)
+        applyInstanceTopologyRef.current(fresh.topology)
       } catch (e) {
         logger.apiError("agentic-workflows/refetch-topology", e)
         const s = sessionRef.current
@@ -168,12 +298,15 @@ export function useWorkflowGraphFromAgenticApi({
           const current = sessionRef.current
           if (current) current.retryTimer = null
           if (!current || current.refetchSeq !== seq) return
-          void refetchAndApplyTopology(seq, attempt + 1)
+          void refetchAndApplyTopologyRef.current(seq, attempt + 1)
         }, backoffMs)
       }
     },
-    [applyInstanceTopology],
+    [],
   )
+
+  const refetchAndApplyTopologyRef = useRef(refetchAndApplyTopology)
+  refetchAndApplyTopologyRef.current = refetchAndApplyTopology
 
   const scheduleTopologyRefetch = useCallback(() => {
     const s = sessionRef.current
@@ -189,19 +322,89 @@ export function useWorkflowGraphFromAgenticApi({
       const latest = sessionRef.current
       if (!latest || latest.refetchSeq !== seq) return
       latest.debounceTimer = null
-      void refetchAndApplyTopology(seq, 0)
+      void refetchAndApplyTopologyRef.current(seq, 0)
     }, REFETCH_DEBOUNCE_MS)
-  }, [refetchAndApplyTopology])
+  }, [])
+
+  const scheduleTopologyRefetchRef = useRef(scheduleTopologyRefetch)
+  scheduleTopologyRefetchRef.current = scheduleTopologyRefetch
+
+  const handleWorkflowInstanceSseEvent = useCallback(
+    (ev: EventV1Wire, catalogWorkflowName: string, instanceId: string) => {
+      if (!eventTouchesInstance(ev, catalogWorkflowName, instanceId)) return
+
+      const partial = extractInstanceTopologyFromEvent(
+        ev,
+        catalogWorkflowName,
+        instanceId,
+      )
+      // When a static id map is active, derive highlight ids in the static
+      // namespace directly from the wire labels/stable_agent_ids — this is
+      // what lets the live event animation light up the static nodes laid
+      // out by graphConfigsData.tsx. Otherwise use the legacy path which
+      // operates in the dynamic id namespace.
+      const idMap = staticIdMapRef.current
+      let ids: MessagingHighlightIds
+      if (idMap) {
+        ids = highlightIdsFromTopologyWithOverlay(partial, idMap)
+      } else {
+        ids = messagingHighlightIdsFromTopology(partial)
+      }
+      const hasAny = ids.nodeIds.size > 0 || ids.edgeIds.size > 0
+      const graphIds = lastAppliedGraphNodeIdsRef.current
+      let hlNodesOnGraph = 0
+      for (const id of ids.nodeIds) {
+        if (graphIds.has(id)) hlNodesOnGraph++
+      }
+      if (hasAny) {
+        lastMessagingHighlightRef.current = {
+          nodeIds: new Set(ids.nodeIds),
+          edgeIds: new Set(ids.edgeIds),
+          edgePairs: new Set(ids.edgePairs),
+        }
+        setNodes(
+          (prev) =>
+            patchGraphActiveHighlight(
+              prev,
+              [],
+              lastMessagingHighlightRef.current,
+            ).nodes,
+        )
+        setEdges(
+          (prev) =>
+            patchGraphActiveHighlight(
+              [],
+              prev,
+              lastMessagingHighlightRef.current,
+            ).edges,
+        )
+        scheduleMessagingHighlightTtl()
+      }
+
+      // With a static id map, the graph never gets rebuilt from topology
+      // refetches — skip the refetch entirely. Without one, the graph is
+      // reconciled with fresh topology after every event.
+      if (!staticIdMapRef.current) {
+        scheduleTopologyRefetchRef.current()
+      }
+    },
+    [setNodes, setEdges, scheduleMessagingHighlightTtl],
+  )
+
+  const handleWorkflowInstanceSseEventRef = useRef(
+    handleWorkflowInstanceSseEvent,
+  )
+  handleWorkflowInstanceSseEventRef.current = handleWorkflowInstanceSseEvent
 
   useEffect(() => {
     const catalogWorkflowName = selectedWorkflowSummary?.name
     if (!agenticMode || !baseUrl || !catalogWorkflowName) {
-      clearSession()
+      clearSessionRef.current()
       setAgenticError(null)
       return
     }
 
-    clearSession()
+    clearSessionRef.current()
 
     const client = createClient(baseUrl)
     let cancelled = false
@@ -222,34 +425,65 @@ export function useWorkflowGraphFromAgenticApi({
           true,
         )
         if (cancelled) return
-        applyInstanceTopology(inst.topology)
+        applyInstanceTopologyRef.current(inst.topology)
 
+        if (cancelled) return
         const session: Session = {
           client,
           baseUrl,
           workflowName: catalogWorkflowName,
           instanceId,
+          pathUuid,
           closeSse: null,
           debounceTimer: null,
           retryTimer: null,
           refetchSeq: 0,
+          sseReconnectAttempts: 0,
         }
         sessionRef.current = session
+        setWorkflowInstanceId(instanceId)
 
-        const close = subscribeWorkflowInstanceSse(
-          baseUrl,
-          catalogWorkflowName,
-          pathUuid,
-          (ev: EventV1Wire) => {
-            if (!eventTouchesInstance(ev, catalogWorkflowName, instanceId))
-              return
-            scheduleTopologyRefetch()
-          },
-          (err) => {
-            logger.apiError("agentic-workflows/sse", err)
-          },
-        )
-        if (sessionRef.current) sessionRef.current.closeSse = close
+        const attachSse = (): void => {
+          const s = sessionRef.current
+          if (!s || s.instanceId !== instanceId || cancelled) return
+          if (s.closeSse) {
+            s.closeSse()
+            s.closeSse = null
+          }
+          if (cancelled) return
+          const close = subscribeWorkflowInstanceSse(
+            s.baseUrl,
+            s.workflowName,
+            s.pathUuid,
+            (ev: EventV1Wire) => {
+              handleWorkflowInstanceSseEventRef.current(
+                ev,
+                catalogWorkflowName,
+                instanceId,
+              )
+            },
+            (err) => {
+              logger.apiError("agentic-workflows/sse", err)
+              const cur = sessionRef.current
+              if (!cur || cur.instanceId !== instanceId || cancelled) return
+              if (cur.sseReconnectAttempts >= 6) return
+              cur.sseReconnectAttempts += 1
+              queueMicrotask(() => {
+                attachSse()
+              })
+            },
+          )
+          if (cancelled) {
+            close()
+            return
+          }
+          if (sessionRef.current?.instanceId === instanceId) {
+            sessionRef.current.closeSse = close
+          }
+        }
+
+        if (cancelled) return
+        attachSse()
       } catch (e) {
         if (!cancelled) {
           const msg = e instanceof Error ? e.message : String(e)
@@ -263,21 +497,15 @@ export function useWorkflowGraphFromAgenticApi({
 
     return () => {
       cancelled = true
-      clearSession()
+      clearSessionRef.current()
     }
-  }, [
-    agenticMode,
-    baseUrl,
-    selectedWorkflowSummary?.name,
-    applyInstanceTopology,
-    pattern,
-    attachHandlers,
-    setNodes,
-    setEdges,
-    clearSession,
-    scheduleTopologyRefetch,
-    refetchAndApplyTopology,
-  ])
+  }, [agenticMode, baseUrl, selectedWorkflowSummary?.name])
 
-  return { agenticMode, agenticError }
+  return {
+    agenticMode,
+    agenticError,
+    workflowInstanceId,
+    staticIdMapActive: staticIdMap !== null,
+    restoreEdgeAnimation,
+  }
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/activeWorkflowInstanceStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/activeWorkflowInstanceStore.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import { create } from "zustand"
+
+/** Bridges the agentic-workflows instance id from the graph bootstrap hook to
+ *  sibling streaming stores so the agent tags emitted events with the same id
+ *  the SSE listener is subscribed under. */
+interface ActiveWorkflowInstanceState {
+  workflowInstanceId: string | null
+  setWorkflowInstanceId: (id: string | null) => void
+}
+
+export const useActiveWorkflowInstanceStore =
+  create<ActiveWorkflowInstanceState>((set) => ({
+    workflowInstanceId: null,
+    setWorkflowInstanceId: (id) => set({ workflowInstanceId: id }),
+  }))

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/auctionStreamingStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/auctionStreamingStore.ts
@@ -25,7 +25,7 @@ interface StreamingState {
   prompt: string | null
   abortController: AbortController | null
   sessionId: string | null // <-- added
-  connect: (prompt: string) => Promise<void>
+  connect: (prompt: string, workflowInstanceId?: string | null) => Promise<void>
   disconnect: () => void
   reset: () => void
 }
@@ -42,7 +42,7 @@ const initialState = {
 export const useAuctionStreamingStore = create<StreamingState>((set) => ({
   ...initialState,
 
-  connect: async (prompt: string) => {
+  connect: async (prompt: string, workflowInstanceId?: string | null) => {
     const abortController = new AbortController()
     set({
       status: "connecting",
@@ -62,7 +62,12 @@ export const useAuctionStreamingStore = create<StreamingState>((set) => ({
         method: "POST",
         credentials: isLocalDev ? "omit" : "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({
+          prompt,
+          ...(workflowInstanceId
+            ? { workflow_instance_id: workflowInstanceId }
+            : {}),
+        }),
         signal: abortController.signal,
       })
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/groupStreamingStore.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/stores/groupStreamingStore.ts
@@ -60,7 +60,10 @@ interface LogisticsStreamingActions {
   setCurrentOrderId: (orderId: string) => void
   setExecutionKey: (key: string) => void
   setSessionId: (id: string) => void
-  startStreaming: (prompt: string) => Promise<void>
+  startStreaming: (
+    prompt: string,
+    workflowInstanceId?: string | null,
+  ) => Promise<void>
   reset: () => void
 }
 
@@ -128,7 +131,10 @@ export const useGroupStreamingStore = create<
       sessionId: id,
     }),
 
-  startStreaming: async (prompt: string) => {
+  startStreaming: async (
+    prompt: string,
+    workflowInstanceId?: string | null,
+  ) => {
     const {
       reset,
       setStreaming,
@@ -143,6 +149,8 @@ export const useGroupStreamingStore = create<
     setStreaming(true)
 
     try {
+      const body: { prompt: string; workflow_instance_id?: string } = { prompt }
+      if (workflowInstanceId) body.workflow_instance_id = workflowInstanceId
       const response = await fetch(
         `${LOGISTICS_APP_API_URL}/agent/prompt/stream`,
         {
@@ -151,7 +159,7 @@ export const useGroupStreamingStore = create<
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ prompt }),
+          body: JSON.stringify(body),
         },
       )
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/useApp.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/useApp.ts
@@ -19,12 +19,16 @@ import {
   pickDefaultWorkflowSummaryForPattern,
   type WorkflowSummary,
 } from "@/utils/agenticWorkflowsApi"
+import { useActiveWorkflowInstanceStore } from "@/stores/activeWorkflowInstanceStore"
 
 export type { ApiResponse } from "@/types/api"
 
 export function useApp() {
   const { sendMessage } = useAgentAPI()
   const streaming = useAppStreamingState()
+  const activeWorkflowInstanceId = useActiveWorkflowInstanceStore(
+    (s) => s.workflowInstanceId,
+  )
 
   const [selectedPattern, setSelectedPattern] = useState<PatternType>(
     PATTERNS.GROUP_MESSAGING,
@@ -234,7 +238,7 @@ export function useApp() {
           streamCompleteRef.current = false
           streaming.resetGroup()
           try {
-            await streaming.startStreaming(query)
+            await streaming.startStreaming(query, activeWorkflowInstanceId)
           } catch (err) {
             logger.apiError("/agent/prompt/stream", err)
             chat.setShowFinalResponse(true)
@@ -248,7 +252,7 @@ export function useApp() {
           chat.setShowAuctionStreaming(true)
           chat.setAgentResponse(undefined)
           streaming.reset()
-          await streaming.connect(query)
+          await streaming.connect(query, activeWorkflowInstanceId)
         } else if (selectedPattern === PATTERNS.A2A_HTTP) {
           chat.setShowFinalResponse(false)
           chat.setShowRecruiterStreaming(true)

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticTopologyIdentityUiMap.test.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticTopologyIdentityUiMap.test.ts
@@ -17,8 +17,8 @@ import {
   stableAgentUuidForRecordName,
 } from "@/utils/agenticTopologyIdentityUiMap"
 
-/** Must match `uuid5(uuid5(NAMESPACE_DNS, "agent.workflow.lungo.coffeeAGNTCY.com"), name)` in Python `workflows.py`. */
-const BRAZIL_UUID = "ea3ce2b8-68b6-5fc9-9fa4-491cb71b7bf4"
+/** Must match `uuid5(uuid5(NAMESPACE_DNS, "agent.workflow.lungo"), name)` in Python `common/stable_agent_id.py`. */
+const BRAZIL_UUID = "9a6cc736-d6fb-5a3e-82d6-3552d09b5ae9"
 
 describe("agenticTopologyIdentityUiMap", () => {
   it("stableAgentUuidForRecordName matches Python backend for Brazil Coffee Farm", () => {

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticTopologyIdentityUiMap.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/agenticTopologyIdentityUiMap.ts
@@ -19,9 +19,9 @@ import { PATTERNS, type PatternType } from "@/utils/patternUtils"
 import urlsConfig from "@/utils/urls.json"
 import { SecurityClass } from "@/utils/SecurityClass"
 
-/** Matches Python `workflows.py`: uuid5(NAMESPACE_DNS, "agent.workflow.lungo.coffeeAGNTCY.com") */
+/** Matches Python `common.stable_agent_id`: uuid5(NAMESPACE_DNS, "agent.workflow.lungo") */
 export const STABLE_AGENT_ID_NAMESPACE = uuidv5(
-  "agent.workflow.lungo.coffeeAGNTCY.com",
+  "agent.workflow.lungo",
   uuidv5.DNS,
 )
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyStaticIdMap.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyStaticIdMap.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * -----------------------------------------------------------------------------
+ * TEMPORARY: Wire-id → static NODE_ID map for patterns with a hand-tuned graph.
+ *
+ * Bridges dynamic wire ids (stable_agent_id, transport canonical key, label)
+ * to the NODE_IDS authored in `graphConfigs.ts` / `graphConfigsData.tsx`, so
+ * SSE-driven highlights/animations land on the statically-rendered nodes and
+ * edges.
+ *
+ * Longer term, the four patterns shipped with static configs should render
+ * directly from the Agentic Workflows API topology (positions, labels, icons
+ * all wire-supplied). At that point the wire id == the rendered id, this
+ * module is no longer needed, and `graphConfigs.ts` / `graphConfigsData.tsx`
+ * can be removed or reduced to animation sequences only.
+ * -----------------------------------------------------------------------------
+ */
+
+import { stableAgentUuidForRecordName } from "@/utils/agenticTopologyIdentityUiMap"
+import { PATTERNS, type PatternType } from "@/utils/patternUtils"
+
+export interface StaticIdMap {
+  /** UUID (no `agent://` prefix) -> static NODE_IDS value. */
+  idByStableAgentUuid: ReadonlyMap<string, string>
+  /** Lowercased label/label1/label1+label2 -> static NODE_IDS value. */
+  idByLabel: ReadonlyMap<string, string>
+  /** Transport canonical key (e.g. `"transport"`) -> static NODE_IDS value. */
+  idByTransportKey: ReadonlyMap<string, string>
+}
+
+function lc(s: string): string {
+  return s.trim().toLowerCase()
+}
+
+/** Build the P/S id map (also serves PUBLISH_SUBSCRIBE_STREAMING). */
+function buildPublishSubscribeIdMap(): StaticIdMap {
+  // OASF agent record top-level names; stable_agent_id derives from these via
+  // `stableAgentUuidForRecordName`. Must stay in sync with the OASF JSON files
+  // under `agents/supervisors/*/oasf/agents/*.json` and the backend in
+  // `api/agentic_workflows/workflows.py`.
+  const idByStableAgentUuid = new Map<string, string>([
+    [stableAgentUuidForRecordName("Auction Supervisor agent"), "1"],
+    [stableAgentUuidForRecordName("Brazil Coffee Farm"), "3"],
+    [stableAgentUuidForRecordName("Colombia Coffee Farm"), "4"],
+    [stableAgentUuidForRecordName("Vietnam Coffee Farm"), "5"],
+    [stableAgentUuidForRecordName("Weather MCP Server"), "6"],
+    [stableAgentUuidForRecordName("Payment MCP Server"), "7"],
+  ])
+  const idByLabel = new Map<string, string>([
+    // Defensive label fallbacks if the wire lacks a stable_agent_id.
+    [lc("Auction Agent"), "1"],
+    [lc("Auction Agent Buyer"), "1"],
+    [lc("Brazil"), "3"],
+    [lc("Colombia"), "4"],
+    [lc("Vietnam"), "5"],
+    [lc("Weather"), "6"],
+    [lc("MCP Server Weather"), "6"],
+    [lc("Payment"), "7"],
+    [lc("MCP Server Payment"), "7"],
+  ])
+  const idByTransportKey = new Map<string, string>([["transport", "2"]])
+  return {
+    idByStableAgentUuid,
+    idByLabel,
+    idByTransportKey,
+  }
+}
+
+function buildGroupCommunicationIdMap(): StaticIdMap {
+  const idByStableAgentUuid = new Map<string, string>([
+    [stableAgentUuidForRecordName("Logistics Supervisor agent"), "1"],
+    [stableAgentUuidForRecordName("Tatooine Farm agent"), "3"],
+    [stableAgentUuidForRecordName("Shipping agent"), "4"],
+    [stableAgentUuidForRecordName("Accountant agent"), "5"],
+  ])
+  const idByLabel = new Map<string, string>([
+    [lc("Buyer Logistics Agent"), "1"],
+    [lc("Buyer"), "1"],
+    [lc("Tatooine"), "3"],
+    [lc("Shipper"), "4"],
+    [lc("Shipper Agent"), "4"],
+    [lc("Accountant"), "5"],
+    [lc("Accountant Agent"), "5"],
+    // The group container has no stable_agent_id; match by label only.
+    [lc("Logistics Group"), "logistics-group"],
+  ])
+  const idByTransportKey = new Map<string, string>([["transport", "2"]])
+  return {
+    idByStableAgentUuid,
+    idByLabel,
+    idByTransportKey,
+  }
+}
+
+function buildDiscoveryIdMap(): StaticIdMap {
+  // Recruiter middleware may emit the OASF record name or the A2A service
+  // card name; both collapse to the static recruiter node.
+  const idByStableAgentUuid = new Map<string, string>([
+    [stableAgentUuidForRecordName("Agentic Recruiter agent"), "recruiter-agent"],
+    [stableAgentUuidForRecordName("RecruiterAgent"), "recruiter-agent"],
+  ])
+  const idByLabel = new Map<string, string>([
+    [lc("Agentic Recruiter"), "recruiter-agent"],
+    [lc("Agentic Recruiter Discovery and delegation"), "recruiter-agent"],
+    [lc("Recruiter"), "recruiter-agent"],
+    // No OASF record for the directory; resolved by label only.
+    [lc("Directory"), "agntcy-directory"],
+    [lc("AGNTCY Agent Directory"), "agntcy-directory"],
+    [lc("Directory AGNTCY Agent Directory"), "agntcy-directory"],
+  ])
+  // Discovery pattern has no transport node in the static config.
+  const idByTransportKey = new Map<string, string>()
+  return {
+    idByStableAgentUuid,
+    idByLabel,
+    idByTransportKey,
+  }
+}
+
+/**
+ * Return an id map for the given pattern, or null when the dynamic
+ * grid-based layout should be used as-is (no static config to honour).
+ */
+export function staticIdMapForPattern(
+  pattern: PatternType,
+): StaticIdMap | null {
+  switch (pattern) {
+    case PATTERNS.PUBLISH_SUBSCRIBE:
+    case PATTERNS.PUBLISH_SUBSCRIBE_STREAMING:
+      return buildPublishSubscribeIdMap()
+    case PATTERNS.GROUP_MESSAGING:
+      return buildGroupCommunicationIdMap()
+    case PATTERNS.A2A_HTTP:
+      return buildDiscoveryIdMap()
+    default:
+      return null
+  }
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyStaticIdMap.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyStaticIdMap.ts
@@ -98,7 +98,10 @@ function buildDiscoveryIdMap(): StaticIdMap {
   // Recruiter middleware may emit the OASF record name or the A2A service
   // card name; both collapse to the static recruiter node.
   const idByStableAgentUuid = new Map<string, string>([
-    [stableAgentUuidForRecordName("Agentic Recruiter agent"), "recruiter-agent"],
+    [
+      stableAgentUuidForRecordName("Agentic Recruiter agent"),
+      "recruiter-agent",
+    ],
     [stableAgentUuidForRecordName("RecruiterAgent"), "recruiter-agent"],
   ])
   const idByLabel = new Map<string, string>([

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyToReactFlow.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyToReactFlow.tsx
@@ -189,7 +189,14 @@ export function topologyWireToReactFlow(
     const rfId = rfIdOf(n)
     const nodeType =
       n.type === NODE_TYPES.TRANSPORT ? NODE_TYPES.TRANSPORT : NODE_TYPES.CUSTOM
-    const position = pos.get(rfId) ?? { x: 0, y: 0 }
+    // Prefer wire-supplied `position` (e.g. starting_workflows.json overrides);
+    // fall back to layered auto-layout when omitted.
+    const position =
+      n.position &&
+      typeof n.position.x === "number" &&
+      typeof n.position.y === "number"
+        ? { x: n.position.x, y: n.position.y }
+        : (pos.get(rfId) ?? { x: 0, y: 0 })
     const gh = resolveGithubFromAgentRecordUri(
       n.agent_record_uri as string | undefined,
       { validateUrls },

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyToReactFlow.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyToReactFlow.tsx
@@ -135,7 +135,10 @@ export function topologyWireToReactFlow(
           CONCRETE_TRANSPORTS.has(nextLabel.trim().toLowerCase())
         if (nextIsConcreteTransport) {
           prev.label = nextLabel
-        } else if (!prevIsConcreteTransport && nextLabel.length > prevLabel.length) {
+        } else if (
+          !prevIsConcreteTransport &&
+          nextLabel.length > prevLabel.length
+        ) {
           prev.label = nextLabel
         }
         if (!prev.agent_record_uri && n.agent_record_uri) {
@@ -180,10 +183,7 @@ export function topologyWireToReactFlow(
     const rfId = rfIdOf(n)
     if (rfId) layerById.set(rfId, n.layer_index ?? 0)
   }
-  const pos = layoutPositionsByLayer(
-    dedupedNodesIn.map(rfIdOf),
-    layerById,
-  )
+  const pos = layoutPositionsByLayer(dedupedNodesIn.map(rfIdOf), layerById)
 
   const nodes: Node[] = dedupedNodesIn.map((n): Node => {
     const rfId = rfIdOf(n)

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyToReactFlow.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/topologyToReactFlow.tsx
@@ -32,6 +32,39 @@ import {
 } from "@/utils/agenticTopologyIdentityUiMap"
 import type { IdentityUiGithubVariant } from "@/utils/agenticTopologyIdentityUiMap"
 
+// Transport label -> canonical synonym. Seed emits "transport"; runtime emits
+// "slim"/"nats"/"jsonrpc" for the same logical transport. Distinct logical
+// transports must use labels outside this table to avoid collapsing.
+const TRANSPORT_SYNONYMS: Record<string, string> = {
+  transport: "transport",
+  slim: "transport",
+  nats: "transport",
+  jsonrpc: "transport",
+}
+const CONCRETE_TRANSPORTS = new Set(
+  Object.entries(TRANSPORT_SYNONYMS)
+    .filter(([k]) => k !== "transport")
+    .map(([k]) => k),
+)
+
+function normalizedTransportKey(label: string | undefined): string {
+  const lower = typeof label === "string" ? label.trim().toLowerCase() : ""
+  return TRANSPORT_SYNONYMS[lower] ?? lower
+}
+
+export function transportCanonicalRfId(label: string | undefined): string {
+  return `transport://${normalizedTransportKey(label)}`
+}
+
+/** Read ``stable_agent_id`` from a wire node, handling both ``string`` and
+ * ``{ root: string }`` shapes. Returns "" when absent. */
+export function extractStableAgentId(n: TopologyNodeWire): string {
+  const s = n.stable_agent_id
+  if (typeof s === "string") return s
+  if (s && typeof s === "object" && typeof s.root === "string") return s.root
+  return ""
+}
+
 function defaultCustomIcon(label: string): React.ReactNode {
   const lower = label.toLowerCase()
   const iconSx = { fontSize: 16 } as const
@@ -62,20 +95,101 @@ export function topologyWireToReactFlow(
   const nodesIn = topology?.nodes ?? []
   const edgesIn = topology?.edges ?? []
 
-  const layerById = new Map<string, number>()
+  // Collapse trace-minted node://UUID aliases via stable_agent_id; fall back
+  // to a (type, label) tuple for seed nodes that lack the field.
+  const dedupKeyFor = (n: TopologyNodeWire): string => {
+    const sid = extractStableAgentId(n)
+    if (sid) return `sid::${sid}`
+    const typeKey =
+      n.type === NODE_TYPES.TRANSPORT ? NODE_TYPES.TRANSPORT : NODE_TYPES.CUSTOM
+    const labelKey =
+      typeKey === NODE_TYPES.TRANSPORT
+        ? normalizedTransportKey(n.label)
+        : typeof n.label === "string"
+          ? n.label.trim().toLowerCase()
+          : ""
+    return `lbl::${typeKey}::${labelKey}`
+  }
+  const aliasToCanonical = new Map<string, string>()
+  const canonicalKeyToId = new Map<string, string>()
+  const canonicalIdToNode = new Map<string, TopologyNodeWire>()
+  const dedupedNodesIn: TopologyNodeWire[] = []
   for (const n of nodesIn) {
-    if (n?.id) layerById.set(n.id, n.layer_index ?? 0)
+    if (!n?.id) continue
+    const dedupKey = dedupKeyFor(n)
+    const existing = canonicalKeyToId.get(dedupKey)
+    if (existing) {
+      aliasToCanonical.set(n.id, existing)
+      // Prefer the more-informative label when later events upgrade it
+      // (e.g. "Transport" -> "SLIM", "agent" -> "Supervisor agent"). Never
+      // downgrade a concrete transport name back to a generic seed label.
+      const prev = canonicalIdToNode.get(existing)
+      if (prev) {
+        const prevLabel = typeof prev.label === "string" ? prev.label : ""
+        const nextLabel = typeof n.label === "string" ? n.label : ""
+        const prevIsConcreteTransport =
+          prev.type === NODE_TYPES.TRANSPORT &&
+          CONCRETE_TRANSPORTS.has(prevLabel.trim().toLowerCase())
+        const nextIsConcreteTransport =
+          n.type === NODE_TYPES.TRANSPORT &&
+          CONCRETE_TRANSPORTS.has(nextLabel.trim().toLowerCase())
+        if (nextIsConcreteTransport) {
+          prev.label = nextLabel
+        } else if (!prevIsConcreteTransport && nextLabel.length > prevLabel.length) {
+          prev.label = nextLabel
+        }
+        if (!prev.agent_record_uri && n.agent_record_uri) {
+          prev.agent_record_uri = n.agent_record_uri
+        }
+      }
+      continue
+    }
+    canonicalKeyToId.set(dedupKey, n.id)
+    aliasToCanonical.set(n.id, n.id)
+    // Clone before in-place label/uri upgrades.
+    const cloned: TopologyNodeWire = { ...n }
+    canonicalIdToNode.set(n.id, cloned)
+    dedupedNodesIn.push(cloned)
+  }
+  const canonical = (id: string | undefined): string =>
+    id ? (aliasToCanonical.get(id) ?? id) : ""
+
+  // stable_agent_id for agents, synonym-normalized canonical id for
+  // transports, wire id otherwise.
+  const rfIdOf = (n: TopologyNodeWire): string => {
+    const sid = extractStableAgentId(n)
+    if (sid) return sid
+    if (n.type === NODE_TYPES.TRANSPORT) {
+      return transportCanonicalRfId(n.label)
+    }
+    return n.id
+  }
+  const wireIdToRfId = new Map<string, string>()
+  for (const n of dedupedNodesIn) {
+    wireIdToRfId.set(n.id, rfIdOf(n))
+  }
+  for (const [alias, can] of aliasToCanonical.entries()) {
+    const rf = wireIdToRfId.get(can)
+    if (rf) wireIdToRfId.set(alias, rf)
+  }
+  const rfIdFor = (wireId: string | undefined): string =>
+    wireId ? (wireIdToRfId.get(wireId) ?? wireId) : ""
+
+  const layerById = new Map<string, number>()
+  for (const n of dedupedNodesIn) {
+    const rfId = rfIdOf(n)
+    if (rfId) layerById.set(rfId, n.layer_index ?? 0)
   }
   const pos = layoutPositionsByLayer(
-    nodesIn.map((n) => n.id).filter(Boolean),
+    dedupedNodesIn.map(rfIdOf),
     layerById,
   )
 
-  const nodes: Node[] = nodesIn.map((raw): Node => {
-    const n = raw as TopologyNodeWire
+  const nodes: Node[] = dedupedNodesIn.map((n): Node => {
+    const rfId = rfIdOf(n)
     const nodeType =
       n.type === NODE_TYPES.TRANSPORT ? NODE_TYPES.TRANSPORT : NODE_TYPES.CUSTOM
-    const position = pos.get(n.id) ?? { x: 0, y: 0 }
+    const position = pos.get(rfId) ?? { x: 0, y: 0 }
     const gh = resolveGithubFromAgentRecordUri(
       n.agent_record_uri as string | undefined,
       { validateUrls },
@@ -88,7 +202,7 @@ export function topologyWireToReactFlow(
         compact: false,
       }
       return {
-        id: n.id,
+        id: rfId,
         type: NODE_TYPES.TRANSPORT,
         position,
         data: data as unknown as Record<string, unknown>,
@@ -112,21 +226,29 @@ export function topologyWireToReactFlow(
     data = enrichAgenticTopologyWellKnownUi(data, n, { validateUrls })
 
     return {
-      id: n.id,
+      id: rfId,
       type: NODE_TYPES.CUSTOM,
       position,
       data: data as unknown as Record<string, unknown>,
     }
   })
 
-  const edges: Edge[] = edgesIn.map((raw): Edge => {
+  const seenEdgePairs = new Set<string>()
+  const edges: Edge[] = []
+  for (const raw of edgesIn) {
     const e = raw as TopologyEdgeWire
+    const source = rfIdFor(canonical(e.source))
+    const target = rfIdFor(canonical(e.target))
+    if (!source || !target) continue
+    const pairKey = `${source}->${target}`
+    if (seenEdgePairs.has(pairKey)) continue
+    seenEdgePairs.add(pairKey)
     const edgeType =
       e.type === EDGE_TYPES.BRANCHING ? EDGE_TYPES.BRANCHING : EDGE_TYPES.CUSTOM
     const base: Edge = {
       id: e.id,
-      source: e.source ?? "",
-      target: e.target ?? "",
+      source,
+      target,
       type: edgeType,
       data: {
         label:
@@ -142,8 +264,8 @@ export function topologyWireToReactFlow(
         branches,
       }
     }
-    return base
-  })
+    edges.push(base)
+  }
 
   return { nodes, edges }
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  **/
 
-import type { EventV1Wire, TopologyWire } from "@/api/agenticWorkflowsTypes"
+import type {
+  EventV1Wire,
+  TopologyNodeWire,
+  TopologyWire,
+} from "@/api/agenticWorkflowsTypes"
 import type { Edge, Node } from "@xyflow/react"
 import {
   extractStableAgentId,
@@ -15,10 +19,102 @@ import { parseStableAgentUuid } from "@/utils/agenticTopologyIdentityUiMap"
 export interface MessagingHighlightIds {
   nodeIds: ReadonlySet<string>
   edgeIds: ReadonlySet<string>
-  /** rfId source->target pairs derived from partial topology, used as a
-   *  fallback when allocator-minted edge ids drift between event and
-   *  refetched topology. */
+  /**
+   * rfId source->target pairs; fallback for drifted allocator-minted edge ids.
+   */
   edgePairs: ReadonlySet<string>
+}
+
+type NodeIdResolver = (node: TopologyNodeWire) => string | null
+
+const TRANSPORT_NODE_TYPE = "transportNode"
+
+/**
+ * Guard for wire fields that must be non-empty before they can identify graph items.
+ */
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+/** Keep label fallback lookups consistent with the static id maps. */
+function normalizedLabel(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : ""
+}
+
+/**
+ * React Flow edge ids can drift, so source/target pairs provide a stable backup key.
+ */
+function edgePairId(source: string, target: string): string {
+  return `${source}->${target}`
+}
+
+function emptyMessagingHighlightIds(): MessagingHighlightIds {
+  return { nodeIds: new Set(), edgeIds: new Set(), edgePairs: new Set() }
+}
+
+/** Match the dynamic ids produced by `topologyWireToReactFlow`. */
+function resolveDynamicNodeId(node: TopologyNodeWire): string | null {
+  const stableAgentId = extractStableAgentId(node)
+  if (stableAgentId) return stableAgentId
+  if (node.type === TRANSPORT_NODE_TYPE)
+    return transportCanonicalRfId(node.label)
+  return hasText(node.id) ? node.id : null
+}
+
+/** Translate wire ids into authored static graph ids used by legacy patterns. */
+function resolveStaticGraphNodeId(
+  node: TopologyNodeWire,
+  idMap: StaticIdMap,
+): string | null {
+  const stableAgentId = extractStableAgentId(node)
+  if (stableAgentId) {
+    const uuid = parseStableAgentUuid(stableAgentId)
+    const staticId = uuid ? idMap.idByStableAgentUuid.get(uuid) : undefined
+    return staticId ?? stableAgentId
+  }
+
+  if (node.type === TRANSPORT_NODE_TYPE) {
+    const canonicalId = transportCanonicalRfId(node.label)
+    const transportKey = canonicalId.replace(/^transport:\/\//, "")
+    return idMap.idByTransportKey.get(transportKey) ?? canonicalId
+  }
+
+  const labelId = idMap.idByLabel.get(normalizedLabel(node.label))
+  if (labelId !== undefined) return labelId
+
+  return hasText(node.id) ? node.id : null
+}
+
+/** Shared topology traversal; callers only choose how each node id is resolved. */
+function collectMessagingHighlightIds(
+  topology: TopologyWire | null | undefined,
+  resolveNodeId: NodeIdResolver,
+): MessagingHighlightIds {
+  if (!topology) return emptyMessagingHighlightIds()
+
+  const nodeIds = new Set<string>()
+  const edgeIds = new Set<string>()
+  const edgePairs = new Set<string>()
+  const wireIdToRenderedId = new Map<string, string>()
+
+  for (const node of topology.nodes ?? []) {
+    const renderedId = resolveNodeId(node)
+    if (!renderedId) continue
+
+    nodeIds.add(renderedId)
+    if (hasText(node.id)) wireIdToRenderedId.set(node.id, renderedId)
+  }
+
+  for (const edge of topology.edges ?? []) {
+    if (hasText(edge.id)) edgeIds.add(edge.id)
+    if (!hasText(edge.source) || !hasText(edge.target)) continue
+
+    const source = wireIdToRenderedId.get(edge.source) ?? edge.source
+    const target = wireIdToRenderedId.get(edge.target) ?? edge.target
+    edgePairs.add(edgePairId(source, target))
+  }
+
+  return { nodeIds, edgeIds, edgePairs }
 }
 
 /** Read the workflow-instance topology fragment carried on an event_v1. */
@@ -34,51 +130,11 @@ export function extractInstanceTopologyFromEvent(
   return topo as TopologyWire
 }
 
-/** Treat every id listed in the partial topology as part of the current
- *  messaging path. Node ids mirror ``rfIdOf`` in topologyToReactFlow:
- *  stable_agent_id for agents, transport canonical id for transports, wire id otherwise. */
+/** Build highlight ids in the dynamic React Flow id namespace. */
 export function messagingHighlightIdsFromTopology(
   topology: TopologyWire | null | undefined,
 ): MessagingHighlightIds {
-  const nodeIds = new Set<string>()
-  const edgeIds = new Set<string>()
-  const edgePairs = new Set<string>()
-  // wire id -> rf id, so edges can be translated to node-id pairs
-  const wireToRf = new Map<string, string>()
-  for (const n of topology?.nodes ?? []) {
-    const wireId = (n as { id?: unknown }).id
-    const nType = (n as { type?: unknown }).type
-    const nLabel = (n as { label?: unknown }).label
-    const sid = extractStableAgentId(n as never)
-    let rfId: string | null = null
-    if (sid) {
-      rfId = sid
-    } else if (nType === "transportNode") {
-      rfId = transportCanonicalRfId(
-        typeof nLabel === "string" ? nLabel : undefined,
-      )
-    } else if (typeof wireId === "string" && wireId.length) {
-      rfId = wireId
-    }
-    if (rfId) {
-      nodeIds.add(rfId)
-      if (typeof wireId === "string" && wireId.length) {
-        wireToRf.set(wireId, rfId)
-      }
-    }
-  }
-  for (const e of topology?.edges ?? []) {
-    const id = (e as { id?: unknown }).id
-    if (typeof id === "string" && id.length) edgeIds.add(id)
-    const src = (e as { source?: unknown }).source
-    const tgt = (e as { target?: unknown }).target
-    if (typeof src === "string" && typeof tgt === "string") {
-      const s = wireToRf.get(src) ?? src
-      const t = wireToRf.get(tgt) ?? tgt
-      edgePairs.add(`${s}->${t}`)
-    }
-  }
-  return { nodeIds, edgeIds, edgePairs }
+  return collectMessagingHighlightIds(topology, resolveDynamicNodeId)
 }
 
 export function patchGraphActiveHighlight(
@@ -100,7 +156,7 @@ export function patchGraphActiveHighlight(
   const nextEdges = edges.map((edge) => {
     const on =
       highlight.edgeIds.has(edge.id) ||
-      highlight.edgePairs.has(`${edge.source}->${edge.target}`)
+      highlight.edgePairs.has(edgePairId(edge.source, edge.target))
     const prev = Boolean(
       (edge.data as { active?: unknown } | undefined)?.active,
     )
@@ -115,71 +171,13 @@ export function patchGraphActiveHighlight(
 }
 
 /**
- * Like `messagingHighlightIdsFromTopology`, but additionally consults wire
- * labels via the supplied id map's `idByLabel`. Labels are the only way to
- * bridge nodes that don't carry a stable_agent_id (e.g. the Logistics Group
- * container, the AGNTCY Agent Directory node).
- *
- * Falls back to dynamic id form when no static id match is found, so the
- * patch step simply skips ids without a static counterpart.
+ * Build highlight ids in the static graph id namespace when a pattern uses authored nodes.
  */
-export function highlightIdsFromTopologyWithOverlay(
+export function staticGraphHighlightIdsFromTopology(
   topology: TopologyWire | null | undefined,
   idMap: StaticIdMap,
 ): MessagingHighlightIds {
-  const nodeIds = new Set<string>()
-  const edgeIds = new Set<string>()
-  const edgePairs = new Set<string>()
-  const wireToRf = new Map<string, string>()
-  for (const n of topology?.nodes ?? []) {
-    const wireId = (n as { id?: unknown }).id
-    const nType = (n as { type?: unknown }).type
-    const nLabel = (n as { label?: unknown }).label
-    const labelStr = typeof nLabel === "string" ? nLabel : ""
-    const sid = extractStableAgentId(n as never)
-    let rfId: string | null = null
-    // 1. stable_agent_id -> static
-    if (sid) {
-      const uuid = parseStableAgentUuid(sid)
-      if (uuid) {
-        const viaStable = idMap.idByStableAgentUuid.get(uuid)
-        if (viaStable !== undefined) rfId = viaStable
-      }
-      if (rfId === null) rfId = sid // pass through; patch step will skip unmatched
-    }
-    // 2. transport canonical -> static
-    if (rfId === null && nType === "transportNode") {
-      const canon = transportCanonicalRfId(labelStr || undefined)
-      const key = canon.replace(/^transport:\/\//, "")
-      const viaTransport = idMap.idByTransportKey.get(key)
-      rfId = viaTransport !== undefined ? viaTransport : canon
-    }
-    // 3. label -> static (covers logistics-group, agntcy-directory)
-    if (rfId === null && labelStr) {
-      const viaLabel = idMap.idByLabel.get(labelStr.trim().toLowerCase())
-      if (viaLabel !== undefined) rfId = viaLabel
-    }
-    // 4. wire id fallback
-    if (rfId === null && typeof wireId === "string" && wireId.length) {
-      rfId = wireId
-    }
-    if (rfId) {
-      nodeIds.add(rfId)
-      if (typeof wireId === "string" && wireId.length) {
-        wireToRf.set(wireId, rfId)
-      }
-    }
-  }
-  for (const e of topology?.edges ?? []) {
-    const id = (e as { id?: unknown }).id
-    if (typeof id === "string" && id.length) edgeIds.add(id)
-    const src = (e as { source?: unknown }).source
-    const tgt = (e as { target?: unknown }).target
-    if (typeof src === "string" && typeof tgt === "string") {
-      const s = wireToRf.get(src) ?? src
-      const t = wireToRf.get(tgt) ?? tgt
-      edgePairs.add(`${s}->${t}`)
-    }
-  }
-  return { nodeIds, edgeIds, edgePairs }
+  return collectMessagingHighlightIds(topology, (node) =>
+    resolveStaticGraphNodeId(node, idMap),
+  )
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import type { EventV1Wire, TopologyWire } from "@/api/agenticWorkflowsTypes"
+import type { Edge, Node } from "@xyflow/react"
+import {
+  extractStableAgentId,
+  transportCanonicalRfId,
+} from "@/utils/topologyToReactFlow"
+import type { StaticIdMap } from "@/utils/topologyStaticIdMap"
+import { parseStableAgentUuid } from "@/utils/agenticTopologyIdentityUiMap"
+
+export interface MessagingHighlightIds {
+  nodeIds: ReadonlySet<string>
+  edgeIds: ReadonlySet<string>
+  /** rfId source->target pairs derived from partial topology, used as a
+   *  fallback when allocator-minted edge ids drift between event and
+   *  refetched topology. */
+  edgePairs: ReadonlySet<string>
+}
+
+/** Read the workflow-instance topology fragment carried on an event_v1. */
+export function extractInstanceTopologyFromEvent(
+  ev: EventV1Wire,
+  workflowName: string,
+  instanceId: string,
+): TopologyWire | null {
+  const inst = ev.data?.workflows?.[workflowName]?.instances?.[instanceId]
+  if (!inst || typeof inst !== "object") return null
+  const topo = (inst as { topology?: unknown }).topology
+  if (!topo || typeof topo !== "object") return null
+  return topo as TopologyWire
+}
+
+/** Treat every id listed in the partial topology as part of the current
+ *  messaging path. Node ids mirror ``rfIdOf`` in topologyToReactFlow:
+ *  stable_agent_id for agents, transport canonical id for transports, wire id otherwise. */
+export function messagingHighlightIdsFromTopology(
+  topology: TopologyWire | null | undefined,
+): MessagingHighlightIds {
+  const nodeIds = new Set<string>()
+  const edgeIds = new Set<string>()
+  const edgePairs = new Set<string>()
+  // wire id -> rf id, so edges can be translated to node-id pairs
+  const wireToRf = new Map<string, string>()
+  for (const n of topology?.nodes ?? []) {
+    const wireId = (n as { id?: unknown }).id
+    const nType = (n as { type?: unknown }).type
+    const nLabel = (n as { label?: unknown }).label
+    const sid = extractStableAgentId(n as never)
+    let rfId: string | null = null
+    if (sid) {
+      rfId = sid
+    } else if (nType === "transportNode") {
+      rfId = transportCanonicalRfId(
+        typeof nLabel === "string" ? nLabel : undefined,
+      )
+    } else if (typeof wireId === "string" && wireId.length) {
+      rfId = wireId
+    }
+    if (rfId) {
+      nodeIds.add(rfId)
+      if (typeof wireId === "string" && wireId.length) {
+        wireToRf.set(wireId, rfId)
+      }
+    }
+  }
+  for (const e of topology?.edges ?? []) {
+    const id = (e as { id?: unknown }).id
+    if (typeof id === "string" && id.length) edgeIds.add(id)
+    const src = (e as { source?: unknown }).source
+    const tgt = (e as { target?: unknown }).target
+    if (typeof src === "string" && typeof tgt === "string") {
+      const s = wireToRf.get(src) ?? src
+      const t = wireToRf.get(tgt) ?? tgt
+      edgePairs.add(`${s}->${t}`)
+    }
+  }
+  return { nodeIds, edgeIds, edgePairs }
+}
+
+export function patchGraphActiveHighlight(
+  nodes: Node[],
+  edges: Edge[],
+  highlight: MessagingHighlightIds,
+): { nodes: Node[]; edges: Edge[] } {
+  const nextNodes = nodes.map((node) => {
+    const on = highlight.nodeIds.has(node.id)
+    const prev = Boolean(
+      (node.data as { active?: unknown } | undefined)?.active,
+    )
+    if (prev === on) return node
+    return {
+      ...node,
+      data: { ...node.data, active: on },
+    }
+  })
+  const nextEdges = edges.map((edge) => {
+    const on =
+      highlight.edgeIds.has(edge.id) ||
+      highlight.edgePairs.has(`${edge.source}->${edge.target}`)
+    const prev = Boolean(
+      (edge.data as { active?: unknown } | undefined)?.active,
+    )
+    if (prev === on && Boolean(edge.animated) === on) return edge
+    return {
+      ...edge,
+      animated: on,
+      data: { ...edge.data, active: on },
+    }
+  })
+  return { nodes: nextNodes, edges: nextEdges }
+}
+
+/**
+ * Like `messagingHighlightIdsFromTopology`, but additionally consults wire
+ * labels via the supplied id map's `idByLabel`. Labels are the only way to
+ * bridge nodes that don't carry a stable_agent_id (e.g. the Logistics Group
+ * container, the AGNTCY Agent Directory node).
+ *
+ * Falls back to dynamic id form when no static id match is found, so the
+ * patch step simply skips ids without a static counterpart.
+ */
+export function highlightIdsFromTopologyWithOverlay(
+  topology: TopologyWire | null | undefined,
+  idMap: StaticIdMap,
+): MessagingHighlightIds {
+  const nodeIds = new Set<string>()
+  const edgeIds = new Set<string>()
+  const edgePairs = new Set<string>()
+  const wireToRf = new Map<string, string>()
+  for (const n of topology?.nodes ?? []) {
+    const wireId = (n as { id?: unknown }).id
+    const nType = (n as { type?: unknown }).type
+    const nLabel = (n as { label?: unknown }).label
+    const labelStr = typeof nLabel === "string" ? nLabel : ""
+    const sid = extractStableAgentId(n as never)
+    let rfId: string | null = null
+    // 1. stable_agent_id -> static
+    if (sid) {
+      const uuid = parseStableAgentUuid(sid)
+      if (uuid) {
+        const viaStable = idMap.idByStableAgentUuid.get(uuid)
+        if (viaStable !== undefined) rfId = viaStable
+      }
+      if (rfId === null) rfId = sid // pass through; patch step will skip unmatched
+    }
+    // 2. transport canonical -> static
+    if (rfId === null && nType === "transportNode") {
+      const canon = transportCanonicalRfId(labelStr || undefined)
+      const key = canon.replace(/^transport:\/\//, "")
+      const viaTransport = idMap.idByTransportKey.get(key)
+      rfId = viaTransport !== undefined ? viaTransport : canon
+    }
+    // 3. label -> static (covers logistics-group, agntcy-directory)
+    if (rfId === null && labelStr) {
+      const viaLabel = idMap.idByLabel.get(labelStr.trim().toLowerCase())
+      if (viaLabel !== undefined) rfId = viaLabel
+    }
+    // 4. wire id fallback
+    if (rfId === null && typeof wireId === "string" && wireId.length) {
+      rfId = wireId
+    }
+    if (rfId) {
+      nodeIds.add(rfId)
+      if (typeof wireId === "string" && wireId.length) {
+        wireToRf.set(wireId, rfId)
+      }
+    }
+  }
+  for (const e of topology?.edges ?? []) {
+    const id = (e as { id?: unknown }).id
+    if (typeof id === "string" && id.length) edgeIds.add(id)
+    const src = (e as { source?: unknown }).source
+    const tgt = (e as { target?: unknown }).target
+    if (typeof src === "string" && typeof tgt === "string") {
+      const s = wireToRf.get(src) ?? src
+      const t = wireToRf.get(tgt) ?? tgt
+      edgePairs.add(`${s}->${t}`)
+    }
+  }
+  return { nodeIds, edgeIds, edgePairs }
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/recruiter/test_main.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/recruiter/test_main.py
@@ -122,7 +122,7 @@ class TestPromptEndpoint:
             assert resp.status_code == 200
             # Verify the session_id was passed through
             mock_call.assert_called_once_with(
-                query="Test", session_id="my-session"
+                query="Test", session_id="my-session", workflow_instance_id=None
             )
 
     def test_prompt_generates_session_id_when_not_provided(self, client):
@@ -191,7 +191,7 @@ class TestPromptEndpoint:
 
 class TestStreamEndpoint:
     def test_stream_returns_ndjson(self, client):
-        async def fake_stream(query, session_id):
+        async def fake_stream(query, session_id, workflow_instance_id=None):
             event = MagicMock()
             event.is_final_response.return_value = True
             event.content = MagicMock()
@@ -218,7 +218,7 @@ class TestStreamEndpoint:
             assert data["response"]["message"] == "Final answer"
 
     def test_stream_intermediate_events(self, client):
-        async def fake_stream(query, session_id):
+        async def fake_stream(query, session_id, workflow_instance_id=None):
             # Intermediate event
             event1 = MagicMock()
             event1.is_final_response.return_value = False
@@ -253,7 +253,7 @@ class TestStreamEndpoint:
             assert intermediate["response"]["state"] == "working"
 
     def test_stream_with_session_id(self, client):
-        async def fake_stream(query, session_id):
+        async def fake_stream(query, session_id, workflow_instance_id=None):
             event = MagicMock()
             event.is_final_response.return_value = True
             event.content = MagicMock()


### PR DESCRIPTION
# Description

Sync the React Flow graph to live workflow-instance state so edges animate and
nodes highlight in response to SSE events from the Agentic Workflows API.

- Forward `workflow_instance_id` from the frontend supervisors POST through to
  the streaming stores; bridge via `activeWorkflowInstanceStore`.
- Dedup wire nodes by `stable_agent_id` / transport-canonical id so SSE events
  land on stable React Flow ids regardless of trace-minted aliases.
- Drive `edge.animated` and node `data.active` from SSE topology fragments via
  `workflowEventMessagingHighlight` + `topologyStaticIdMap`. Preserve animation
  across static-config rebuilds with `restoreEdgeAnimation`.
- Move node positions onto the wire: optional `position { x, y }` on seed nodes
  in `starting_workflows.json`; `topologyWireToReactFlow` prefers it and falls
  back to layered auto-layout when absent.

## Testing

```
cd frontend && npm run dev
```

**Auction Supervisor**
```
docker compose --profile farms --profile observability up --build --pull never
```

**Logistics Supervisor**
```
docker compose --profile logistics --profile observability up --build --pull never
```

https://github.com/user-attachments/assets/de53845e-71da-462c-8b60-a50a0b4bc238

## Known Limitations
* Events are emitted for A2A clients only via middleware, MCP clients are not supported. 
* slim-a2a-python < 1.0 does properly pass middleware, effect is that point-to-point slimrpc does not produce events. Fixed in A2A 1.0 where the transport is not responsible for middleware.
https://github.com/agntcy/coffeeAgntcy/issues/531

## Issue Link

Resolves #542

## Type of Change

- [X] New Feature

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass