### PR TITLE
fix(lungo,helm,awapi): add externalSecret resource

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for the Agentic Workflows HTTP API
 name: agentic-workflows-api
-version: 0.1.1
+version: 0.1.2

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/deployment.tpl.yaml
@@ -41,6 +41,10 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ .Values.appName }}-configmap
+        {{ if .Values.externalSecrets }}
+          - secretRef:
+              name: {{ .Values.appName }}-secrets
+        {{ end }}
         {{ if .Values.resources.enabled }}
         resources:
           requests:

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/es-secrets.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/agentic-workflows-api/templates/es-secrets.tpl.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.externalSecrets }}
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.appName }}-secrets
+  namespace: {{ .Release.Namespace }}
+spec:
+
+  # SecretStoreRef defines which SecretStore to use when fetching the secret data
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreName }}
+    kind: {{ .Values.externalSecrets.secretStoreKind }}  # or SecretStore
+
+  # RefreshInterval is the amount of time before the values reading again from the SecretStore provider
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" (from time.ParseDuration)
+  # May be set to zero to fetch and create it once
+  refreshInterval: "1h0m0s"
+
+  # the target describes the secret that shall be created
+  # there can only be one target per ExternalSecret
+  target:
+
+    # The secret name of the resource
+    # Defaults to .metadata.name of the ExternalSecret
+    # It is immutable
+    name: {{ .Values.appName }}-secrets
+
+  # Data defines the connection between the Kubernetes Secret keys and the Provider data
+  data:
+    {{- range .Values.externalSecrets.data }}
+    - {{ . | toYaml | nindent 6 }}
+    {{- end }}
+  {{ end }}


### PR DESCRIPTION
# Description

Added external secrets secret resource to AWAPI to be able to serve LLM model API key on deployment.

It's enough  to release the chart and update the deployment code, there is no need for new app/image release.

## Issue Link

Fixes #673 in the short run.
#674 should be tracking the long term fix.

## Type of Change

- [X] Bugfix

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
