### PR TITLE
docs(#588): add agent interaction mermaid diagrams to workflow docs

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
@@ -1,5 +1,21 @@
 # A2A HTTP
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    User["User / Requester"]
+    Recruiter["Agentic Recruiter"]
+    Directory["AGNTCY Agent Directory"]
+    CandidateA["Candidate Agent A"]
+    CandidateB["Candidate Agent B"]
+
+    User <-->|"Discovery Request / Shortlist"| Recruiter
+    Directory -->|"Agent Listings + Metadata"| Recruiter
+    Recruiter <-->|"A2A Probe"| CandidateA
+    Recruiter <-->|"A2A Probe"| CandidateB
+```
+
 ## Pattern
 
 **Recruiter-style discovery** is a general pattern for **on-demand selection** in an ecosystem of many possible

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/adversarial_review_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/adversarial_review_agents.md
@@ -1,5 +1,20 @@
 # Adversarial Review Agents
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Buyer["Buying / Pricing Agent"]
+    Critic["Risk Review Agent"]
+    Policy["Policy Agent"]
+    Approver["Human Approver"]
+
+    Buyer <-->|"Proposal + Evidence"| Critic
+    Critic <-->|"Policy Check"| Policy
+    Critic -->|"Structured Objections"| Buyer
+    Critic <-->|"Escalation / Decision"| Approver
+```
+
 ## Pattern
 
 **Adversarial review** is a way to force a **challenger voice** before expensive commitments: risk against optimism,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent-to-system_bridge.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent-to-system_bridge.md
@@ -1,5 +1,21 @@
 # Agent-to-System Bridge
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Carbon["Carbon Accounting Agent"]
+    Bridge["System Bridge / Adapter"]
+    Emissions["Emissions Service"]
+    Finance["Finance System"]
+    Decision["Route Decision Agent"]
+
+    Carbon <-->|"System Query"| Bridge
+    Bridge <-->|"Emissions Facts"| Emissions
+    Bridge <-->|"Recognized Cost Data"| Finance
+    Carbon -->|"Normalized Evidence"| Decision
+```
+
 ## Pattern
 
 An **agent-to-system bridge** lets agents **invoke trusted external systems**—enterprise planning tools, emissions

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent_workflow_chain.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent_workflow_chain.md
@@ -1,5 +1,21 @@
 # Agent Workflow Chain
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Farm["Farm Data Agent"]
+    Quality["Quality Agent"]
+    Pricing["Pricing Agent"]
+    Commitment["Commitment Agent"]
+    State["Shared Procurement State"]
+
+    Farm <-->|"Farm Facts"| State
+    State <-->|"Quality Assessment"| Quality
+    State <-->|"Price Recommendation"| Pricing
+    State <-->|"Commitment Package"| Commitment
+```
+
 ## Pattern
 
 **Agent workflow chain** means breaking a **complex goal into ordered agent steps**, each enriching **shared state** so

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/approval_gate_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/approval_gate_agent.md
@@ -1,5 +1,21 @@
 # Approval Gate Agent
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Buying["Buying Agent"]
+    Gate["Approval Gate Agent"]
+    Policy["Policy Agent"]
+    Exec["Executive Approver"]
+    Contract["Contract / Purchase System"]
+
+    Buying -->|"High-Risk Purchase Proposal"| Gate
+    Gate <-->|"Policy + Risk Context"| Policy
+    Gate <-->|"Approval Request / Decision"| Exec
+    Gate -->|"Approved Commitment"| Contract
+```
+
 ## Pattern
 
 An **approval gate** pauses automated flow when **stakes exceed autonomy**: bulk purchases, novel counterparties, or

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/composable_agent_service.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/composable_agent_service.md
@@ -1,5 +1,21 @@
 # Composable Agent Service
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Catalog["Agent Catalog"]
+    Carbon["Carbon Accounting Agent Service"]
+    Procurement["Procurement Agent"]
+    Logistics["Logistics Agent"]
+    Reporting["Reporting Agent"]
+
+    Catalog <-->|"Service Registration + Version"| Carbon
+    Procurement <-->|"Emissions Request"| Carbon
+    Logistics <-->|"Route Carbon Request"| Carbon
+    Reporting <-->|"Reusable Carbon Facts"| Carbon
+```
+
 ## Pattern
 
 **Composable agent service** packages an agent like a **product**: discoverable in a catalog, **versioned interfaces**,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/coordinator_+_worker_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/coordinator_+_worker_agents.md
@@ -1,5 +1,21 @@
 # Coordinator + Worker Agents
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Coordinator["Fulfillment Coordinator Agent"]
+    Warehouse["Warehouse Agent"]
+    Customs["Customs Agent"]
+    Carrier["Carrier Agent"]
+    Finance["Finance Agent"]
+
+    Coordinator <-->|"Release Task / Status"| Warehouse
+    Coordinator <-->|"Filing Task / Clearance"| Customs
+    Coordinator <-->|"Booking Task / ETA"| Carrier
+    Coordinator <-->|"Invoice Task / Settlement"| Finance
+```
+
 ## Pattern
 
 **Coordinator and worker** arrangements **separate planning from execution**: one agent keeps the work breakdown,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/decentralized_consensus_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/decentralized_consensus_agents.md
@@ -1,5 +1,25 @@
 # Decentralized Consensus Agents
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    NA["North America Demand Agent"]
+    EU["Europe Demand Agent"]
+    APAC["APAC Demand Agent"]
+    Merge["Consensus Merge Agent"]
+    Plan["Global Demand Plan"]
+
+    NA <-->|"Belief Update"| EU
+    EU <-->|"Belief Update"| APAC
+    APAC <-->|"Belief Update"| NA
+
+    NA -->|"Regional Forecast"| Merge
+    EU -->|"Regional Forecast"| Merge
+    APAC -->|"Regional Forecast"| Merge
+    Merge -->|"Converged Number"| Plan
+```
+
 ## Pattern
 
 **Decentralized consensus** aims to **reach agreement without a single permanent hub**: local agents exchange beliefs

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/directory-based_dispatch.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/directory-based_dispatch.md
@@ -1,5 +1,21 @@
 # Directory-Based Dispatch
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Router["Dispatch Router Agent"]
+    Directory["Agent Directory"]
+    Weather["Weather Agent"]
+    Soil["Soil Agent"]
+    Logistics["Logistics Agent"]
+
+    Router <-->|"Skill + Trust Lookup"| Directory
+    Router <-->|"Weather Emphasis"| Weather
+    Router <-->|"Soil Emphasis"| Soil
+    Router <-->|"Logistics Emphasis"| Logistics
+```
+
 ## Pattern
 
 **Directory-based dispatch** chooses the **next specialist from intent and context** instead of hard-wiring a single

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/economic_constraint_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/economic_constraint_agent.md
@@ -1,5 +1,21 @@
 # Economic Constraint Agent
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Route["Route Planning Agent"]
+    Constraint["Economic Constraint Agent"]
+    Carbon["Carbon Budget Model"]
+    Cost["Cost Model"]
+    Time["Delivery Time Model"]
+
+    Route <-->|"Optimization Request"| Constraint
+    Constraint <-->|"Carbon Limit"| Carbon
+    Constraint <-->|"Dollar Cost"| Cost
+    Constraint <-->|"Delivery Days"| Time
+```
+
 ## Pattern
 
 An **economic constraint agent** optimizes under **explicit budgets**—cost, time, carbon, or other currencies—so

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/end-to-end_telemetry.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/end-to-end_telemetry.md
@@ -1,5 +1,21 @@
 # End-to-End Telemetry
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Farm["Farm Agent"]
+    Buyer["Buying Agent"]
+    Logistics["Logistics Agent"]
+    Finance["Finance Agent"]
+    Telemetry["Telemetry Collector"]
+
+    Farm -->|"Trace Span: Supply"| Telemetry
+    Buyer -->|"Trace Span: Decision"| Telemetry
+    Logistics -->|"Trace Span: Movement"| Telemetry
+    Finance -->|"Trace Span: Settlement"| Telemetry
+```
+
 ## Pattern
 
 **End-to-end telemetry** traces **decisions and interactions across the whole chain**—from early inputs through

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/event_ledger_episodic_memory.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/event_ledger_episodic_memory.md
@@ -1,5 +1,21 @@
 # Event Ledger (Episodic Memory)
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Buyer["Buying Agent"]
+    Logistics["Logistics Agent"]
+    Policy["Policy Agent"]
+    Ledger["Event Ledger"]
+    Ops["Operations Reviewer"]
+
+    Buyer -->|"Decision Event"| Ledger
+    Logistics -->|"Tool Call Event"| Ledger
+    Policy -->|"Policy Check Event"| Ledger
+    Ops <-->|"Replay Timeline"| Ledger
+```
+
 ## Pattern
 
 An **event ledger** (episodic memory for agents) appends a **faithful history of decisions**—prompts, tool calls, policy

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/feedback_loop.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/feedback_loop.md
@@ -1,5 +1,22 @@
 # Feedback Loop
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Buyer["Buyer Agent"]
+    Supplier["Supplier / Farm Agent"]
+    Feedback["Feedback Agent"]
+    Policy["Routing Policy Agent"]
+    Directory["Agent Directory"]
+
+    Buyer <-->|"Order / Outcome"| Supplier
+    Buyer -->|"Satisfaction Score"| Feedback
+    Supplier -->|"Delivery Result"| Feedback
+    Feedback -->|"Performance Signal"| Policy
+    Policy -->|"Updated Selection Weight"| Directory
+```
+
 ## Pattern
 
 A **feedback loop** folds **human or system feedback**—scores, disputes, delivery outcomes—back into **routing and

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
@@ -1,5 +1,21 @@
 # Group Messaging
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Transport["Transport: SLIM"]
+    Buyer["Buyer Logistics Agent"]
+    Farm["Tatooine Coffee Farm Agent"]
+    Shipper["Shipper Agent"]
+    Accountant["Accountant Agent"]
+
+    Buyer <-->|"A2A"| Transport
+    Farm <-->|"A2A"| Transport
+    Shipper <-->|"A2A"| Transport
+    Accountant <-->|"A2A"| Transport
+```
+
 ## Pattern
 
 **Group messaging and coordination** is a general arrangement when **several specialists** must **see the same

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/orchestrator_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/orchestrator_agent.md
@@ -1,5 +1,21 @@
 # Orchestrator Agent
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Orchestrator["Global Operations Orchestrator"]
+    RegionA["Americas Regional Agent"]
+    RegionB["EMEA Regional Agent"]
+    RegionC["APAC Regional Agent"]
+    Policy["Global Policy Agent"]
+
+    Orchestrator <-->|"Inventory Claim / Status"| RegionA
+    Orchestrator <-->|"Inventory Claim / Status"| RegionB
+    Orchestrator <-->|"Inventory Claim / Status"| RegionC
+    Orchestrator <-->|"Precedence Rules"| Policy
+```
+
 ## Pattern
 
 A **top-level orchestrator** coordinates, monitors, and governs **many workflows at once**: it resolves conflicts,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/performance_scoring_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/performance_scoring_agent.md
@@ -1,5 +1,21 @@
 # Performance Scoring Agent
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Procurement["Procurement Agent"]
+    Telemetry["Telemetry Collector"]
+    Outcomes["Business Outcomes Store"]
+    Scoring["Performance Scoring Agent"]
+    Feedback["Feedback / Reflection Agent"]
+
+    Procurement -->|"Run Metadata"| Telemetry
+    Outcomes -->|"Cost Time Carbon Quality"| Scoring
+    Telemetry -->|"Trace + Timing Data"| Scoring
+    Scoring -->|"KPI Score"| Feedback
+```
+
 ## Pattern
 
 A **performance scoring agent** measures how well agentic runs meet **declared KPIs**—cost, time, carbon, quality, or

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/policy-enforced_execution.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/policy-enforced_execution.md
@@ -1,5 +1,21 @@
 # Policy-Enforced Execution
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Buying["Buying Agent"]
+    Policy["Policy Enforcement Agent"]
+    Identity["Identity / Trust Agent"]
+    Supplier["Supplier Agent"]
+    Contract["Contract System"]
+
+    Buying -->|"Contract Request"| Policy
+    Policy <-->|"Identity + Attestation"| Identity
+    Policy <-->|"Supplier Facts"| Supplier
+    Policy -->|"Allow / Deny"| Contract
+```
+
 ## Pattern
 
 **Policy-enforced execution** **blocks or conditions actions** against explicit **trust and ethics rules**—labor,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
@@ -1,5 +1,26 @@
 # Publish Subscribe
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Auction["Auction Agent"]
+    Transport["Transport: Pub/Sub"]
+    Brazil["Brazil Coffee Farm Agent"]
+    Colombia["Colombia Coffee Farm Agent"]
+    Vietnam["Vietnam Coffee Farm Agent"]
+    Weather["Weather MCP Server"]
+    Payment["Payment MCP Server"]
+
+    Auction <-->|"Market Inquiry"| Transport
+    Transport <-->|"Offer Topic"| Brazil
+    Transport <-->|"Offer Topic"| Colombia
+    Transport <-->|"Offer Topic"| Vietnam
+
+    Colombia <-->|"Weather Diligence"| Weather
+    Colombia <-->|"Payment Diligence"| Payment
+```
+
 ## Pattern
 
 **Supervisor and workers** is a general arrangement for multi-agent work: **one coordinator** owns the end-to-end

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe_streaming.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe_streaming.md
@@ -1,5 +1,26 @@
 # Publish Subscribe Streaming Coffee Auction Network
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Auction["Auction Agent"]
+    Transport["Transport: Streaming Pub/Sub"]
+    Brazil["Brazil Coffee Farm Agent"]
+    Colombia["Colombia Coffee Farm Agent"]
+    Vietnam["Vietnam Coffee Farm Agent"]
+    Weather["Weather MCP Server"]
+    Payment["Payment MCP Server"]
+
+    Auction <-->|"Streaming Market Inquiry"| Transport
+    Transport <-->|"Streaming Offer Chunks"| Brazil
+    Transport <-->|"Streaming Offer Chunks"| Colombia
+    Transport <-->|"Streaming Offer Chunks"| Vietnam
+
+    Colombia <-->|"Streaming Weather Counsel"| Weather
+    Colombia <-->|"Streaming Payment Counsel"| Payment
+```
+
 ## Pattern
 
 **Supervisor and workers** is a general arrangement for multi-agent work: **one coordinator** owns the end-to-end

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/resilience_&_re-routing.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/resilience_&_re-routing.md
@@ -1,5 +1,23 @@
 # Resilience & Re-Routing
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Coordinator["Fulfillment Coordinator Agent"]
+    Monitor["Failure Monitor Agent"]
+    Directory["Certified Logistics Directory"]
+    CarrierA["Primary Carrier Agent"]
+    CarrierB["Alternate Carrier Agent"]
+    Customer["Customer Promise Agent"]
+
+    Coordinator <-->|"Shipment Plan"| CarrierA
+    CarrierA -->|"Failure Signal"| Monitor
+    Monitor <-->|"Alternate Lookup"| Directory
+    Coordinator <-->|"Re-route Task"| CarrierB
+    Coordinator -->|"Updated Promise"| Customer
+```
+
 ## Pattern
 
 **Resilience and re-routing** recovers from failure by **switching agents or paths**: discover alternates, compensate

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/secure_group_collaboration.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/secure_group_collaboration.md
@@ -1,5 +1,23 @@
 # Secure Group Collaboration
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Room["Secure Collaboration Room"]
+    Farm["Farm Agent"]
+    Coop["Coop Agent"]
+    Exporter["Exporter Agent"]
+    Finance["Finance Agent"]
+    Moderator["Moderator Agent"]
+
+    Farm <-->|"Scoped Offer"| Room
+    Coop <-->|"Allocation Update"| Room
+    Exporter <-->|"Export Terms"| Room
+    Finance <-->|"Payment Terms"| Room
+    Moderator <-->|"Membership + Phase Control"| Room
+```
+
 ## Pattern
 
 **Secure group collaboration** lets **several agents coordinate inside a trusted boundary**: authenticated membership,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/self-evaluation_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/self-evaluation_agent.md
@@ -1,5 +1,21 @@
 # Self-Evaluation Agent
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Telemetry["Telemetry Collector"]
+    Outcomes["Business Outcomes Store"]
+    Reflection["Self-Evaluation Agent"]
+    Human["Human Reviewer"]
+    Policy["Prompt / Policy Store"]
+
+    Telemetry -->|"Past Run Data"| Reflection
+    Outcomes -->|"Forecast vs Actual"| Reflection
+    Reflection -->|"Recommended Change"| Human
+    Human -->|"Approved Update"| Policy
+```
+
 ## Pattern
 
 A **self-evaluation** (reflection) pattern compares **past outcomes** to intent—forecasts versus arrivals, routing

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/sense_decide_act_loop.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/sense_decide_act_loop.md
@@ -1,5 +1,22 @@
 # Sense–Decide–Act Loop
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Sense["Sensing Agent"]
+    Decide["Decision Agent"]
+    Act["Action Agent"]
+    Transport["Transport / Partner Messages"]
+    Telemetry["Operational Telemetry"]
+
+    Telemetry -->|"Fresh Signals"| Sense
+    Sense -->|"Normalized Situation"| Decide
+    Decide -->|"Next Action"| Act
+    Act -->|"Route / Replan Message"| Transport
+    Transport -->|"New State"| Telemetry
+```
+
 ## Pattern
 
 The **sense–decide–act loop** runs **observe → act → re-evaluate** in cycles so plans update when the world moves—ports

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/session_context_buffer.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/session_context_buffer.md
@@ -1,5 +1,24 @@
 # Session Context Buffer
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Buyer["Buyer Agent"]
+    Farm["Farm Agent"]
+    Finance["Finance Agent"]
+    Buffer["Session Context Buffer"]
+    Room["Negotiation Thread"]
+
+    Buyer <-->|"Bid Floor + Counter"| Buffer
+    Farm <-->|"Offer + Availability"| Buffer
+    Finance <-->|"Payment Constraint"| Buffer
+
+    Buyer <-->|"Negotiation Message"| Room
+    Farm <-->|"Negotiation Message"| Room
+    Finance <-->|"Negotiation Message"| Room
+```
+
 ## Pattern
 
 A **session context buffer** is a **temporary, shared scratchpad** for one negotiation or task—bids, floors, deadlines,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_knowledge_store.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_knowledge_store.md
@@ -1,5 +1,21 @@
 # Shared Knowledge Store
 
+## Agent Interaction Diagram
+
+```mermaid
+graph TD
+    Store["Shared Knowledge Store"]
+    Planner["Planning Agent"]
+    Buyer["Buying Agent"]
+    Farm["Farm Agent"]
+    Analytics["Analytics / Ingestion Agent"]
+
+    Planner <-->|"Yield History Query"| Store
+    Buyer <-->|"Settled Price Query"| Store
+    Farm -->|"Partner Record Update"| Store
+    Analytics -->|"Curated Corrections"| Store
+```
+
 ## Pattern
 
 A **shared knowledge store** **persists knowledge across tasks and time**—yield history, supplier reliability, settled


### PR DESCRIPTION
## Summary

Adds a `## Agent Interaction Diagram` mermaid block to each of the 25 reference-library workflow docs under `api/agentic_workflows/docs/workflows/`.

Split out of the pattern reference library explorer PR (#651) to keep that review focused on code — this PR is **purely additive doc content** (25 files, +422 lines) with no code dependency. The FE renders these diagrams when present but works fine without them.

## Testing
N/A — markdown content only. Diagrams render in the pattern-doc canvas (see #651).

Epic: #588