### PR TITLE
feat(lungo, corto): re-tweak Dockerfile.ui 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,10 @@
 **/__pycache__
 **/.DS_Store
 
+# Node: never copy host-built deps or build output into images
+**/node_modules
+**/dist
+
 # For repo root context
 .git
 .github

--- a/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/corto/docker/Dockerfile.ui
@@ -11,12 +11,12 @@ RUN --mount=type=cache,id=corto-npm,target=/root/.npm \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/corto/exchange/frontend/package-lock.json,target=package-lock.json \
     npm ci
 
-# Copy application files, including assets
+# Copy application files, including assets (node_modules excluded via .dockerignore)
 COPY coffeeAGNTCY/coffee_agents/corto/exchange/frontend/ .
 
 # Build the frontend
-RUN npm install --verbose
-RUN npm run build --verbose
+RUN --mount=type=cache,id=corto-npm,target=/root/.npm \
+    npm run build --verbose
 
 # Expose port 3000
 EXPOSE 3000

--- a/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker/Dockerfile.ui
@@ -11,12 +11,12 @@ RUN --mount=type=cache,id=lungo-npm,target=/root/.npm \
     --mount=type=bind,source=coffeeAGNTCY/coffee_agents/lungo/frontend/package-lock.json,target=package-lock.json \
     npm ci
 
-# Copy application files, including assets
+# Copy application files, including assets (node_modules excluded via .dockerignore)
 COPY coffeeAGNTCY/coffee_agents/lungo/frontend/ .
 
 # Build the frontend
-RUN npm install --verbose
-RUN npm run build --verbose
+RUN --mount=type=cache,id=lungo-npm,target=/root/.npm \
+    npm run build --verbose
 
 # Expose port 3000
 EXPOSE 3000


### PR DESCRIPTION
# Description

This PR brings some small improvements and a bug fix to the Dockerfile.ui files.

1. The `npm run build` command now has access to the cache at `npm_config_cache` pre-built during the `npm ci` step.

2. Removed the `npm install` command because `npm ci` (which stands for "clean install") already does that and has the advantage of **not** altering `package.json` in place during the build.
    * Caveat (but not a problem at all, IMO): since `npm install` is gone, the build will now fail hard if `package-lock.json` is out of sync rather than silently fixing it (which I don't think we'd want happening.. we should be disciplined with the contents of that file). If a build breaks with a lockfile error, run `npm install` locally, commit the updated `package-lock.json`, and you're set.
    * This step was also hiding a latent bug when building from our local envs (see point 3).

3. Added `node_modules` and `dist` folders to `.dockerignore` so the `COPY` can never drag host-built deps (e.g. macOS-native esbuild/rollup binaries and preexisting downloaded `node_modules`) into the Linux image.
    * In our case this was also a latent bug when building from our local envs because the `COPY` would bring in our local `node_modules` folder overwriting the one cleanly/freshly built by `npm ci` in the previous Dockerfile step.

### Build time advantages
* reduce the UI image size for Lungo by 400MB (from ~940MB to ~540MB)
* reduce the local build time from scratch (no-cache) for the UI image by 20-30s (from ~55-65s to ~30s)

## Issue Link

Fixes #598

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
