### PR TITLE
chore(colombia-farm): fix typos and drop no-op finally block

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express oqr implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
@@ -166,8 +166,6 @@ class FarmAgent:
         except Exception as e:
             logger.error(f"Error during MCP tool call: {e}")
             return {"weather_forecast_success": False, "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")]}
-        finally:
-            pass
 
     async def _inventory_node(self, state: GraphState) -> dict:
         """
@@ -188,7 +186,7 @@ class FarmAgent:
             template="""You are a helpful Colombian coffee farm manager.
                 You should estimate the seasonal coffee yield after checking the weather given.
                 Always return a numeric yield estimate with units (e.g. "5000 lbs").
-                This should contain the the basic yield for colombia (5000 lbs) plus an estimated bonus yield based on the weather forecast (e.g. + 100 lbs per temperature unit above 0).
+                This should contain the basic yield for colombia (5000 lbs) plus an estimated bonus yield based on the weather forecast (e.g. + 100 lbs per temperature unit above 0).
                 No explanation needed.
 
                 Weather forecast: {weather_forecast}
@@ -244,7 +242,7 @@ class FarmAgent:
         prompt = PromptTemplate(
             template="""You are an order assistant. Based on the user's question and the following order data, provide a concise and helpful response.
             If they ask about a specific order number, provide its status.
-            If they ask about placing order an order, generate a random order id and tracking number.
+            If they ask about placing an order, generate a random order id and tracking number.
 
             Order Data: {order_data}
             User question: {user_message}


### PR DESCRIPTION
# Description

cleanup of the Colombia farm agent with no behavior change:

- License header: "either express oqr implied" now reads "or".
- Inventory prompt template: removed a doubled "the the".
- Orders prompt template: "placing order an order" now reads "placing an order".
- Removed an empty "finally: pass" in _get_weather_forecast. It ran in both the success and error paths but did nothing.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (chore)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
