### PR TITLE
chore(lungo): update OASF records preferredTransport for farms to slim

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json
@@ -47,7 +47,7 @@
           ],
           "description": "An AI agent that returns the yield of coffee beans in pounds for the Brazil farm.",
           "name": "Brazil Coffee Farm",
-          "preferredTransport": "slimrpc",
+          "preferredTransport": "slim",
           "protocolVersion": "0.3.0",
           "skills": [
             {

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/colombia-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/colombia-coffee-farm.json
@@ -47,7 +47,7 @@
           ],
           "description": "An AI agent that returns the yield of coffee beans in pounds for the Colombia farm.",
           "name": "Colombia Coffee Farm",
-          "preferredTransport": "slimrpc",
+          "preferredTransport": "slim",
           "protocolVersion": "0.3.0",
           "skills": [
             {

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json
@@ -51,7 +51,7 @@
           ],
           "description": "An AI agent that returns the yield of coffee beans in pounds for the Vietnam farm.",
           "name": "Vietnam Coffee Farm",
-          "preferredTransport": "slimrpc",
+          "preferredTransport": "slim",
           "protocolVersion": "0.3.0",
           "skills": [
             {


### PR DESCRIPTION
# Description

This PR aims to update the OASF records `preferredTransport` field for farms (from `slimprc`) to `slim` in accordance with the A2A agent cards from their corresponding `card.py` files (example for Brazil: `coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/card.py`).

I tested the change manually in each scenario from the sidebar.

## Issue Link

Fixes #668 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
