### PR TITLE
chore(lungo,corto): do not trigger pytest on frontend changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,8 @@ on:
       - 'coffeeAGNTCY/coffee_agents/lungo/**'
       - 'coffeeAGNTCY/coffee_agents/recruiter/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
+      - '!coffeeAGNTCY/coffee_agents/corto/exchange/frontend/**'
+      - '!coffeeAGNTCY/coffee_agents/lungo/frontend/**'
       - '.dockerignore'
   pull_request:
     paths:
@@ -15,6 +17,8 @@ on:
       - 'coffeeAGNTCY/coffee_agents/lungo/**'
       - 'coffeeAGNTCY/coffee_agents/recruiter/**'
       - '!coffeeAGNTCY/coffee_agents/*/deployment/helm/**'
+      - '!coffeeAGNTCY/coffee_agents/corto/exchange/frontend/**'
+      - '!coffeeAGNTCY/coffee_agents/lungo/frontend/**'
       - '.github/workflows/test.yaml'
       - '.github/workflows/test-reusable.yaml'
       - '.github/actions/check-paths-have-changes/**'


### PR DESCRIPTION
# Description

Our "integration tests" from `.github/workflows/test.yaml` are in fact strictly Python tests (`uv run pytest ...`).

I don't believe there's any point in running them for changes made strictly to the frontend code. With lungo integration tests taking 25 minutes, this could be a developer experience improvement when only dealing with frontend updates/fixes.
I could be convinced otherwise.

## Issue Link

N/A

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
