### PR TITLE
fix(lungo,helm,ui): fix configmap loading

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/deployment.tpl.yaml
@@ -53,9 +53,6 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 10
           {{ end }}
-          envFrom:
-            - configMapRef:
-                name: {{ .Values.appName }}-configmap
           {{ if .Values.externalSecrets }}
             - secretRef:
                 name: {{ .Values.appName }}-secrets


### PR DESCRIPTION
# Description

Missed a reference to the old configmap structure.
It is not trivial how to make this part generic so as a quick-fix there is no env loading for now in the lungo ui chart.

## Issue Link

fixes #638

## Type of Change

- [X] Bugfix

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
