### PR TITLE
fix(lungo,helm): fix SLIM shared secret propagation

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.3"
 description: A Helm chart for Auction Supervisor
 name: auction-supervisor
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/auction-supervisor/values.yaml
@@ -25,7 +25,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   #  llmStreaming: False
 

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.6"
 description: A Helm chart for the Brazil Farm
 name: brazil-farm
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/brazil-farm/values.yaml
@@ -24,7 +24,7 @@ config:
   slimServer: ""
   natsServer: ""
   # When externalSecrets is not used, set to inject SLIM_SHARED_SECRET via Helm Secret (see transport-secret.tpl.yaml).
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
 #  llmStreaming: False
 

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.11"
 description: A Helm chart for the Colombia Farm
 name: colombia-farm
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/colombia-farm/values.yaml
@@ -22,7 +22,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   # Identity configuration
   identityApiServerUrl: "" # Identity API endpoint

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lungo-local-cluster
 description: A Helm chart for deploying Lungo services in a local cluster
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "1.0"
 dependencies:
   - name: slim

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -21,40 +21,40 @@ dependencies:
     version: "10.1.2"
     repository: "oci://ghcr.io/grafana/helm-charts"
   - name: auction-supervisor
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../auction-supervisor"
   - name: brazil-farm
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../brazil-farm"
   - name: vietnam-farm
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../vietnam-farm"
   - name: colombia-farm
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../colombia-farm"
   - name: weather-mcp-server
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../weather-mcp-server"
   - name: logistics-farm
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../logistics-farm"
   - name: logistics-helpdesk
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../logistics-helpdesk"
   - name: logistics-supervisor
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../logistics-supervisor"
   - name: logistics-shipper
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../logistics-shipper"
   - name: logistics-accountant
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../logistics-accountant"
   - name: recruiter
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../recruiter"
   - name: recruiter-supervisor
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../recruiter-supervisor"
   - name: lungo-ui
     version: "0.1.0"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/Chart.yaml
@@ -62,3 +62,6 @@ dependencies:
   - name: agentic-workflows-api
     version: "0.1.0"
     repository: "file://../agentic-workflows-api"
+  - name: payment-mcp-server
+    version: "0.1.1"
+    repository: "file://../payment-mcp-server"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/local-cluster/values.yaml
@@ -36,7 +36,7 @@ weather-mcp-server:
   slimServer: "lungo-local-cluster-slim:46357"
   natsServer: "lungo-local-cluster-nats:4222"
   # Set via CI/helmfile or leave empty if using image default from config.config for dev only.
-  slimSharedSecret: ""
+  slimSharedSecret: "dummy_password" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: "http://lungo-local-cluster-opentelemetry-collector:4318"
 
 agentic-workflows-api:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics Accountant agent
 name: logistics-accountant
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-accountant/values.yaml
@@ -19,7 +19,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   corsAllowedOrigins: ""
 

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics Farm agent
 name: logistics-farm
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-farm/values.yaml
@@ -19,7 +19,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   corsAllowedOrigins: ""
 

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics HelpDesk agent
 name: logistics-helpdesk
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/templates/deployment.tpl.yaml
@@ -63,7 +63,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-helpdesk/values.yaml
@@ -22,7 +22,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   corsAllowedOrigins: ""
 #  llmStreaming: False

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Logistics Shipper agent
 name: logistics-shipper
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-shipper/values.yaml
@@ -19,7 +19,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   corsAllowedOrigins: ""
 

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.3"
 description: A Helm chart for the Logistics Supervisor agent
 name: logistics-supervisor
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/deployment.tpl.yaml
@@ -63,7 +63,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/logistics-supervisor/values.yaml
@@ -22,7 +22,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   experimentalFeature: "true"
   corsAllowedOrigins: ""

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/payment-mcp-server/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/payment-mcp-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Payment MCP Server
 name: payment-mcp-server
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/payment-mcp-server/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/payment-mcp-server/values.yaml
@@ -11,7 +11,7 @@ defaultMessageTransport: ""
 slimServer: ""
 natsServer: ""
 # When set, creates a Secret and mounts SLIM_SHARED_SECRET via valueFrom.
-slimSharedSecret: ""
+slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
 
 identityServiceApiKey: ""
 identityAuthEnabled: "false"

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Helm chart for Recruiter Supervisor
 name: recruiter-supervisor
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/templates/deployment.tpl.yaml
@@ -63,7 +63,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter-supervisor/values.yaml
@@ -24,7 +24,7 @@ config:
   transportServerEndpoint: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
 
   # Identity SaaS Org-Level API

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Helm chart for Recruiter
 name: recruiter
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/recruiter/values.yaml
@@ -30,7 +30,7 @@ config:
   transportServerEndpoint: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
 
 # You can use your own config here for service account

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.9"
 description: A Helm chart for the Vietnam Farm
 name: vietnam-farm
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/templates/deployment.tpl.yaml
@@ -61,7 +61,8 @@ spec:
         {{ if .Values.externalSecrets }}
           - secretRef:
               name: {{ .Values.appName }}-secrets
-        {{ else if .Values.config.slimSharedSecret }}
+        {{ end }}
+        {{ if .Values.config.slimSharedSecret }}
           - secretRef:
               name: {{ .Values.appName }}-transport-secret
         {{ end }}

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/templates/transport-secret.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/templates/transport-secret.tpl.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.slimSharedSecret (not .Values.externalSecrets) }}
+{{- if .Values.config.slimSharedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/vietnam-farm/values.yaml
@@ -22,7 +22,7 @@ config:
   defaultMessageTransport: ""
   slimServer: ""
   natsServer: ""
-  slimSharedSecret: ""
+  slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
   otlpHttpEndpoint: ""
   # Identity configuration
   identityApiServerUrl: "" # Identity API endpoint

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/weather-mcp-server/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/weather-mcp-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.4"
 description: A Helm chart for the Weather MCP Server
 name: weather-mcp-server
-version: 0.1.0
+version: 0.1.1

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/weather-mcp-server/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/weather-mcp-server/values.yaml
@@ -10,7 +10,7 @@ otlpHttpEndpoint: ""
 defaultMessageTransport: ""
 slimServer: ""
 natsServer: ""
-slimSharedSecret: ""
+slimSharedSecret: "" # SLIM_SHARED_SECRET: set here to create {app}-transport-secret (overrides ES when both are used). Leave empty to take SLIM_SHARED_SECRET only from externalSecrets / vault
 
 image:
   repository: ghcr.io/agntcy/coffee-agntcy/weather-mcp-server


### PR DESCRIPTION
# Description

1. Fixed the SLIM shared secret external-secrets and chart config propagation precedence, it was default chart config, overridden by any ES config even without the SLIM shared secret key/env definition, now it's default ES config overridden by explicit chart config. This way at chart value definition time it can be explicitly decided which to pass (chart config overrides ES) and allows mixed usage (some secrets come from ES, but this one is not defined there).
2. Updated the chart config value with a comment on the precedence.
3. Released each affected chart with a bumped patch version.
4. Added the payment MCP server to the local-cluster chart dependencies.
5. Updated the local-cluster chart dependency versions to the new chart versions.
6. Released the local-cluster chart with a bumped minor version.

## Issue Link

.

## Type of Change

- [X] Bugfix
- [X] New Feature

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
