### PR TITLE
ci(gha,docker,helm): add version guard.

### DIFF
--- a/.github/workflows/delete-ghcr-package-version.yaml
+++ b/.github/workflows/delete-ghcr-package-version.yaml
@@ -1,0 +1,75 @@
+name: Delete GHCR Package Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_type:
+        description: "GitHub Packages type (ghcr.io uses container)"
+        type: choice
+        required: true
+        default: container
+        options: [container]
+      owner:
+        description: "Org or user that owns the package"
+        type: choice
+        required: true
+        default: agntcy
+        options: [agntcy]
+      repository:
+        description: "Repository that contains the package"
+        type: choice
+        required: true
+        default: coffee-agntcy
+        options: [coffee-agntcy]
+      package_name:
+        description: "Package path without ghcr.io/owner/repository (e.g. lungo-ui or helm/lungo-ui)"
+        type: string
+        required: true
+      version:
+        description: "Tag or version to delete (e.g. latest, 1.2.3, pr-42)"
+        type: string
+        required: true
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Delete package version if it exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          package_type=${{ inputs.package_type }}
+          owner=${{ inputs.owner }}
+          repository=${{ inputs.repository }}
+          package_name=${{ inputs.package_name }}
+          version=${{ inputs.version }}
+
+          if echo "${package_name}" | grep -q '^helm/'; then
+            repository="coffee_agntcy" # Note: Legacy naming uses underscore instead of hyphen.
+          fi
+
+          echo "Deleting package ${package_type} version: ghcr.io/${owner}/${repository}/${package_name}:${version}"
+
+          package_encoded=$(jq -nr --arg p "${repository}/${package_name}" '$p|@uri')
+          api_base="/orgs/${owner}/packages/${package_type}/${package_encoded}"
+
+          # Note: name below matches the digest for images/charts.
+          version_id=$(gh api "${api_base}/versions" --paginate \
+            --jq ".[] | select(
+              .name == \"${version}\" or
+              (.metadata.container.tags[]? == \"${version}\")
+            ) | .id" \
+            | head -n1)
+
+          if [[ -z "${version_id}" ]]; then
+            echo "Not found: ghcr.io/${owner}/${repository}/${package_name}:${version}"
+            exit 0
+          fi
+
+          gh api -X DELETE "${api_base}/versions/${version_id}"
+          echo "Deleted: ghcr.io/${owner}/${repository}/${package_name}:${version} (id ${version_id})"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -264,7 +264,7 @@ jobs:
           fi
 
   docker-build-corto:
-    needs: [subprojects-to-build, compute-build-parameters]
+    needs: [subprojects-to-build, compute-build-parameters, check-push-target-existence]
     if: ${{ needs.subprojects-to-build.outputs.build_corto == 'true' }}
 
     strategy:
@@ -291,7 +291,7 @@ jobs:
       git_branch: ${{ needs.compute-build-parameters.outputs.git_branch }}
 
   docker-build-lungo:
-    needs: [subprojects-to-build, compute-build-parameters]
+    needs: [subprojects-to-build, compute-build-parameters, check-push-target-existence]
     if: ${{ needs.subprojects-to-build.outputs.build_lungo == 'true' }}
 
     strategy:
@@ -340,7 +340,7 @@ jobs:
       git_branch: ${{ needs.compute-build-parameters.outputs.git_branch }}
 
   docker-build-recruiter:
-    needs: [subprojects-to-build, compute-build-parameters]
+    needs: [subprojects-to-build, compute-build-parameters, check-push-target-existence]
     if: ${{ needs.subprojects-to-build.outputs.build_recruiter == 'true' }}
 
     strategy:

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -174,6 +174,7 @@ jobs:
           git_branch=${{ github.ref_name }}
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            push=false
             image_tag=pr-${{ github.event.pull_request.number }}
             git_branch=${{ github.head_ref }}
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -196,6 +196,73 @@ jobs:
           echo "image_tag=$image_tag" | tee -a $GITHUB_OUTPUT
           echo "git_branch=$git_branch" | tee -a $GITHUB_OUTPUT
 
+  check-push-target-existence:
+    needs: [subprojects-to-build, compute-build-parameters]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      packages: read
+      contents: read
+    steps:
+      - name: Check if push target exists
+        run: |
+          build_corto=${{ needs.subprojects-to-build.outputs.build_corto }}
+          build_lungo=${{ needs.subprojects-to-build.outputs.build_lungo }}
+          build_recruiter=${{ needs.subprojects-to-build.outputs.build_recruiter }}
+          push=${{ needs.compute-build-parameters.outputs.push }}
+          image_tag=${{ needs.compute-build-parameters.outputs.image_tag }}
+
+          floating_tags=("latest")
+          if printf '%s\n' "${floating_tags[@]}" | grep -Fxq "$image_tag"; then
+            echo "Warning: The 'latest' tag is a floating tag so it will be ignored."
+            exit 0
+          fi
+
+          existing_images=()
+          for project in corto lungo recruiter; do
+            build=build_$project
+
+            if [[ "${!build}" == "true" ]] && [[ "${push}" == "true" ]] && [[ "${image_tag}" != "" ]]; then
+              if [[ "${project}" == "corto" ]]; then
+                images=(corto-ui corto-exchange corto-farm)
+              elif [[ "${project}" == "lungo" ]]; then
+                images=(lungo-ui auction-supervisor agentic-workflows-api brazil-farm colombia-farm vietnam-farm weather-mcp-server payment-mcp-server logistics-shipper logistics-accountant logistics-farm logistics-supervisor logistics-helpdesk recruiter-supervisor)
+              elif [[ "${project}" == "recruiter" ]]; then
+                images=(recruiter)
+              fi
+
+              for image in "${images[@]}"; do
+                image_path="agntcy/coffee-agntcy/${image}"
+
+                token=$(curl -fsSL -u "${{ github.actor }}:${{ github.token }}" \
+                  "https://ghcr.io/token?service=ghcr.io&scope=repository:${image_path}:pull" \
+                  | jq -r .token)
+
+                http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                  -H "Authorization: Bearer ${token}" \
+                  -H "Accept: application/vnd.oci.image.index.v1+json" \
+                  "https://ghcr.io/v2/${image_path}/manifests/${image_tag}")
+
+                if [[ "$http_code" == "200" ]]; then
+                  echo "Error: Image $image_path:${image_tag} already exists"
+                  existing_images+=("$image_path:${image_tag}")
+                fi
+              done
+            fi
+          done
+
+          if [[ "${#existing_images[@]}" -gt 0 ]]; then
+            echo "Error: The following images already exist:"
+            for image in "${existing_images[@]}"; do
+              echo "- $image"
+            done
+            echo "Cancelling build and push. Change the tag or use the 'Delete GHCR Package Version' workflow to delete the existing images before retrying."
+
+            exit 1
+          fi
+
   docker-build-corto:
     needs: [subprojects-to-build, compute-build-parameters]
     if: ${{ needs.subprojects-to-build.outputs.build_corto == 'true' }}
