### PR TITLE
fix(lungo,helm,ui): fix chart envfrom again

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.9"
 description: A Helm chart for Lungo UI
 name: lungo-ui
-version: 0.1.5
+version: 0.1.6

--- a/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/deployment.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/deployment/helm/ui/templates/deployment.tpl.yaml
@@ -53,8 +53,8 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 10
           {{ end }}
-          envFrom:
           {{ if .Values.externalSecrets }}
+          envFrom:
             - secretRef:
                 name: {{ .Values.appName }}-secrets
           {{ end }}


### PR DESCRIPTION
# Description

If external secrets are not provided from values then the envFrom would be empty object and that makes an invalid YAML, so I'm moving the envFrom into the conditional, we don't use it without ES ATM.

## Issue Link

.

## Type of Change

- [X] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
