### PR TITLE
chore(lungo): document API contracts and specs

### DIFF
--- a/.agents/skills/api-documentation-lungo/SKILL.md
+++ b/.agents/skills/api-documentation-lungo/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: api-documentation-lungo
+description: >-
+  Authors and maintains the human-facing Agentic Workflows API documentation for the lungo subproject at coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md, covering the catalog API, workflow-instance lifecycle/state, the internal event ingress, the SSE and NDJSON streaming formats, the canonical event_v1 JSON Schema, and the topology/use-case response shapes a frontend consumes. Use when documenting or updating the lungo workflow API; when an OpenAPI document under coffeeAGNTCY/coffee_agents/lungo/schema/openapi, the JSON Schema under coffeeAGNTCY/coffee_agents/lungo/schema/jsonschemas, or the router under coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows changes; or when a prompt references a ticket/issue, pull request, or file/folder that changes the lungo API contracts or specifications. DO NOT TRIGGER AUTOMATICALLY. ASK THE USER IF THE SKILL SHOULD BE USED.
+---
+
+# Agentic Workflows API documentation (lungo)
+
+Produces and maintains a single human-facing reference document for the lungo **Agentic Workflows API** from the machine-readable contracts already in the repo. The document is a guide; the specs are the source of truth, so the skill **derives** prose from the specs and never invents shapes.
+
+The lungo project root is `coffeeAGNTCY/coffee_agents/lungo/`. Paths in the [Source registry](#source-registry) are relative to that project root. The output document itself lives at `coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md` and links to sources with paths relative to its own `docs/` folder (e.g. `../schema/jsonschemas/event_v1.json`).
+
+## Output
+
+- Document: `coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md`.
+
+This document satisfies the interface-definition tickets it was first written for: [#447 — API endpoints](https://github.com/agntcy/coffeeAgntcy/issues/447) and [#446 — workflow-instance state JSON schema](https://github.com/agntcy/coffeeAgntcy/issues/446). Keep those links in the document's intro and schema section.
+
+## Source registry
+
+These are the authoritative inputs. Read them fresh on every run; do not trust the existing document to be current. Enumerate from the specs rather than hard-coding endpoint names or counts — the document must scale as the contracts grow.
+
+| Role | Path (relative to lungo root) | What to extract |
+|------|-------------------------------|-----------------|
+| OpenAPI entry point | `schema/openapi/openapi.yaml` | Title, version, tag, top-level structure |
+| OpenAPI path items | `schema/openapi/paths/agentic-workflows.yaml` | Every endpoint: method, path, params, query flags, responses, `x-internal` |
+| OpenAPI shared schemas | `schema/openapi/components/schemas.yaml` | Catalog/list DTO shapes; mapping of `Event`/`Workflow`/`WorkflowInstance`/`Topology`/`InstanceId` to `event_v1` |
+| **Canonical state schema** | `schema/jsonschemas/event_v1.json` | `$defs`, required fields, full-vs-partial variants, identifier patterns, invariants |
+| Event-type enum | `schema/jsonschemas/event_type_v1.json` | `metadata.type` enum values and extensibility note |
+| Schema examples | `schema/jsonschemas/examples/*.json` | Worked full/partial/empty payloads to link and (sparingly) excerpt |
+| Router (behavior not in spec) | `api/agentic_workflows/router.py` | Status-code semantics, SSE framing/comment-frame, backpressure, NDJSON framing, `topology_only` projection behavior |
+| DTOs | `api/agentic_workflows/dtos.py` | Field constraints; "temporary until #468" status note |
+| Auth | `api/agentic_workflows/auth.py` | Bearer requirement, `401`, startup key assertion |
+| Store interface | `common/workflow_instance_store/interfaces.py` | In-memory, keyed-by-instance, read vs write/fan-out split |
+| Server | `api/agentic_workflows/server.py` | Default port, app wiring |
+| Catalog data | `api/agentic_workflows/patterns.py`, `api/agentic_workflows/use_cases.py`, `api/agentic_workflows/starting_workflows.json` | Real example values for patterns, use-cases, workflows, topology |
+| Related doc | `docs/a2a_event_schema_middleware.md` | Cross-link for the event emitter (write) side |
+
+Sibling skills generate the contracts this document describes; when contracts change they are usually the upstream cause and should run first:
+
+- `.agents/skills/openapi-to-python-lungo/SKILL.md` — OpenAPI ⇄ FastAPI router/DTOs.
+- `.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md` — JSON Schema ⇄ Pydantic types.
+
+## Document structure
+
+Keep the document organized in this order (the headings are stable so links and anchors don't churn). Re-derive the content of each from the [Source registry](#source-registry):
+
+1. **Title + intro** — one-paragraph scope; the #447/#446 satisfaction note.
+2. **Authoritative sources** — a table linking the in-repo specs (OpenAPI, `event_v1.json`, Pydantic mirror, router) plus the example payloads, and a status note about temporary catalog DTOs (#468).
+3. **Conventions** — identifier URI schemes table; path-UUID vs payload-URI rule; authentication; storage model; default port.
+4. **Endpoint summary** — one table row per endpoint (purpose, method & path, response type).
+5. **Catalog API** — `GET /patterns/`, `GET /use-cases/`, `GET /agentic-workflows/` (filters), `…/documentation/`, and a pointer to the NDJSON chat.
+6. **Workflow details & topology response shapes** — `GET …/{workflow_name}/` + `topology_only`; an explicit node/agent-node/edge field breakdown; an example topology projection from `starting_workflows.json`.
+7. **Workflow-instance lifecycle & state** — instantiate, list, get state, delete, each with status codes.
+8. **Internal event ingress** — `POST …/events/` (mark internal), validation checks, status codes.
+9. **Streaming formats** — SSE instance-event stream (framing, comment frame, filtering, backpressure) and the NDJSON pattern-chat stream.
+10. **Workflow-instance state JSON Schema (`event_v1`)** — link to the published schema; "why one schema" (full snapshot vs delta); top-level shape; `$defs` reference table; event types; worked examples.
+11. **Frontend integration checklist** — numbered end-to-end flow (selectors → list → starting graph → instantiate → SSE → reconcile → delete).
+
+## Workflow
+
+Copy this checklist and tick items as you go:
+
+```
+- [ ] 1. Read every input in the Source registry (specs first, then router for behavior)
+- [ ] 2. Enumerate endpoints from OpenAPI and $defs from event_v1.json (do not hard-code)
+- [ ] 3. Reconcile spec against router.py; capture behavior the spec can't (status codes, SSE/NDJSON framing, backpressure)
+- [ ] 4. Write/refresh each document section per "Document structure", deriving every shape from a source
+- [ ] 5. Use real example values from the catalog data files; link (don't inline) full example payloads
+- [ ] 6. Apply the writing conventions
+- [ ] 7. Verify links and lint
+- [ ] 8. If new issues/PRs/files were referenced, update the Source registry AND the document (see "Keeping current")
+```
+
+### Source-of-truth rules
+
+- **Derive, never invent.** Every endpoint, field, status code, and constraint must trace to a source file. If the spec and the router disagree, document the router's actual behavior and flag the drift to the user.
+- **Spec for shape, router for behavior.** OpenAPI/JSON Schema give request/response shapes; `router.py` is authoritative for things the spec omits — exact status codes (e.g. `504` on instantiate merge timeout, `202`/`204` idempotent delete), the SSE leading comment frame and `exclude_none` compaction, per-subscriber queue bounds/drop-oldest, and the NDJSON `{"response"}`/`{"done"}`/`{"error"}` frames.
+- **Enumerate, don't count.** Build the endpoint summary and `$defs` table by listing what's in the specs so the document stays correct as endpoints/types are added.
+- **Real examples.** Pull patterns, use-cases, workflow summaries, and topology from `patterns.py`, `use_cases.py`, and `starting_workflows.json` so samples match what the API returns.
+
+### Writing conventions
+
+- Markdown prose is **not** hard-wrapped for length: one paragraph or list item per line. Keep tables, fenced code blocks, and JSON/SSE/NDJSON examples structured as-is (their line breaks are meaningful).
+- Link to source files with paths relative to `docs/` (`../schema/...`, `../api/...`). Link full example payloads rather than pasting them; excerpt only small, illustrative fragments.
+- Use fenced code blocks with a language tag (`json`, `jsonc`, `http`, `text`, `bash`) for samples; these are illustrative, not citations of repo lines.
+- Keep terminology consistent: "endpoint", "workflow instance", "topology", "event".
+
+### Verification
+
+Run from the repo root (the doc lives under the lungo project):
+
+```bash
+cd coffeeAGNTCY/coffee_agents/lungo/docs
+for p in $(grep -oE '\]\(\.\.?/[^)]+\)' workflow-instance_api.md | sed -E 's/^\]\(//; s/\)$//'); do
+  [ -e "$p" ] && echo "OK   $p" || echo "MISS $p"
+done
+```
+
+Fix any `MISS` link before finishing, then check the document for linter/markdown warnings and resolve any introduced.
+
+## Keeping the sources and this skill current
+
+This is a standing requirement, not a one-off. When a prompt or request references a **new ticket/issue, pull request, or file/folder** that changes the lungo API contracts or specifications:
+
+1. **Run upstream skills first if the contract files changed.** A reference that adds/renames endpoints or types usually means `schema/openapi/*` or `schema/jsonschemas/*` (and their Pydantic/router mirrors) should be regenerated via the sibling skills before documenting.
+2. **Update the document** — re-run the [Workflow](#workflow) so every affected section reflects the new contract. Add or update issue/PR links where they belong (intro for epics, schema section for schema tickets, the relevant endpoint/section otherwise).
+3. **Update this skill** — if a new authoritative file/folder is now part of the contract surface, add a row to the [Source registry](#source-registry); if a new endpoint family or document section is needed, extend [Document structure](#document-structure). Keep the frontmatter `description` trigger terms in sync with any newly referenced paths so discovery stays accurate. Do not record one-off ticket numbers in the registry — link them from the document instead, and only add durable file/folder sources here.
+4. **Keep the index in sync** — this skill is registered in the repository [`AGENTS.md`](../../../AGENTS.md) Skills table; update that entry if the skill's name or scope changes.
+
+Surface any contract inconsistency you find (spec vs router vs schema) to the user rather than silently papering over it in prose.

--- a/.agents/skills/api-documentation-lungo/SKILL.md
+++ b/.agents/skills/api-documentation-lungo/SKILL.md
@@ -28,7 +28,8 @@ These are the authoritative inputs. Read them fresh on every run; do not trust t
 | **Canonical state schema** | `schema/jsonschemas/event_v1.json` | `$defs`, required fields, full-vs-partial variants, identifier patterns, invariants |
 | Event-type enum | `schema/jsonschemas/event_type_v1.json` | `metadata.type` enum values and extensibility note |
 | Schema examples | `schema/jsonschemas/examples/*.json` | Worked full/partial/empty payloads to link and (sparingly) excerpt |
-| Router (behavior not in spec) | `api/agentic_workflows/router.py` | Status-code semantics, SSE framing/comment-frame, backpressure, NDJSON framing, `topology_only` projection behavior |
+| Router (behavior not in spec) | `api/agentic_workflows/router.py` | Per-endpoint status codes and their trigger conditions (every `HTTPException` in the handler **and** in dependencies/helpers it calls, not just the OpenAPI-declared responses), SSE framing/comment-frame, backpressure, NDJSON framing, `topology_only` projection behavior |
+| Instance lifecycle helpers | `api/agentic_workflows/instance_lifecycle.py` | Error conditions the handlers translate into status codes (e.g. `ValueError` from `build_instantiate_seed_event`/projection helpers → `500`) |
 | DTOs | `api/agentic_workflows/dtos.py` | Field constraints; "temporary until #468" status note |
 | Auth | `api/agentic_workflows/auth.py` | Bearer requirement, `401`, startup key assertion |
 | Store interface | `common/workflow_instance_store/interfaces.py` | In-memory, keyed-by-instance, read vs write/fan-out split |
@@ -64,7 +65,7 @@ Copy this checklist and tick items as you go:
 ```
 - [ ] 1. Read every input in the Source registry (specs first, then router for behavior)
 - [ ] 2. Enumerate endpoints from OpenAPI and $defs from event_v1.json (do not hard-code)
-- [ ] 3. Reconcile spec against router.py; capture behavior the spec can't (status codes, SSE/NDJSON framing, backpressure)
+- [ ] 3. Reconcile spec against router.py; capture behavior the spec can't (the full reachable status-code set + trigger conditions from handlers, dependencies, and helper modules; SSE/NDJSON framing; backpressure)
 - [ ] 4. Write/refresh each document section per "Document structure", deriving every shape from a source
 - [ ] 5. Use real example values from the catalog data files; link (don't inline) full example payloads
 - [ ] 6. Apply the writing conventions
@@ -76,6 +77,7 @@ Copy this checklist and tick items as you go:
 
 - **Derive, never invent.** Every endpoint, field, status code, and constraint must trace to a source file. If the spec and the router disagree, document the router's actual behavior and flag the drift to the user.
 - **Spec for shape, router for behavior.** OpenAPI/JSON Schema give request/response shapes; `router.py` is authoritative for things the spec omits — exact status codes (e.g. `504` on instantiate merge timeout, `202`/`204` idempotent delete), the SSE leading comment frame and `exclude_none` compaction, per-subscriber queue bounds/drop-oldest, and the NDJSON `{"response"}`/`{"done"}`/`{"error"}` frames.
+- **Derive the full status-code set from the code, not just the OpenAPI `responses`.** For each endpoint, trace every reachable `HTTPException` — in the handler body, in shared dependencies it uses (e.g. `_workflow_instance_store` → `503` when the store is unset), and in helper modules it calls (e.g. `instance_lifecycle.py` `ValueError` → `500`). The OpenAPI spec often documents only the happy-path and a subset of errors; the document must list the codes the code can actually return. For each code, state the **condition** that triggers it (and note when it reflects a server-side fault vs. client input).
 - **Enumerate, don't count.** Build the endpoint summary and `$defs` table by listing what's in the specs so the document stays correct as endpoints/types are added.
 - **Real examples.** Pull patterns, use-cases, workflow summaries, and topology from `patterns.py`, `use_cases.py`, and `starting_workflows.json` so samples match what the API returns.
 
@@ -85,6 +87,7 @@ Copy this checklist and tick items as you go:
 - Link to source files with paths relative to `docs/` (`../schema/...`, `../api/...`). Link full example payloads rather than pasting them; excerpt only small, illustrative fragments.
 - Use fenced code blocks with a language tag (`json`, `jsonc`, `http`, `text`, `bash`) for samples; these are illustrative, not citations of repo lines.
 - Keep terminology consistent: "endpoint", "workflow instance", "topology", "event".
+- Present per-endpoint status codes as a markdown bullet list introduced by a `Status codes:` line (or an equivalent lead-in such as `Behavior and status codes:`), one code per item in the form `` - `<code>` — <condition>. `` — never as an inline semicolon- or comma-separated sentence. Keep this consistent across every endpoint that lists more than one code.
 
 ### Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 | Generate release notes | [.agents/skills/generate-release-notes/SKILL.md](.agents/skills/generate-release-notes/SKILL.md) |
 | OpenAPI → Python (lungo) | [.agents/skills/openapi-to-python-lungo/SKILL.md](.agents/skills/openapi-to-python-lungo/SKILL.md) |
 | JSON Schema → Pydantic (lungo) | [.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md](.agents/skills/jsonschema-to-pydantic-lungo/SKILL.md) |
+| API documentation (lungo) | [.agents/skills/api-documentation-lungo/SKILL.md](.agents/skills/api-documentation-lungo/SKILL.md) |
 
 ## Repository references
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
@@ -1,0 +1,463 @@
+# Agentic Workflow Instance API
+
+Interface documentation for the Lungo **Agentic Workflows API**: the catalog (patterns, use-cases, workflows), workflow-instance lifecycle and state, the internal event ingress, and the Server-Sent Events (SSE) stream. It also documents the wire formats — the canonical `event_v1` JSON Schema, SSE framing, and the NDJSON pattern-chat stream — and the response shapes a frontend needs to render the use-case list and workflow topology without guessing.
+
+This document satisfies the interface-definition tickets [#447 — API endpoints](https://github.com/agntcy/coffeeAgntcy/issues/447) and [#446 — workflow-instance state JSON schema](https://github.com/agntcy/coffeeAgntcy/issues/446).
+
+## Authoritative sources
+
+The contracts described here are **published in-repo**. This document is a guide; the machine-readable specs are the source of truth.
+
+| Contract | File |
+| --- | --- |
+| OpenAPI 3.1 spec (root) | [`../schema/openapi/openapi.yaml`](../schema/openapi/openapi.yaml) |
+| OpenAPI path items | [`../schema/openapi/paths/agentic-workflows.yaml`](../schema/openapi/paths/agentic-workflows.yaml) |
+| OpenAPI shared schemas | [`../schema/openapi/components/schemas.yaml`](../schema/openapi/components/schemas.yaml) |
+| **Workflow-instance state JSON Schema** (`event_v1`) | [`../schema/jsonschemas/event_v1.json`](../schema/jsonschemas/event_v1.json) |
+| Event-type enum JSON Schema | [`../schema/jsonschemas/event_type_v1.json`](../schema/jsonschemas/event_type_v1.json) |
+| Pydantic mirror of the schema | [`../schema/types/event.py`](../schema/types/event.py) |
+| FastAPI router (implementation) | [`../api/agentic_workflows/router.py`](../api/agentic_workflows/router.py) |
+
+Examples of complete and partial messages live alongside the schema:
+
+- Full snapshot: [`../schema/jsonschemas/examples/event_v1_full.json`](../schema/jsonschemas/examples/event_v1_full.json)
+- Partial delta: [`../schema/jsonschemas/examples/event_v1_partial.json`](../schema/jsonschemas/examples/event_v1_partial.json)
+- Empty workflows: [`../schema/jsonschemas/examples/event_v1_empty_workflows.json`](../schema/jsonschemas/examples/event_v1_empty_workflows.json)
+
+> **Status.** The catalog list DTOs (patterns, use-cases, workflow summaries) are temporary API-layer types defined in [`../api/agentic_workflows/dtos.py`](../api/agentic_workflows/dtos.py). They are being folded into the canonical JSON Schema (tracked in [#468](https://github.com/agntcy/coffeeAgntcy/issues/468)) so OpenAPI, JSON Schema, and Pydantic remain a single source of truth. The instance/state and event shapes (`Workflow`, `WorkflowInstance`, `Topology`, `Event`) are already canonical in `event_v1.json`.
+
+## Conventions
+
+### Identifiers
+
+All identifiers are opaque URI strings with a scheme prefix wrapping a UUID. The canonical patterns are defined in `event_v1.json#/$defs`:
+
+| Kind | Scheme | Example |
+| --- | --- | --- |
+| Event | `event://` | `event://6ba7b811-9dad-11d1-80b4-00c04fd430c8` |
+| Correlation | `correlation://` | `correlation://6ba7b810-9dad-11d1-80b4-00c04fd430c8` |
+| Workflow instance | `instance://` | `instance://6ba7b817-9dad-11d1-80b4-00c04fd430c8` |
+| Graph node | `node://` | `node://6ba7b812-9dad-11d1-80b4-00c04fd430c8` |
+| Graph edge | `edge://` | `edge://6ba7b815-9dad-11d1-80b4-00c04fd430c8` |
+| Stable agent id | `agent://` | `agent://470de4a0-a6bc-5e1b-82dd-e41de2af3f85` |
+| Chat session | `session://` | `session://550e8400-e29b-41d4-a716-446655440000` |
+
+**Path vs. payload identifiers.** Instance-scoped routes take a **bare UUID** in the URL path (`WorkflowInstancePathId`, e.g. `/agentic-workflows/Publish%20Subscribe/instances/6ba7b817-9dad-11d1-80b4-00c04fd430c8/`). JSON payloads and response fields always use the full `instance://<uuid>` URI (`InstanceId`). The server converts between the two.
+
+### Authentication
+
+Every endpoint (except `GET /health`) requires a bearer token:
+
+```http
+Authorization: Bearer <WORKFLOW_API_KEY>
+```
+
+A missing or mismatched token yields `401 Unauthorized` ([`../api/agentic_workflows/auth.py`](../api/agentic_workflows/auth.py)). The server refuses to start unless `WORKFLOW_API_KEY` is configured.
+
+### Storage model
+
+State is held **in-memory**, keyed by `workflow_instance_id`, with **no persistence** (per #447). The state API and SSE endpoint read from the store; the internal `POST .../events/` ingress (the A2A / MCP middleware path) writes to the store and notifies SSE subscribers. The store surface is defined in [`../common/workflow_instance_store/interfaces.py`](../common/workflow_instance_store/interfaces.py).
+
+### Default port
+
+The standalone service listens on `:9105` ([`../api/agentic_workflows/server.py`](../api/agentic_workflows/server.py)).
+
+## Endpoint summary
+
+| Purpose | Method & path | Response |
+| --- | --- | --- |
+| Redirect root to catalog | `GET /` | `307` → `/patterns/` |
+| List patterns | `GET /patterns/` | `PatternListResponse` |
+| Chat with a pattern's docs | `POST /patterns/{name}/chat` | NDJSON stream |
+| List use-cases | `GET /use-cases/` | `UseCaseListResponse` |
+| List workflows (filterable) | `GET /agentic-workflows/` | `WorkflowSummaryMapResponse` |
+| Workflow details / starting topology | `GET /agentic-workflows/{workflow_name}/` | `Workflow` |
+| Workflow documentation (markdown) | `GET /agentic-workflows/{workflow_name}/documentation/` | `WorkflowDocumentationResponse` |
+| Instantiate a workflow | `POST /agentic-workflows/{workflow_name}/` | `InstantiateWorkflowResponse` |
+| List workflow instances | `GET /agentic-workflows/{workflow_name}/instances/` | `WorkflowInstanceMapResponse` |
+| Get instance state (full / topology only) | `GET /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/` | `WorkflowInstance` |
+| Delete instance | `DELETE /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/` | `202` / `204` |
+| **(internal)** Post state update event | `POST /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/events/` | `204` |
+| SSE stream of instance events | `GET /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/events/stream` | `text/event-stream` |
+
+The endpoint set mirrors the table in [#447](https://github.com/agntcy/coffeeAgntcy/issues/447); `documentation/` and `patterns/{name}/chat` are additional surfaces present in the implementation.
+
+---
+
+## Catalog API
+
+The catalog lets a frontend discover what can be run and how to filter it. All catalog data is currently static ([`patterns.py`](../api/agentic_workflows/patterns.py), [`use_cases.py`](../api/agentic_workflows/use_cases.py), [`starting_workflows.json`](../api/agentic_workflows/starting_workflows.json)).
+
+### `GET /patterns/` — list patterns
+
+Returns the architectural patterns available in the catalog.
+
+```json
+{
+  "items": [
+    { "name": "Supervisor" },
+    { "name": "Peer Group" },
+    { "name": "Recruiter" }
+  ]
+}
+```
+
+### `GET /use-cases/` — list use-cases
+
+Returns the business use-cases available in the catalog. This is the shape a frontend should bind a use-case selector to.
+
+```json
+{
+  "items": [
+    { "name": "Coffee Agntcy" }
+  ]
+}
+```
+
+`UseCaseListResponse` is an object with a required `items` array; each item is an object with a required, non-empty `name` string and no additional properties (`UseCase` / `UseCaseListResponse` in [`components/schemas.yaml`](../schema/openapi/components/schemas.yaml)). The list-of-objects shape (rather than a bare array of strings) is intentional so each use-case can grow extra fields later without breaking clients.
+
+### `GET /agentic-workflows/` — list workflows
+
+Returns the workflows in the catalog as a **map keyed by workflow name**. Optional repeated query parameters filter the result:
+
+- `patterns` — `[]string` (repeat the param: `?patterns=Supervisor&patterns=Recruiter`)
+- `use_cases` — `[]string` (`?use_cases=Coffee%20Agntcy`)
+
+Both filters are independent; when both are supplied a workflow must match a pattern **and** a use-case to be included.
+
+```http
+GET /agentic-workflows/?patterns=Supervisor&use_cases=Coffee%20Agntcy
+```
+
+```json
+{
+  "Publish Subscribe": {
+    "name": "Publish Subscribe",
+    "pattern": "Supervisor",
+    "use_case": "Coffee Agntcy",
+    "scenario": "Purchasing"
+  },
+  "Publish Subscribe Streaming": {
+    "name": "Publish Subscribe Streaming",
+    "pattern": "Supervisor",
+    "use_case": "Coffee Agntcy",
+    "scenario": "Purchasing"
+  }
+}
+```
+
+Each value is a `WorkflowSummary`: `name`, `pattern`, `use_case`, and `scenario` (a brief extra qualifier for the use-case). The map key always equals `WorkflowSummary.name`.
+
+### `GET /agentic-workflows/{workflow_name}/documentation/` — workflow docs
+
+Returns the reference markdown for a catalog workflow, both as a single blob and split into sections at `##` headings (for TOC / anchored rendering). Backed by files under [`../api/agentic_workflows/docs/workflows/`](../api/agentic_workflows/docs/workflows).
+
+```json
+{
+  "slug": "publish_subscribe",
+  "workflow_name": "Publish Subscribe",
+  "title": "Publish Subscribe",
+  "sections": [
+    {
+      "anchor": "overview",
+      "heading": "Overview",
+      "body_markdown": "..."
+    }
+  ],
+  "full_markdown": "# Publish Subscribe\n\n## Overview\n..."
+}
+```
+
+Returns `404` for an unknown workflow name or when no markdown file maps to it.
+
+### `POST /patterns/{name}/chat` — chat with a pattern's docs (NDJSON)
+
+A retrieval-grounded chat over a pattern's reference markdown. See [NDJSON pattern-chat stream](#ndjson-pattern-chat-stream) for the wire format.
+
+---
+
+## Workflow details & topology response shapes
+
+### `GET /agentic-workflows/{workflow_name}/` — workflow details
+
+Returns the full `Workflow` object (`event_v1.json#/$defs/workflow`): catalog metadata, the predefined **`starting_topology`**, and the `instances` map. This is the shape a frontend renders to draw the **starting graph** before any instance is created.
+
+Query parameter:
+
+- `topology_only` (boolean, default `false`) — when `true`, the server returns a topology-focused projection (the `instances` map is emptied), so the client gets just the starting graph.
+
+`Workflow` (required fields): `name`, `pattern`, `use_case`, `scenario`, `starting_topology`, `instances`. `additionalProperties` is allowed.
+
+#### Topology shape
+
+A **topology** (`event_v1.json#/$defs/topology`) is an object with `nodes` and `edges` arrays. The *full* form (used for `starting_topology` and instance init) requires both arrays; the *partial* form (`#/$defs/partial_topology`, used for deltas) allows them to be omitted.
+
+**Node** (`#/$defs/regular_node`, required for a full node): `id` (`node://…`), `operation` (`create` | `read` | `update` | `delete`), `type` (e.g. `customNode`, `transportNode`, `group`), `label`, `size` (`{ width, height }`, relative layout sizing), and `layer_index`. `additionalProperties` is allowed (the starting catalog, for example, carries an extra `position: { x, y }`).
+
+An **agent node** (`#/$defs/agent_node`) additionally carries `agent_record_uri` (required) and `stable_agent_id` (`agent://…`). Nodes without agent extension fields are plain regular nodes; the schema keeps the two mutually exclusive via `anyOf`/`not`.
+
+**Edge** (`#/$defs/edge`, required for a full edge): `id` (`edge://…`), `operation`, `type`, `source` (`node://…`), `target` (`node://…`), `bidirectional` (boolean), and `weight` (number). `additionalProperties` is allowed.
+
+Example topology projection (`?topology_only=true`):
+
+```json
+{
+  "name": "A2A HTTP",
+  "pattern": "Recruiter",
+  "use_case": "Coffee Agntcy",
+  "scenario": "Capability Discovery",
+  "starting_topology": {
+    "nodes": [
+      {
+        "id": "node://4a000001-0001-4000-a001-000000000001",
+        "operation": "read",
+        "type": "customNode",
+        "label": "Agentic Recruiter",
+        "size": { "width": 1.0, "height": 1.0 },
+        "layer_index": 0,
+        "position": { "x": 400, "y": 300 },
+        "agent_record_uri": "../../agents/supervisors/recruiter/oasf/agents/recruiter.json"
+      },
+      {
+        "id": "node://4a000001-0001-4000-a001-000000000002",
+        "operation": "read",
+        "type": "customNode",
+        "label": "AGNTCY Agent Directory",
+        "size": { "width": 1.0, "height": 1.0 },
+        "layer_index": 1,
+        "position": { "x": 800, "y": 100 }
+      }
+    ],
+    "edges": [
+      {
+        "id": "edge://4a000001-0001-4000-a001-e00000000001",
+        "operation": "read",
+        "type": "custom",
+        "source": "node://4a000001-0001-4000-a001-000000000002",
+        "target": "node://4a000001-0001-4000-a001-000000000001",
+        "bidirectional": false,
+        "weight": 1.0
+      }
+    ]
+  },
+  "instances": {}
+}
+```
+
+Returns `404` when `workflow_name` is not in the catalog.
+
+> **Note on node ids.** At startup the catalog loader assigns fresh runtime `node://`/`edge://` ids and derives `stable_agent_id` (a UUID5 of the agent record `name`) for agent nodes. Treat ids returned by the API as the live values; do not assume they match the static JSON file verbatim.
+
+---
+
+## Workflow-instance lifecycle & state
+
+### `POST /agentic-workflows/{workflow_name}/` — instantiate
+
+Creates a new instance of the workflow and seeds its starting topology into the store. Responds with the instance id to track (as an `instance://…` URI).
+
+```json
+{ "workflow_instance_id": "instance://6ba7b817-9dad-11d1-80b4-00c04fd430c8" }
+```
+
+Behavior and status codes:
+
+- `200` — instance created; body is `InstantiateWorkflowResponse`.
+- `404` — unknown `workflow_name`.
+- `400` — the seed event failed schema validation.
+- `503` — store not configured / closed.
+- `504` — the event was accepted and queued but the in-memory merge did not finish in time. **Each `POST` creates a new instance**, so do not blindly retry; poll the instances list or `GET` the instance state first.
+
+### `GET /agentic-workflows/{workflow_name}/instances/` — list instances
+
+Returns the instances of a workflow as a **map keyed by `instance://…` id**; each value is a `WorkflowInstance`.
+
+```json
+{
+  "instance://6ba7b817-9dad-11d1-80b4-00c04fd430c8": {
+    "id": "instance://6ba7b817-9dad-11d1-80b4-00c04fd430c8",
+    "topology": { "nodes": [ /* … */ ], "edges": [ /* … */ ] }
+  }
+}
+```
+
+Returns `404` when `workflow_name` is not in the catalog.
+
+### `GET /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/` — instance state
+
+Returns a single `WorkflowInstance` (`event_v1.json#/$defs/workflow_instance`): the current dynamic state of that instance. `WorkflowInstance` requires `id` (`instance://…`, identical to its key in the parent map) and `topology` (a `partial_topology` reflecting the live graph). `additionalProperties` is allowed for extra runtime state.
+
+Query parameter:
+
+- `topology_only` (boolean, default `false`) — when `true`, returns a topology-only projection of the instance.
+
+`{workflow_instance_id}` is the **bare UUID** path segment; the response `id` field is the full `instance://<uuid>` URI.
+
+Status codes: `200` on success; `404` when the workflow or the instance is unknown.
+
+### `DELETE /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/` — delete instance
+
+Schedules removal from the in-memory store. **Idempotent**:
+
+- `202` — instance existed; deletion accepted (runs in the background).
+- `204` — nothing to delete (already removed or never existed).
+- `404` — unknown `workflow_name`.
+
+---
+
+## Internal event ingress
+
+### `POST /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/events/`
+
+> **Internal only.** This is the write path used by the A2A / MCP state middleware, not by untrusted public clients (marked `x-internal: true` in OpenAPI). See [`a2a_event_schema_middleware.md`](a2a_event_schema_middleware.md) for the emitter side.
+
+Applies a workflow-instance **state update event** to the store. The request body is a full `Event` document validated against [`event_v1.json`](../schema/jsonschemas/event_v1.json). The server checks that:
+
+1. The event's `data.workflows` contains the path `workflow_name`.
+2. That workflow's `instances` map targets the path `workflow_instance_id` (canonicalized to `instance://<uuid>`).
+3. The workflow exists in the catalog and the instance exists in the store.
+
+On success the event is enqueued, merged into the accumulated state, and fanned out to SSE subscribers of that instance.
+
+Status codes:
+
+- `204` — event accepted.
+- `400` — payload does not match the path target, or failed schema validation.
+- `404` — unknown workflow or instance.
+- `503` — store closed.
+
+---
+
+## Streaming formats
+
+### SSE workflow-instance event stream
+
+#### `GET /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/events/stream`
+
+Opens a `text/event-stream` (SSE) connection that emits every event applied to the given instance. Response headers set `Cache-Control: no-store`, `Connection: keep-alive`, and `X-Accel-Buffering: no` so proxies don't buffer.
+
+**Framing.** Each event is one SSE message: a single `data:` line containing the **compact `event_v1` JSON** (no `event:`/`id:` lines), terminated by a blank line. `None`-valued fields are omitted (`exclude_none`). On connect, the server first sends an SSE comment frame (`:\n\n`) to flush response headers before it blocks waiting for events.
+
+```text
+:
+
+data: {"metadata":{"timestamp":"2026-03-17T12:00:01Z","schema_version":"1.0.0","correlation":{"id":"correlation://550e8400-e29b-41d4-a716-446655440001"},"id":"event://550e8400-e29b-41d4-a716-446655440002","type":"RecruiterNodeSearch","source":"auction_supervisor"},"data":{"workflows":{"recruiter":{"name":"Recruiter","pattern":"recruiter_pattern","use_case":"hiring","scenario":"agent recruitment","starting_topology":{ /* … */ },"instances":{"instance://550e8400-e29b-41d4-a716-446655440003":{"id":"instance://550e8400-e29b-41d4-a716-446655440003","topology":{"nodes":[{"id":"node://550e8400-e29b-41d4-a716-446655440010","operation":"update","type":"customNode","label":"Auction Agent (search)","agent_record_uri":"../../agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json"}],"edges":[]}}}}}}}
+
+```
+
+Each `data:` payload validates against `event_v1.json`. The stream only carries events whose `data.workflows[workflow_name].instances` includes the subscribed instance id; events for other instances are filtered out server-side.
+
+**Backpressure.** The per-subscriber queue is bounded (100 frames). When it fills past the high-water mark, the oldest frames are dropped first — clients should treat the stream as a best-effort change feed and reconcile against `GET …/instances/{id}/` if they detect a gap.
+
+A frontend typically: `POST` to instantiate → render the `starting_topology` from `GET …/{workflow_name}/` → open the SSE stream → apply each event's `topology` delta (using `operation` per node/edge) to the rendered graph.
+
+### NDJSON pattern-chat stream
+
+#### `POST /patterns/{name}/chat`
+
+A newline-delimited JSON (`application/x-ndjson`) stream for chatting with a pattern's reference docs. Request body (`PatternChatRequest`):
+
+```json
+{
+  "session_id": "session://550e8400-e29b-41d4-a716-446655440000",
+  "message": "How does the supervisor pattern route requests?"
+}
+```
+
+- `session_id` — client-minted UUIDv4 wrapped as a `session://<uuid>` URI; the server holds conversation state in memory keyed by `(pattern_name, session_id)`.
+- `message` — the latest user turn (1–32768 chars).
+
+**Framing.** One JSON object per line:
+
+- `{"response": "<chunk>"}` — a chunk of the answer (zero or more).
+- `{"done": true}` — terminates a successful stream.
+- `{"error": "<message>"}` — emitted instead if the stream fails mid-flight, then the connection closes.
+
+```text
+{"response": "The supervisor pattern "}
+{"response": "routes requests by ..."}
+{"done": true}
+```
+
+Returns `404` (before opening the stream) when the pattern has no reference markdown, and `422` when the request body fails validation.
+
+---
+
+## Workflow-instance state JSON Schema (`event_v1`)
+
+The single, validatable contract shared by senders (agents, LangGraph adapters), the A2A state middleware, the internal event ingress, and the SSE stream is published at [`../schema/jsonschemas/event_v1.json`](../schema/jsonschemas/event_v1.json) (JSON Schema draft 2020-12, `$id` `https://github.com/agntcy/coffeeAgntcy/schema/jsonschemas/event_v1.json`). This is the schema requested in [#446](https://github.com/agntcy/coffeeAgntcy/issues/446); it is referenced by OpenAPI (`components/schemas.yaml` maps `Event`, `Workflow`, `WorkflowInstance`, `Topology`, `PartialTopology`, `InstanceId` to it) and mirrored in Pydantic ([`../schema/types/event.py`](../schema/types/event.py)). Validation helpers live in [`../schema/validate.py`](../schema/validate.py).
+
+### Why one schema
+
+A single schema represents **both** a full state snapshot (init / reset, when fully filled) **and** an event/delta (partial topology). Full variants (`node`, `edge`, `topology`, `regular_node`) require all fields; partial variants (`partial_node`, `partial_edge`, `partial_topology`, `partial_regular_node`) require only `id` + `operation` and allow the rest to be omitted. The `operation` field (`create` / `read` / `update` / `delete`) tells a consumer how to apply each node/edge against the current graph.
+
+### Top-level shape
+
+An `Event` is `{ metadata, data }` (both required, `additionalProperties: false` at the root):
+
+```jsonc
+{
+  "metadata": {                       // syntactic + semantic metadata (all required)
+    "timestamp": "RFC3339 date-time",
+    "schema_version": "1.0.0",        // semantic version of this contract
+    "correlation": {                  // ties events from one user action / request
+      "id": "correlation://<uuid>",   // required
+      "message": "optional string"    // additionalProperties allowed
+    },
+    "id": "event://<uuid>",           // unique event id
+    "type": "StateProgressUpdate",    // see event_type_v1.json (extendable enum)
+    "source": "auction_supervisor"    // producer identifier
+    // additionalProperties allowed
+  },
+  "data": {                           // business data (partial_state)
+    "workflows": {                    // required; map workflow_name -> workflow
+      "<workflow_name>": {
+        "name": "…", "pattern": "…",  // all four catalog fields required + unique
+        "use_case": "…", "scenario": "…",
+        "starting_topology": { /* full topology */ },   // required
+        "instances": {                // required; map instance_id -> instance
+          "instance://<uuid>": {
+            "id": "instance://<uuid>", // required; must equal the map key
+            "topology": { /* partial_topology */ }
+            // additionalProperties allowed
+          }
+        }
+        // additionalProperties allowed
+      }
+    }
+    // additionalProperties allowed (e.g. app_state)
+  }
+}
+```
+
+Key invariant: each property name under `workflow.instances` **must equal** the nested object's `id` (the same `instance://<uuid>` string).
+
+### `$defs` reference
+
+| `$def` | Meaning |
+| --- | --- |
+| `event_id`, `correlation_id`, `instance_id`, `node_id`, `edge_id`, `stable_agent_id` | URI-pattern id strings (see [Identifiers](#identifiers)). |
+| `operation` | Entity op: `create` \| `read` \| `update` \| `delete`. |
+| `size` | Relative layout size `{ width, height }` (defaults `1.0`). |
+| `metadata` | Required event metadata block. |
+| `correlation` | `{ id (required), message? }`, `additionalProperties: true`. |
+| `partial_regular_node` / `regular_node` | Sparse vs. full non-agent node. |
+| `partial_agent_node` / `agent_node` | Node + agent extension (`agent_record_uri`, `stable_agent_id`). |
+| `partial_node` / `node` | A regular node **or** an agent node (mutually exclusive). |
+| `partial_edge` / `edge` | Sparse vs. full edge. |
+| `partial_topology` / `topology` | `{ nodes, edges }`; partial allows omission, full requires both. |
+| `workflow_instance` | `{ id (required), topology }`, `additionalProperties: true`. |
+| `workflow` | Catalog metadata + `starting_topology` + `instances`. |
+| `data` | `{ workflows (required) }`, `additionalProperties: true`. |
+
+### Event types
+
+`metadata.type` is constrained by [`event_type_v1.json#/$defs/event_type`](../schema/jsonschemas/event_type_v1.json): a string enum that is **extendable at the emitter**. Current values (`RecruiterNodeSearch`, `StateProgressUpdate`) are placeholders to be finalized as emitters are implemented.
+
+### Worked examples
+
+- **Full snapshot (init / reset)** — every node/edge fully populated: [`examples/event_v1_full.json`](../schema/jsonschemas/examples/event_v1_full.json).
+- **Partial delta (update)** — one node carrying `operation: "update"` and only the changed fields, empty `edges`: [`examples/event_v1_partial.json`](../schema/jsonschemas/examples/event_v1_partial.json).
+- **Empty workflows + extra `app_state`** — demonstrates root-level `additionalProperties`: [`examples/event_v1_empty_workflows.json`](../schema/jsonschemas/examples/event_v1_empty_workflows.json).
+
+---

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
@@ -254,7 +254,7 @@ Returns `404` when `workflow_name` is not in the catalog.
 
 ### `POST /agentic-workflows/{workflow_name}/` — instantiate
 
-Creates a new instance of the workflow and seeds its starting topology into the store. Responds with the instance id to track (as an `instance://…` URI).
+Creates a new empty instance of the workflow and registers it in the store. The corresponding starting topology is stored at the workflow level and seeded into the instance with a follow-up event. Responds with the instance id to track (as an `instance://…` URI).
 
 ```json
 { "workflow_instance_id": "instance://6ba7b817-9dad-11d1-80b4-00c04fd430c8" }
@@ -265,6 +265,7 @@ Behavior and status codes:
 - `200` — instance created; body is `InstantiateWorkflowResponse`.
 - `404` — unknown `workflow_name`.
 - `400` — the seed event failed schema validation.
+- `500` — catalog inconsistency: the seed builder found the catalog `Workflow.name` did not match the resolved `workflow_name` (a server-side data-integrity fault, not client input).
 - `503` — store not configured / closed.
 - `504` — the event was accepted and queued but the in-memory merge did not finish in time. **Each `POST` creates a new instance**, so do not blindly retry; poll the instances list or `GET` the instance state first.
 
@@ -293,7 +294,12 @@ Query parameter:
 
 `{workflow_instance_id}` is the **bare UUID** path segment; the response `id` field is the full `instance://<uuid>` URI.
 
-Status codes: `200` on success; `404` when the workflow or the instance is unknown.
+Status codes:
+
+- `200` — success.
+- `404` — the workflow or the instance is unknown.
+- `500` — the store returned a malformed instance projection (a server-side data-integrity fault).
+- `503` — the instance store is not configured.
 
 ### `DELETE /agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/` — delete instance
 
@@ -379,7 +385,10 @@ A newline-delimited JSON (`application/x-ndjson`) stream for chatting with a pat
 {"done": true}
 ```
 
-Returns `404` (before opening the stream) when the pattern has no reference markdown, and `422` when the request body fails validation.
+Status codes:
+
+- `404` — the pattern has no reference markdown (returned before opening the stream).
+- `422` — the request body failed validation.
 
 ---
 


### PR DESCRIPTION
# Description

This PR aims to document the agentic workflow API (instance/state, catalog API, and SSE, NDJSON format and schema) and document use-case list and topology response shapes.

This PR also includes a Skill to try to make this process more replicable. The Skill mentions that new additions to API contracts and specs should trigger updates to both the documentation and the Skill (this last one if there are new sources of information/truth to consider).

## Issue Link

Fixes #454 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
