### PR TITLE
chore(repo): add release notes gen prompt/skill

### DIFF
--- a/.agents/prompts/release-notes/PROMPT.md
+++ b/.agents/prompts/release-notes/PROMPT.md
@@ -1,0 +1,112 @@
+# Release notes generation
+
+## Parameters
+
+Read `.agents/prompts/release-notes/params.yaml` and use:
+
+|       Field        |                 Meaning                 |
+| ------------------ | --------------------------------------- |
+| `previous_version` | Tag/version of the last release         |
+| `current_version`  | Version you are writing notes for       |
+| `repo_url`         | GitHub repository URL                   |
+| `github_repo`      | `owner/name` for links and `gh` queries |
+
+## Task
+
+Generate release notes for `repo_url` covering changes **since** `previous_version` **through** what will ship as
+`current_version`.
+
+- Base the diff on merges to the default branch since the `previous_version` tag.
+- Use the previous release as a style reference: git tag `previous_version`, and the matching section in repository root
+  `CHANGELOG.md`.
+- Prefer **PR-level** granularity; do not enumerate individual commits except when a change landed on the default branch
+  **without** an associated PR.
+- Be concise and practical.
+
+## Output structure
+
+Produce a new `CHANGELOG.md` entry for `current_version` with this structure:
+
+### 1. Title line
+
+```markdown
+## {current_version} ({YYYY-MM-DD})
+```
+
+Use today's date unless the user specifies another.
+
+### 2. One-line release blurb
+
+Short paragraph highlighting the most important themes of the release.
+
+### 3. Summary
+
+Order of emphasis:
+
+1. Semver **breaking** changes, configuration/setup/interface changes, and breaking behavior changes — **first**.
+2. **Migration steps** when any of the above apply; include concrete examples (env vars, commands, config snippets).
+3. High-profile new features.
+
+For each highlighted item in this section, use a closed HTML dropdown:
+
+```html
+<details>
+<summary><strong>Short title</strong> — optional subtitle</summary>
+
+- Concise bullets with links to PRs where relevant.
+</details>
+```
+
+### 4. Dependency changes
+
+List only dependencies whose versions **changed** since `previous_version`. Do not list unchanged dependencies.
+
+Derive versions from lockfiles and manifests, including as applicable:
+
+- `coffeeAGNTCY/coffee_agents/lungo/uv.lock`
+- `coffeeAGNTCY/coffee_agents/corto/uv.lock`
+- `coffeeAGNTCY/coffee_agents/recruiter/uv.lock`
+- `coffeeAGNTCY/coffee_agents/lungo/frontend/package-lock.json`
+- `coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package-lock.json`
+
+### 5. Changeset (chronological)
+
+List changes in the order they landed on the default branch:
+
+- One line per PR (preferred), or per direct commit when no PR exists.
+- Each item uses a **closed** HTML dropdown.
+- Closed summary line format: PR title, PR number, and author — e.g. `#601 — @author — short title`.
+- Open body: detailed but concise description of what was implemented.
+
+### 6. Contributors
+
+- **First-time contributors**: thank external contributors appearing for the first time in this release.
+- **Returning contributors**: thank repeat external contributors.
+- **Omit** the internal project crew: @codyhartsook, @delthazor, @jparello, @mihaialexandrescu, @misi-bp, @pregnor.
+- If a section would be empty, omit the section **and** its heading.
+
+## Reference files
+
+|          Purpose          |                              Path                               |
+| ------------------------- | --------------------------------------------------------------- |
+| Style / structure example | `CHANGELOG.md` (see `.agents/prompts/release-notes/example.md`) |
+| README dependency format  | `README.md` → `### Built With`                                  |
+
+## Output format (response to the user)
+
+**Do not modify repository files** unless explicitly asked.
+
+Return **two** markdown fenced code blocks:
+
+1. **CHANGELOG entry** — full markdown for the new `## {current_version}` section, ready to paste into `CHANGELOG.md`
+   below the `# Changelog` heading.
+2. **README Built With** — markdown for the `### Built With` bullet list, matching `README.md` style but with versions
+   from the lockfiles above.
+
+If the CHANGELOG entry contains inner markdown code blocks (migration examples), escape inner triple-backticks so the
+outer fence does not break.
+
+## Quality bar
+
+Match the tone, structure, and HTML `<details>` usage of the example in `CHANGELOG.md` for release `0.1.1` unless the
+user asks otherwise.

