### PR TITLE
feat: add .dockerignore at repo root level

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# .dockerignore placed in root because every service in the docker-compose files
+# currently uses `context: ../../../` so the build context is always the repo root.
+
+**/.venv
+**/.pytest_cache
+**/.pytest-logs
+**/__pycache__
+**/.DS_Store
+
+# For repo root context
+.git
+.github
+.cursor
+.agents
+

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/docker-build-push.yaml'
       - '.github/workflows/docker-build-reusable.yaml'
       - '.github/actions/check-paths-have-changes/**'
+      - '.dockerignore'
   workflow_dispatch:
     inputs:
       push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ on:
       - 'coffeeAGNTCY/coffee_agents/lungo/**'
       - 'coffeeAGNTCY/coffee_agents/recruiter/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
+      - '.dockerignore'
   pull_request:
     paths:
       - 'coffeeAGNTCY/coffee_agents/corto/**'
@@ -17,6 +18,7 @@ on:
       - '.github/workflows/test.yaml'
       - '.github/workflows/test-reusable.yaml'
       - '.github/actions/check-paths-have-changes/**'
+      - '.dockerignore'
   workflow_call:
     inputs:
       pip_overrides:


### PR DESCRIPTION
# Description

We should trim out the build context (right now it's the repo root and there are not path exclusions).

Unnecessary elements examples:
  * `.git` folder from repo root
  * `pytest` cache folders (no reason to bundle those)
  * `.venv` folders which are pointless to bundle because we rebuild the dependencies (libraries and binaries) during image build
  * **Question**: are there relevant similar paths on the `npm` side ? I don't know. I don't expect the improvements to be remarkable but if we could do that too it would be nice.

These things lead to each of our container images having an extra (unnecessary) 2.5G of storage and for the builds to take longer (at least 40s on every image) because when Docker build starts it creates a tarball of the entire "build context" (which is then also walked every time a file is requested by a build step).

I think the **easiest solution** (and best ROI) is to use a `.dockerignore` file at repo root level.

I added at the end of this PR description some command examples and relevant outputs showing the improvement.


## Issue Link

Fixes #594 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

---

### Data from local testing:

command: `=time -h docker compose --profile "farms" build --no-cache`
time:
  * w/o .dockerignore : 2m12s
  * w/  .dockerignore : 1m1s

command: `=time -h docker compose --profile "farms" --profile "logistics" build --no-cache`
time:
  * w/o .dockerignore : 2m9s
  * w/  .dockerignore : 1m7s


```
# without .dockerignore
=> [vietnam-farm-server internal] load build context     30.4s
=> => transferring context: 1.76GB                       29.9s
```
```
# with .dockerignore
=> [vietnam-farm-server internal] load build context      4.0s
=> => transferring context: 9.23MB                        3.8s
```