### PR TITLE
refactor: use uv docker base image for agents

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
@@ -16,12 +16,6 @@ ARG BUILD_SOURCE=local
 ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
@@ -17,12 +17,21 @@ ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv  uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/corto/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
 
 ## Generate about.properties file with build metadata
 RUN printf "app.name=corto-exchange\n"                > about.properties && \

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
@@ -18,7 +18,9 @@ ARG IMAGE_TAG=unknown
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv  uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/corto/ .
 

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
@@ -1,6 +1,6 @@
 # `coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange`
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Build arguments for metadata
 ARG BUILD_VERSION=unknown
@@ -21,11 +21,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
@@ -1,16 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including ping, curl, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
@@ -2,8 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./
-RUN uv sync --locked --no-editable
+
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
+ENV UV_LINK_MODE=copy
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/corto/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "farm/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including ping, curl, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/corto/pyproject.toml coffeeAGNTCY/coffee_agents/corto/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.ui
@@ -2,25 +2,21 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install wget, curl, and ping (iputils)
-RUN apk add --no-cache wget curl iputils
-
-# Copy package.json and package-lock.json, then install dependencies
-COPY coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package.json coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package-lock.json ./
+# Install dependencies
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package.json,target=package.json \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package-lock.json,target=package-lock.json \
+    npm ci
 
 # Copy application files, including assets
 COPY coffeeAGNTCY/coffee_agents/corto/exchange/frontend/ .
 
-# This build step is simply for checking the validity of the build:
-# running type checks, linting, and making sure the build is functional.
-RUN ["npm", "install", "--verbose"]
-RUN ["npm", "run", "build", "--verbose"]
-RUN ["npm", "cache", "clean", "--force"]
+# Build the frontend
+RUN npm install --verbose
+RUN npm run build --verbose
 
 # Expose port 3000
 EXPOSE 3000
 
-# Copy the script to build and serve the UI
-COPY coffeeAGNTCY/coffee_agents/corto/docker/ui-build-and-serve.sh ./ui-build-and-serve.sh
 # Start the application
-CMD ["sh", "./ui-build-and-serve.sh"]
+CMD ["npx", "serve", "-s", "dist", "-l", "3000"]

--- a/coffeeAGNTCY/coffee_agents/corto/docker/ui-build-and-serve.sh
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/ui-build-and-serve.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-npm run build
-npx serve -s dist -l 3000

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
@@ -16,12 +16,21 @@ ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install python dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
 
 RUN printf "app.name=agentic-workflows-api\n"                > about.properties && \
     printf "app.service=agentic-workflows-api\n"              >> about.properties && \

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
@@ -15,11 +15,6 @@ ARG BUILD_SOURCE=local
 ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
@@ -17,7 +17,9 @@ ARG IMAGE_TAG=unknown
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
@@ -1,6 +1,6 @@
 # Agentic Workflows HTTP API
 # SLIM v0.7+ requires debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 ARG BUILD_VERSION=unknown
 ARG BUILD_DATE=unknown
@@ -19,12 +19,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
@@ -1,6 +1,6 @@
 # `coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.exchange`
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 ARG BUILD_VERSION=unknown
 ARG BUILD_DATE=unknown
@@ -20,14 +20,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
@@ -15,12 +15,6 @@ ARG BUILD_SOURCE=local
 ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