@@ -262,7 +329,7 @@ jobs:
     permissions: # permissions can only be maintained or reduced (not elevated) throughout a chain of workflows
       packages: write
       contents: read
-      
+
     uses: ./.github/workflows/docker-build-reusable.yaml
     with:
       name: ${{ matrix.image.name }}

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -40,6 +40,7 @@ jobs:
   subprojects-to-build:
     runs-on: ubuntu-latest
     outputs:
+      push: ${{ steps.choose-subprojects.outputs.push }}
       build_corto: ${{ steps.choose-subprojects.outputs.build_corto }}
       build_lungo: ${{ steps.choose-subprojects.outputs.build_lungo }}
     defaults:
@@ -72,7 +73,7 @@ jobs:
         run: |
           paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR/$HELM_SUBDIR" '[$new_val] + .')
           echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
-          
+
           paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR/$HELM_SUBDIR" '[$new_val] + .')
           echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
 
@@ -101,18 +102,97 @@ jobs:
           build_lungo=false
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.ref_name }}" == "main" ]]; then
+              push=true
+            else
+              push=false
+            fi
+
             build_corto=true
             build_lungo=true
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            push=${{ inputs.push }}
             build_corto=${{ inputs.build_corto }}
             build_lungo=${{ inputs.build_lungo }}
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            push=false
             build_corto=${{ steps.check-paths-corto.outputs.changed }}
             build_lungo=${{ steps.check-paths-lungo.outputs.changed }}
           fi
 
+          echo "push=$push" | tee -a $GITHUB_OUTPUT
           echo "build_corto=$build_corto" | tee -a $GITHUB_OUTPUT
           echo "build_lungo=$build_lungo" | tee -a $GITHUB_OUTPUT