--- a/.agents/prompts/release-notes/example.md
+++ b/.agents/prompts/release-notes/example.md
@@ -1,0 +1,8 @@
+# Release notes — examples
+
+| Reference | Location |
+|-----------|----------|
+| Target structure and tone | [CHANGELOG.md](../../../CHANGELOG.md) — section `## 0.1.1` |
+| Previous release style | [CHANGELOG.md](../../../CHANGELOG.md) — section for `previous_version` from [params.yaml](./params.yaml) |
+| Previous release tag | `git show previous_version` |
+| README dependency list format | [README.md](../../../README.md) — `### Built With` |

--- a/.agents/prompts/release-notes/params.yaml
+++ b/.agents/prompts/release-notes/params.yaml
@@ -1,0 +1,5 @@
+# Edit before each release-notes run.
+previous_version: "0.1.0"
+current_version: "0.1.1"
+repo_url: "https://github.com/agntcy/coffeeAgntcy"
+github_repo: "agntcy/coffeeAgntcy"

--- a/.agents/skills/generate-release-notes/SKILL.md
+++ b/.agents/skills/generate-release-notes/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: generate-release-notes
+description: >-
+  Generates coffeeAgntcy CHANGELOG release notes and README Built With updates from
+  PRs and dependency lockfiles since the previous release tag. Use when the user asks
+  for release notes, a changelog entry, GitHub release text, or preparing a semver release.
+disable-model-invocation: true
+---
+
+# Generate release notes (coffeeAgntcy)
+
+## Inputs
+
+| File | Purpose |
+|------|---------|
+| [.agents/prompts/release-notes/params.yaml](../../prompts/release-notes/params.yaml) | `previous_version`, `current_version`, repo identifiers |
+| [.agents/prompts/release-notes/PROMPT.md](../../prompts/release-notes/PROMPT.md) | Full generation spec |
+| [.agents/prompts/release-notes/example.md](../../prompts/release-notes/example.md) | Pointers to gold-standard examples |
+
+## Workflow
+
+```
+- [ ] 1. Read params.yaml — confirm versions with the user if missing or stale
+- [ ] 2. Read PROMPT.md — follow it verbatim for structure and output rules
+- [ ] 3. Read CHANGELOG.md — previous release section + example section from example.md
+- [ ] 4. Collect changes since previous_version (PRs on default branch; direct commits only when no PR)
+- [ ] 5. Read dependency lockfiles listed in PROMPT.md
+- [ ] 6. Read README.md Built With section for formatting reference
+- [ ] 7. Output two markdown code blocks — do not edit files unless asked
+```
+
+## Discovery commands
+
+Use when the user has not supplied a PR list:
+
+```bash
+git tag -l 'v*' --sort=-version:refname | head
+git log v{previous_version}..HEAD --merges --oneline
+gh pr list --repo {github_repo} --state merged --base main --limit 100
+```
+
+Substitute `{previous_version}`, `{current_version}`, and `{github_repo}` from `params.yaml`. Prefix tags with `v` only if that matches existing tags in the repo.
+
+## Rules
+
+- Follow [PROMPT.md](../../prompts/release-notes/PROMPT.md) for structure, contributor omit list, and HTML `<details>` format.
+- Do not paraphrase or shorten the user's spec; apply it as written.
+- Default: generate text only. Edit `CHANGELOG.md` or `README.md` only when the user explicitly requests file changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent context index
+
+## Prompts
+
+| Topic | File |
+|-------|------|
+| Release notes — version parameters | [.agents/prompts/release-notes/params.yaml](.agents/prompts/release-notes/params.yaml) |
+| Release notes — generation spec | [.agents/prompts/release-notes/PROMPT.md](.agents/prompts/release-notes/PROMPT.md) |
+| Release notes — style references | [.agents/prompts/release-notes/example.md](.agents/prompts/release-notes/example.md) |
+
+## Skills
+
+| Topic | File |
+|-------|------|
+| Generate release notes | [.agents/skills/generate-release-notes/SKILL.md](.agents/skills/generate-release-notes/SKILL.md) |
+| OpenAPI → Python (lungo) | [.agents/skills/openapi-to-python-lungo/SKILL.md](.agents/skills/openapi-to-python-lungo/SKILL.md) |
+| JSON Schema → Pydantic (lungo) | [.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md](.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md) |
+
+## Repository references
+
+| Topic | File |
+|-------|------|
+| Changelog | [CHANGELOG.md](CHANGELOG.md) |
+| README (Built With format) | [README.md](README.md) |


### PR DESCRIPTION
# Description

- Added a prompt template (with params) for generating release notes for coffeeAgntcy tag releases in the same style as 0.1.0 and 0.1.1 had been done.
- Added a skill for wrapping the release notes generation prompt.
- Added AGNETS.md for referencing the available skills, prompts, etc. LLM agent tools.

## Issue Link

.

## Type of Change

- [X] Other (please describe): chore, DX

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
