### PR TITLE
release(lungo,helm,ui): bump chart ->0.1.1

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.9"
 description: A Helm chart for Lungo UI
 name: lungo-ui
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
# Description

1. In #571 the UI chart was modified in a minor fashion that requires propagating a new API key from the UI to the Agentic Workflows API, for this we need to release the modified UI charts to enable the propagation.

## Issue Link

.

## Type of Change

- [X] Other (please describe): release

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