@@ -16,12 +16,21 @@ ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
 
 ## Generate about.properties file with build metadata
 RUN printf "app.name=lungo-exchange\n"                > about.properties && \

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
@@ -17,7 +17,9 @@ ARG IMAGE_TAG=unknown
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
@@ -3,7 +3,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/farms/brazil/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
@@ -2,10 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/farms/brazil/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including ping, curl, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including ping, curl, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
@@ -2,10 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/farms/colombia/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including ping, curl, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including ping, curl, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
@@ -3,7 +3,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/farms/colombia/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
@@ -3,7 +3,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/logistics/accountant/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
@@ -2,10 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/logistics/accountant/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
@@ -3,7 +3,10 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/logistics/farm/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
@@ -2,11 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/logistics/farm/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
@@ -3,7 +3,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/logistics/helpdesk/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
@@ -2,10 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/logistics/helpdesk/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
@@ -2,10 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/logistics/shipper/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
@@ -3,7 +3,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/logistics/shipper/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
@@ -3,7 +3,10 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/supervisors/logistics/main.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
@@ -2,11 +2,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/supervisors/logistics/main.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
@@ -1,12 +1,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
@@ -3,7 +3,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 EXPOSE 8125

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
@@ -1,19 +1,11 @@
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
@@ -2,11 +2,21 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 EXPOSE 8125
 CMD ["uv", "run", "python", "agents/mcp_servers/payment_service.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
@@ -15,12 +15,6 @@ ARG BUILD_SOURCE=local
 ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
@@ -16,12 +16,21 @@ ARG IMAGE_NAME=unknown
 ARG IMAGE_TAG=unknown
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
 
 ## Generate about.properties file with build metadata
 RUN printf "app.name=lungo-recruiter-supervisor\n"       > about.properties && \

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
@@ -17,7 +17,9 @@ ARG IMAGE_TAG=unknown
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
@@ -1,6 +1,6 @@
 # `coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor`
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 ARG BUILD_VERSION=unknown
 ARG BUILD_DATE=unknown
@@ -20,14 +20,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
@@ -2,22 +2,21 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Copy package.json and package-lock.json, then install dependencies
-COPY coffeeAGNTCY/coffee_agents/lungo/frontend/package.json coffeeAGNTCY/coffee_agents/lungo/frontend/package-lock.json ./
+# Install dependencies
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/frontend/package.json,target=package.json \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/frontend/package-lock.json,target=package-lock.json \
+    npm ci
 
 # Copy application files, including assets
 COPY coffeeAGNTCY/coffee_agents/lungo/frontend/ .
 
-# This build step is simply for checking the validity of the build:
-# running type checks, linting, and making sure the build is functional.
-RUN ["npm", "install", "--verbose"]
-RUN ["npm", "run", "build", "--verbose"]
-RUN ["npm", "cache", "clean", "--force"]
+# Build the frontend
+RUN npm install --verbose
+RUN npm run build --verbose
 
 # Expose port 3000
 EXPOSE 3000
 
-# Copy the script to build and serve the UI
-COPY coffeeAGNTCY/coffee_agents/lungo/docker/ui-build-and-serve.sh ./ui-build-and-serve.sh
 # Start the application
-CMD ["sh", "./ui-build-and-serve.sh"]
+CMD ["npx", "serve", "-s", "dist", "-l", "3000"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
@@ -2,9 +2,6 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install wget, curl, and ping (iputils)
-RUN apk add --no-cache wget curl iputils
-
 # Copy package.json and package-lock.json, then install dependencies
 COPY coffeeAGNTCY/coffee_agents/lungo/frontend/package.json coffeeAGNTCY/coffee_agents/lungo/frontend/package-lock.json ./
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
@@ -2,7 +2,10 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 CMD ["uv", "run", "python", "agents/farms/vietnam/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
@@ -1,18 +1,10 @@
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including ping, curl, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
@@ -1,11 +1,5 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including ping, curl, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
@@ -1,11 +1,20 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 CMD ["uv", "run", "python", "agents/farms/vietnam/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
@@ -1,17 +1,10 @@
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
+
 # Install system dependencies, including curl, ping, and wget
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl wget iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
@@ -2,7 +2,9 @@ FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 EXPOSE 8125

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
@@ -1,11 +1,21 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
+
 EXPOSE 8125
 CMD ["uv", "run", "python", "agents/mcp_servers/weather_service.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
@@ -1,11 +1,5 @@
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including curl, ping, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/lungo/pyproject.toml coffeeAGNTCY/coffee_agents/lungo/uv.lock ./
 RUN uv sync --locked --no-editable

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/ui-build-and-serve.sh
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/ui-build-and-serve.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-npm run build
-npx serve -s dist -l 3000

--- a/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
+++ b/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
@@ -12,7 +12,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml coffeeAGNTCY/coffee_agents/recruiter/uv.lock coffeeAGNTCY/coffee_agents/recruiter/README.md ./
-RUN uv sync --locked --no-editable
+
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
 
 COPY coffeeAGNTCY/coffee_agents/recruiter/ .
 

--- a/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
+++ b/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # SLIM v0.7+ requires to use debian trixie distribution
-FROM python:3.13.11-slim-trixie
+FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
 # Install system dependencies, including ping, curl, and wget
 RUN apt-get update && \
@@ -15,14 +15,6 @@ RUN apt-get update && \
 RUN ARCH=$(dpkg --print-architecture) && \
     curl -L https://github.com/agntcy/dir/releases/download/v1.0.0/dirctl-linux-${ARCH} -o /usr/local/bin/dirctl && \
     chmod +x /usr/local/bin/dirctl
-
-# Install uv and create virtual environment
-RUN pip install --no-cache-dir uv && \
-    uv venv -q /venv
-ENV PATH="/venv/bin:$PATH"
-
-# Set PYTHONPATH to include the application directory
-ENV PYTHONPATH="/app"
 
 WORKDIR /app
 COPY coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml coffeeAGNTCY/coffee_agents/recruiter/uv.lock coffeeAGNTCY/coffee_agents/recruiter/README.md ./

--- a/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
+++ b/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
@@ -11,12 +11,21 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/dirctl
 
 WORKDIR /app
-COPY coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml coffeeAGNTCY/coffee_agents/recruiter/uv.lock coffeeAGNTCY/coffee_agents/recruiter/README.md ./
 
+# Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --no-editable
+
+# Install python dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/recruiter/uv.lock,target=uv.lock \
+    --mount=type=bind,source=coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
 
 COPY coffeeAGNTCY/coffee_agents/recruiter/ .
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
 
 # Expose the A2A server port
 EXPOSE 8881

--- a/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
+++ b/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
@@ -4,12 +4,6 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install system dependencies, including ping, curl, and wget
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl wget iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Install dirctl binary for MCP toolset (detect architecture for multi-platform builds)
 # Note: Using specific version as /releases/latest/ points to GUI release which doesn't include dirctl
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
+++ b/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
@@ -4,11 +4,7 @@
 # SLIM v0.7+ requires to use debian trixie distribution
 FROM astral/uv:0.11.16-python3.13-trixie-slim@sha256:d57fc364ed714127c162a01b316bfb7b9a3fd09d97c665781a5607acaa35d254
 
-# Install dirctl binary for MCP toolset (detect architecture for multi-platform builds)
-# Note: Using specific version as /releases/latest/ points to GUI release which doesn't include dirctl
-RUN ARCH=$(dpkg --print-architecture) && \
-    curl -L https://github.com/agntcy/dir/releases/download/v1.0.0/dirctl-linux-${ARCH} -o /usr/local/bin/dirctl && \
-    chmod +x /usr/local/bin/dirctl
+COPY --from=ghcr.io/agntcy/dir-ctl:v1.0.0 /dirctl /usr/local/bin/dirctl
 
 WORKDIR /app
 


### PR DESCRIPTION
# Description

This PR change-set includes improvements across the dockerfiles, mainly focusing on the optimization of the agents building. This is achieved by using `uv` docker image as a base image and remove some steps from docker image building.

The improvements measured on a M1 Pro Macbook Pro was around 30s (2min instead of 2.5 min) with `farms,observality,frontend` compose profiles.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
