### PR TITLE
feat(lungo,age-wf): add ingress, fix port & local-cluster

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Agentic Workflows HTTP API
 name: agentic-workflows-api
-version: 0.0.2
+version: 0.1.0

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/ingress.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/ingress.tpl.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.ingress.serviceName }}
+                port:
+                  number: {{ .Values.ingress.servicePort }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecret }}
+{{- end }}
+
+{{/* Optional second ingress for a specific path prefix and annotations */}}
+{{- if .Values.extraIngress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.extraIngress.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.extraIngress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.extraIngress.className }}
+  rules:
+    - host: {{ .Values.extraIngress.host }}
+      http:
+        paths:
+          - path: {{ .Values.extraIngress.path }}
+            pathType: {{ .Values.extraIngress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ .Values.extraIngress.serviceName }}
+                port:
+                  number: {{ .Values.extraIngress.servicePort }}
+  tls:
+    - hosts:
+        - {{ .Values.extraIngress.host }}
+      secretName: {{ .Values.extraIngress.tlsSecret }}
+{{- end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/service.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/service.tpl.yaml
@@ -13,7 +13,7 @@ spec:
   - port: {{ .Values.service.port }}
     name: http
     {{- if eq .Values.environment "local"}}
-    nodePort: 30083
+    nodePort: 30084
     {{- end}}
   selector:
     app:  {{ .Values.appName }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/values.yaml
@@ -25,6 +25,29 @@ workflowApiKeySecret:
   name: agentic-workflows-api-api-key-secret
   key: WORKFLOW_API_KEY
 
+# You can use your own ingress stack of operators and letsencrypt mechanism
+ingress:
+  enabled: false # If set to true, configure the values below for your ingress setup
+  name: ""
+  className: ""
+  host: ""
+  serviceName: ""
+  servicePort: ""
+  tlsSecret: ""
+  annotations: {}
+
+extraIngress:
+  enabled: false # If set to true, configure the values below for your additional ingress setup
+  name: ""
+  className: ""
+  host: ""
+  serviceName: ""
+  servicePort: ""
+  tlsSecret: ""
+  path: ""
+  pathType: ""
+  annotations: {}
+
 probes:
   readinessProbeEnabled: true
   livenessProbeEnabled: true

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -57,7 +57,7 @@ dependencies:
     version: "0.1.0"
     repository: "file://../recruiter-supervisor"
   - name: lungo-ui
-    version: "0.0.9"
+    version: "0.1.0"
     repository: "file://../ui"
   - name: agentic-workflows-api
     version: "0.1.0"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -60,5 +60,5 @@ dependencies:
     version: "0.0.9"
     repository: "file://../ui"
   - name: agentic-workflows-api
-    version: "0.0.2"
+    version: "0.1.0"
     repository: "file://../agentic-workflows-api"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lungo-local-cluster
 description: A Helm chart for deploying Lungo services in a local cluster
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.0"
 dependencies:
   - name: slim

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/kind-config.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/kind-config.yaml
@@ -8,5 +8,7 @@ nodes:
     hostPort: 30080
   - containerPort: 30081
     hostPort: 30081
+  - containerPort: 30082
+    hostPort: 30082
   - containerPort: 30083
     hostPort: 3000

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/kind-config.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/kind-config.yaml
@@ -12,3 +12,5 @@ nodes:
     hostPort: 30082
   - containerPort: 30083
     hostPort: 3000
+  - containerPort: 30084
+    hostPort: 30084

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/values.yaml
@@ -78,7 +78,7 @@ lungo-ui:
     exchangeAppApiUrl: "http://localhost:30080"
     logisticsAppApiUrl: "http://localhost:30081"
     discoveryAppApiUrl: "http://localhost:30082"
-    agenticWorkflowsApiUrl: "http://localhost:30083"
+    agenticWorkflowsApiUrl: "http://localhost:30084"
 
 # Populated by helmfile / config-overrides.yaml.gotmpl for local dev; defaults avoid nil when templating alone.
 localExternalSecret:


### PR DESCRIPTION
# Description

1. Added ingress for Agentic Workflows API to be able to deploy and reach it without piggybacking on the UI ingress (current workaround).
    The ingress and config setup was mimicking earlier Lungo ingresses from the supervisor charts.
2. Updated the Agentic Workflows container/node port 30083->30084, 30083 is also used by the UI and even though we redirect that to 3000 on localhost, I wanted to make we don't clash/reuse ports in any context.
3. Released a version bump of the Agentic workflows chart version to 0.1.0 with these changes.
4. Added the recruiter container port to the kind control plane config in local-cluster.
5. Fixed the Agentic Workflows container port config in local-cluster references.
6. Bumped the Agentic Workflows chart version in local-cluster to 0.1.0.
7. Bumped the Lungo UI chart version in local-cluster to 0.1.0 (old version was invalid, we just never ran into this).
8. Released a version bump of the local cluster chart version to 0.3.0 with these changes.

## Issue Link

Link the primary issue in the PR description using `#` (e.g. `Fixes #123`). This enables two‑way linking.

## Type of Change

- [X] Bugfix
- [X] New Feature

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
