### PR TITLE
feat: Dockerfiles - pin uv and npm cache location and use per-project id field in Buildkit cache

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.exchange
@@ -21,8 +21,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=corto-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -30,7 +33,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/corto/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=corto-uv,target=/root/.cache/uv \
     uv sync --locked
 
 ## Generate about.properties file with build metadata

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.farm
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=corto-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/corto/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=corto-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "farm/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.ui
@@ -2,8 +2,11 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+# Pin the npm cache location so BuildKit cache mounts and npm agree on the path
+ENV npm_config_cache=/root/.npm
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.npm \
+RUN --mount=type=cache,id=corto-npm,target=/root/.npm \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package.json,target=package.json \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package-lock.json,target=package-lock.json \
     npm ci

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.agentic-workflows-api
@@ -20,8 +20,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install python dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -29,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 RUN printf "app.name=agentic-workflows-api\n"                > about.properties && \

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.auction-supervisor
@@ -20,8 +20,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -29,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 ## Generate about.properties file with build metadata

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.brazil-farm
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/farms/brazil/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.colombia-farm
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/farms/colombia/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-accountant
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/logistics/accountant/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-farm
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/logistics/farm/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-helpdesk
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/logistics/helpdesk/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-shipper
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/logistics/shipper/server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.logistics-supervisor
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/supervisors/logistics/main.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.payment-mcp
@@ -6,8 +6,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -15,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 EXPOSE 8125

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.recruiter-supervisor
@@ -20,8 +20,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -29,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 ## Generate about.properties file with build metadata

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
@@ -2,8 +2,11 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+# Pin the npm cache location so BuildKit cache mounts and npm agree on the path
+ENV npm_config_cache=/root/.npm
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.npm \
+RUN --mount=type=cache,id=lungo-npm,target=/root/.npm \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/frontend/package.json,target=package.json \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/frontend/package-lock.json,target=package-lock.json \
     npm ci

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.vietnam-farm
@@ -5,8 +5,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -14,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 CMD ["uv", "run", "python", "agents/farms/vietnam/farm_server.py"]

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.weather-mcp
@@ -5,8 +5,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -14,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/lungo/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=lungo-uv,target=/root/.cache/uv \
     uv sync --locked
 
 EXPOSE 8125

--- a/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
+++ b/coffeeAGNTCY/coffee_agents/recruiter/Dockerfile
@@ -11,8 +11,11 @@ WORKDIR /app
 # Silences warnings about not being able to link files since the cache and sync target are on separate file systems
 ENV UV_LINK_MODE=copy
 
+# Pin the uv cache location so BuildKit cache mounts and uv agree on the path
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Install python dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=recruiter-uv,target=/root/.cache/uv \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/recruiter/uv.lock,target=uv.lock \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/recruiter/pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project
@@ -20,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY coffeeAGNTCY/coffee_agents/recruiter/ .
 
 # Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=recruiter-uv,target=/root/.cache/uv \
     uv sync --locked
 
 # Expose the A2A server port


### PR DESCRIPTION
# Description

This PR aims to address 2 follow up ideas for https://github.com/agntcy/coffeeAgntcy/pull/581 :
  1. be explicit about where the uv cache is expected to be found
    * thread: https://github.com/agntcy/coffeeAgntcy/pull/581#discussion_r3303768175
  2. Seeing as the dependencies may not always be identical between our subprojects (corto, lungo, recruiter), it would be better to id the `uv` cache backing folder per project
    * thread: https://github.com/agntcy/coffeeAgntcy/pull/581#discussion_r3303806753
  3. analogous solutions but for npm (using `npm_config_cache` and `id=<prj>-npm`)

More context and details can be found in Issue 593 (also linked below).

## Issue Link

Fixes #593 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

---

Why `npm_config_cache` and not `NPM_CONFIG_CACHE`. `npm` reads config from env vars by lowercasing the variable name and stripping the `npm_config_` prefix (so `npm_config_cache` → the `cache` config key). The uppercase form also works, but lowercase is the documented npm-native convention and matches what the npm docs show. Either would have been fine; I went with the canonical npm form.