+
+  check-push-target-existence:
+    needs: [subprojects-to-build]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      packages: read
+      contents: read
+    steps:
+      - name: Check Helm integrity
+        run: |
+          push=${{ needs.subprojects-to-build.outputs.push }}
+          build_corto=${{ needs.subprojects-to-build.outputs.build_corto }}
+          build_lungo=${{ needs.subprojects-to-build.outputs.build_lungo }}
+
+          existing_charts=()
+          for project in corto lungo; do
+            build=build_$project
+
+            if [[ "${!build}" == "true" ]] && [[ "${push}" == "true" ]]; then
+              if [[ "${project}" == "corto" ]]; then
+                charts=(corto-ui corto-exchange corto-farm)
+              elif [[ "${project}" == "lungo" ]]; then
+                charts=(lungo-ui auction-supervisor agentic-workflows-api brazil-farm colombia-farm vietnam-farm weather-mcp-server payment-mcp-server logistics-shipper logistics-accountant logistics-farm logistics-supervisor logistics-helpdesk recruiter recruiter-supervisor)
+              fi
+
+              for chart in "${charts[@]}"; do
+                chart_path="coffee_agntcy%2Fhelm%2F${chart}"
+
+                directory="${chart}"
+                if [[ "${chart}" == "lungo-ui" ]]; then
+                  directory="ui"
+                fi
+                chart_directory="coffeeAGNTCY/coffee_agents/${project}/deployment/helm/${directory}"
+
+                base="${{ github.event.before }}"
+                head="${{ github.sha }}"
+                if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                  base="${{ github.event.pull_request.base.sha }}"
+                  head="${{ github.event.pull_request.head.sha }}"
+                fi
+
+                if git diff --name-only --exit-code "$base" "$head" -- "${chart_directory}/"; then
+                  continue # Note: If the chart directory has no changes, skip checking for existing chart versions.
+                fi
+
+                chart_version=$(grep '^version:' ${chart_directory}/Chart.yaml | awk '{print $2}')
+
+                version_id=$(gh api "/orgs/agntcy/packages/container/${chart_path}/versions" \
+                  --jq '.[] | select(.metadata.container.tags[]? == "'${chart_version}'") | .id' \
+                  | head -n1)
+
+                if [[ -n "${version_id}" ]]; then
+                  existing_charts+=("ghcr.io/agntcy/${chart_path}:${chart_version}")
+                fi
+              done
+            fi
+          done
+
+          if [[ "${#existing_charts[@]}" -gt 0 ]]; then
+            echo "Error: The following chart versions already exist:"
+            for chart in "${existing_charts[@]}"; do
+              echo "- $chart"
+            done
+            echo "Cancelling package and push. Change the version or use the 'Delete GHCR Package Version' workflow to delete the existing chart versions before retrying."
+
+            exit 1
+          fi
 
   helm-package-corto:
     needs: subprojects-to-build

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -134,6 +134,9 @@ jobs:
       packages: read
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Check Helm integrity
         run: |
           push=${{ needs.subprojects-to-build.outputs.push }}

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -195,7 +195,7 @@ jobs:
           fi
 
   helm-package-corto:
-    needs: subprojects-to-build
+    needs: [subprojects-to-build, check-push-target-existence]
     if: ${{ needs.subprojects-to-build.outputs.build_corto == 'true' }}
 
     strategy:
@@ -220,7 +220,7 @@ jobs:
 
 
   helm-package-lungo:
-    needs: subprojects-to-build
+    needs: [subprojects-to-build, check-push-target-existence]
     if: ${{ needs.subprojects-to-build.outputs.build_lungo == 'true' }}
 
     strategy:


### PR DESCRIPTION
# Description

Before: 
- We are not tagging helm charts in Git, we are using the Chart.yaml version for tagging, this is preexisting to my arrival and is a suggested practice to avoid unnecessary work, but with the current tag handling it needed a bit of safeguarding on other events to avoid overpushing preexisting chart versions.
- We allowed overpushing charts (and maybe images as well, but I'm not 100% sure if that would require an extra flag).

After:
- Implemented a workflow_dispatch manual workflow to be able to delete ghcr.io package versions.
- Added a guard to the docker build and push workflow that checks whether any image we would push in a push scenario exists already, collects all those and errors the workflow without proceeding to push.
- Added a guard to the helm package and push workflow that checks whether any chart we would push in a push scenario exists already, collects all those and errors the workflow without proceeding to push.

Consequences:
- Chart release afterwards happens whenever we merge chart.yaml version to main. In the past we did this + on each tag we overpushed the existing chart from the tag ref that broke immutability - and caused ArgoCD issues.
- This also enforces the current unwritten practice of bumping chart versions in each PR we modify charts in.
- There is another guard added to not care about unmodified charts when checking the preexisting versions.

## Issue Link

fixes #637 

## Type of Change

- [X] Other (please describe): CI

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
