### PR TITLE
fix(lungoui,helm): fix deployment template envfrom

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.9"
 description: A Helm chart for Lungo UI
 name: lungo-ui
-version: 0.1.4
+version: 0.1.5

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/deployment.tpl.yaml
@@ -53,6 +53,7 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 10
           {{ end }}
+          envFrom:
           {{ if .Values.externalSecrets }}
             - secretRef:
                 name: {{ .Values.appName }}-secrets


### PR DESCRIPTION
# Description

Fixing lungo UI deployment template's envFrom used for the external secrets (unused currently).
It was messed up in #642 .

## Issue Link

.

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
