### PR TITLE
feat: common MCP client lib + use in Colombia

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -15,27 +15,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import os
 
 from langgraph.graph import MessagesState
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import PromptTemplate
 from langgraph.graph import StateGraph, END
 
-from agntcy_app_sdk.factory import AgntcyFactory
 from ioa_observe.sdk.decorators import agent, graph
 
 from agents.exceptions import AuthError
 from agents.farms.colombia.card import AGENT_CARD, AGENT_ID
-from agents.mcp_servers.utils import invoke_payment_mcp_tool, _mcp_transport, _mcp_endpoint
-from config.config import OTEL_SDK_DISABLED
+from agents.mcp_servers.utils import invoke_payment_mcp_tool
 from common.llm import get_llm
-from common.mcp_event_middleware import wrap_mcp_client
+from common.mcp_client import call_mcp_tool
 
 logger = logging.getLogger("lungo.colombia_farm_agent.agent")
-
-# Initialize a multi-protocol, multi-transport agntcy factory.
-factory = AgntcyFactory("lungo.colombia_farm", enable_tracing=not OTEL_SDK_DISABLED)
 
 # --- 1. Define Node Names as Constants ---
 class NodeStates:
@@ -110,78 +104,39 @@ class FarmAgent:
         else:
             return {"next_node": NodeStates.GENERAL_RESPONSE, "messages": state["messages"]}
 
-    async def _get_weather_forecast(self,state: GraphState) -> str:
+    async def _get_weather_forecast(self, state: GraphState) -> dict:
         """
-        This method creates an agntcy-app-sdk transport instance and MCP client to communicate with the
-        "lungo_weather_service" agent, lists available tools, and calls the "get_forecast" tool with a
-        fixed location ("colombia"). It handles both streamed and non-streamed responses, aggregates the
-        forecast content, and returns it wrapped in an AIMessage inside a dictionary under the "messages" key.
+        Calls the "get_forecast" tool on the "lungo_weather_service" MCP server for a
+        fixed location ("colombia") through the shared ``call_mcp_tool`` helper, which
+        owns the agntcy-app-sdk client contract and result normalization (including
+        streamed responses). Returns the forecast wrapped in an AIMessage under the
+        "weather_forecast" key.
 
-        If an error occurs during the MCP tool call, it logs the error and returns an error message similarly wrapped.
+        If the MCP tool call fails, it logs the error and returns an error message
+        similarly wrapped.
 
         Returns:
-            dict: A dictionary containing a list with a single AIMessage object holding the weather forecast string
-                or an error message if the call fails.
+            dict: ``weather_forecast_success`` plus a single AIMessage holding the
+                forecast string, or an error message if the call fails.
         """
-        transport_instance = factory.create_transport(
-            _mcp_transport,
-            endpoint=_mcp_endpoint,
-            shared_secret_identity=os.getenv("SLIM_SHARED_SECRET"),
-            name="default/default/mcp_client")
-
-        # view available tools
         try:
-            mcp_ctx = await factory.mcp().create_client(
+            forecast = await call_mcp_tool(
                 topic="lungo_weather_service",
-                transport=transport_instance,
-                message_timeout=45
-            )
-            mcp_ctx = wrap_mcp_client(
-                mcp_ctx,
+                tool_name="get_forecast",
+                arguments={"location": "colombia"},
                 agent_id=AGENT_CARD.name,
-                mcp_server="lungo_weather_service",
                 source=AGENT_ID,
                 workflow_name=state.get("workflow_name"),
                 instance_id=state.get("workflow_instance_id"),
+                message_timeout=45,
+                list_tools_first=True,
+                extract_text=True,
             )
-            async with mcp_ctx as client:
-                response = await client.list_tools()
-                available_tools = [
-                    {
-                        "name": tool.name,
-                        "description": tool.description,
-                        "input_schema": tool.inputSchema,
-                    }
-                    for tool in response.tools
-                ]
-                logger.info(f"Available tools: {available_tools}")
-
-                result = await client.call_tool(
-                    name="get_forecast",
-                    arguments={"location": "colombia"},
-                )
-                logger.info(f"Tool call result: {result}")
-
-                mcp_call_result = ""
-                if hasattr(result, "__aiter__"):
-                    # gather streamed chunks
-                    async for chunk in result:
-                        delta = chunk.choices[0].delta
-                        mcp_call_result += delta.content or ""
-                else:
-                    content_list = result.content
-                    if isinstance(content_list, list) and len(content_list) > 0:
-                        mcp_call_result = content_list[0].text
-                    else:
-                        mcp_call_result = "No content returned from tool."
-
-                logger.info(f"Weather forecast result: {mcp_call_result}")
-                return {"weather_forecast_success": True, "weather_forecast": [AIMessage(mcp_call_result)]}
+            logger.info(f"Weather forecast result: {forecast}")
+            return {"weather_forecast_success": True, "weather_forecast": [AIMessage(forecast)]}
         except Exception as e:
             logger.error(f"Error during MCP tool call: {e}")
-            return {"weather_forecast_success": False, "weather_forecast": [AIMessage(f"Weather Forecast MCP Server was Unavailable")]}
-        finally:
-            pass
+            return {"weather_forecast_success": False, "weather_forecast": [AIMessage("Weather Forecast MCP Server was Unavailable")]}
 
     async def _inventory_node(self, state: GraphState) -> dict:
         """

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/payment_service.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/payment_service.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from agntcy_app_sdk.app_sessions import AppContainer
 from agntcy_app_sdk.factory import AgntcyFactory
-from agents.mcp_servers.utils import _mcp_transport, _mcp_endpoint
+from common.mcp_client import mcp_transport, mcp_endpoint
 from config.config import OTEL_SDK_DISABLED
 
 logger = logging.getLogger("payment_service")
@@ -55,8 +55,8 @@ def list_transactions() -> dict:
 
 async def main():
   transport = factory.create_transport(
-    _mcp_transport,
-    endpoint=_mcp_endpoint,
+    mcp_transport,
+    endpoint=mcp_endpoint,
     shared_secret_identity=os.getenv("SLIM_SHARED_SECRET"),
     name="default/default/lungo_payment_service",
   )

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/utils.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/utils.py
@@ -1,22 +1,12 @@
 # Copyright 2025 AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Literal
-from agntcy_app_sdk.factory import AgntcyFactory
-from agents.exceptions import AuthError
-from common.mcp_event_middleware import wrap_mcp_client
-from config.config import DEFAULT_MESSAGE_TRANSPORT, SLIM_SERVER, NATS_SERVER, OTEL_SDK_DISABLED
 import os
+from typing import Literal
 
-_TRANSPORT_MAP = {
-  "SLIM": ("SLIM", f"http://{SLIM_SERVER}"),
-  "NATS": ("NATS", f"nats://{NATS_SERVER}"),
-}
+from agents.exceptions import AuthError
+from common.mcp_client import call_mcp_tool
 
-if DEFAULT_MESSAGE_TRANSPORT not in _TRANSPORT_MAP:
-  raise ValueError(f"Unsupported DEFAULT_MESSAGE_TRANSPORT: {DEFAULT_MESSAGE_TRANSPORT}. Must be 'SLIM' or 'NATS'.")
-
-_mcp_transport, _mcp_endpoint = _TRANSPORT_MAP[DEFAULT_MESSAGE_TRANSPORT]
 
 async def invoke_payment_mcp_tool(
   tool_name: Literal["create_payment", "list_transactions"],
@@ -30,32 +20,17 @@ async def invoke_payment_mcp_tool(
   if os.getenv("IDENTITY_AUTH_ENABLED", "").lower() not in ["true", "enabled"]:
     return {}
 
-  factory = AgntcyFactory("lungo.payment_mcp_client", enable_tracing=not OTEL_SDK_DISABLED)
-
-  transport_instance = factory.create_transport(
-    transport=_mcp_transport,
-    endpoint=_mcp_endpoint,
-    name="default/default/fast_mcp_client",
-  )
-
-  client = await factory.mcp().create_client(
-    topic="lungo_payment_service",
-    transport=transport_instance,
-  )
-
-  client = wrap_mcp_client(
-    client,
-    agent_id=agent_id,
-    mcp_server="lungo_payment_service",
-    source=source,
-    workflow_name=workflow_name,
-    instance_id=instance_id,
-  )
-
   try:
-    async with client as c:
-      result = await c.call_tool(tool_name, {})
-      return result
+    return await call_mcp_tool(
+      topic="lungo_payment_service",
+      tool_name=tool_name,
+      agent_id=agent_id,
+      source=source,
+      workflow_name=workflow_name,
+      instance_id=instance_id,
+      use_shared_secret=False,
+      transport_name="default/default/fast_mcp_client",
+    )
   except Exception as e:
     error_message = str(e).lower()
     if any(keyword in error_message for keyword in ["authentication failed", "unauthorized"]):

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/weather_service.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/weather_service.py
@@ -13,7 +13,7 @@ from mcp.server.fastmcp import FastMCP
 import httpx
 from agntcy_app_sdk.factory import AgntcyFactory
 
-from agents.mcp_servers.utils import _mcp_transport, _mcp_endpoint
+from common.mcp_client import mcp_transport, mcp_endpoint
 from config.config import OTEL_SDK_DISABLED
 
 logger = logging.getLogger(__name__)
@@ -93,8 +93,8 @@ async def get_forecast(location: str) -> str:
 async def main():
     # serve the MCP server via a message bridge
     transport = factory.create_transport(
-        _mcp_transport,
-        endpoint=_mcp_endpoint,
+        mcp_transport,
+        endpoint=mcp_endpoint,
         shared_secret_identity=os.getenv("SLIM_SHARED_SECRET"),
         name="default/default/lungo_weather_service")
 

--- a/coffeeAGNTCY/coffee_agents/lungo/common/mcp_client/__init__.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/mcp_client/__init__.py
@@ -1,0 +1,16 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Centralized client for calling MCP tools over the agntcy message bus."""
+
+from common.mcp_client.client import (
+	call_mcp_tool,
+	mcp_endpoint,
+	mcp_transport,
+)
+
+__all__ = [
+	"call_mcp_tool",
+	"mcp_endpoint",
+	"mcp_transport",
+]

--- a/coffeeAGNTCY/coffee_agents/lungo/common/mcp_client/client.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/mcp_client/client.py
@@ -1,0 +1,166 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single entry point for calling MCP tools over the agntcy message bus.
+
+Every MCP tool call in Lungo flows through :func:`call_mcp_tool`, so the
+agntcy-app-sdk client contract lives in exactly one place:
+
+* ``factory.mcp().create_client(...)`` is keyword-only.
+* ``call_tool`` is always invoked as ``call_tool(name=..., arguments=...)``.
+
+Per-server differences (topic, timeout, shared-secret identity, whether to
+list tools first, and the result shape) are expressed as arguments rather than
+as divergent, independently maintained call sites. That is what previously let
+a signature regression reach one MCP chain (payment) without touching another
+(weather).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from agntcy_app_sdk.factory import AgntcyFactory
+
+from common.mcp_event_middleware import wrap_mcp_client
+from config.config import (
+	DEFAULT_MESSAGE_TRANSPORT,
+	NATS_SERVER,
+	OTEL_SDK_DISABLED,
+	SLIM_SERVER,
+)
+
+logger = logging.getLogger("lungo.common.mcp_client")
+
+_TRANSPORT_MAP: dict[str, tuple[str, str]] = {
+	"SLIM": ("SLIM", f"http://{SLIM_SERVER}"),
+	"NATS": ("NATS", f"nats://{NATS_SERVER}"),
+}
+
+if DEFAULT_MESSAGE_TRANSPORT not in _TRANSPORT_MAP:
+	raise ValueError(
+		f"Unsupported DEFAULT_MESSAGE_TRANSPORT: {DEFAULT_MESSAGE_TRANSPORT}. "
+		"Must be 'SLIM' or 'NATS'."
+	)
+
+# Resolved once at import: the transport kind ("SLIM"/"NATS") and its endpoint.
+mcp_transport, mcp_endpoint = _TRANSPORT_MAP[DEFAULT_MESSAGE_TRANSPORT]
+
+_DEFAULT_FACTORY_NAME = "lungo.mcp_client"
+_DEFAULT_TRANSPORT_NAME = "default/default/mcp_client"
+
+
+def _build_factory() -> AgntcyFactory:
+	"""Build the agntcy factory used to open MCP clients."""
+	return AgntcyFactory(_DEFAULT_FACTORY_NAME, enable_tracing=not OTEL_SDK_DISABLED)
+
+
+async def _extract_text_content(result: Any) -> str:
+	"""Normalize an MCP tool result to text (streamed or single response).
+
+	Must run inside the client context: a streamed result is an async
+	iterator that is only valid while the session is open.
+	"""
+	if hasattr(result, "__aiter__"):
+		text = ""
+		async for chunk in result:
+			delta = chunk.choices[0].delta
+			text += delta.content or ""
+		return text
+
+	content = getattr(result, "content", None)
+	if isinstance(content, list) and content:
+		return content[0].text
+	return "No content returned from tool."
+
+
+async def call_mcp_tool(
+	*,
+	topic: str,
+	tool_name: str,
+	arguments: dict[str, Any] | None = None,
+	agent_id: str,
+	source: str,
+	workflow_name: str | None = None,
+	instance_id: str | None = None,
+	message_timeout: int | None = None,
+	use_shared_secret: bool = True,
+	transport_name: str = _DEFAULT_TRANSPORT_NAME,
+	list_tools_first: bool = False,
+	extract_text: bool = False,
+	factory: AgntcyFactory | None = None,
+) -> Any:
+	"""Call a single MCP tool on ``topic`` and return its result.
+
+	This is the only place that talks to the agntcy-app-sdk MCP client, so the
+	call contract is defined once and shared by every Lungo MCP chain.
+
+	Args:
+		topic: Message-bus topic the target MCP server listens on
+			(e.g. ``"lungo_weather_service"``). Also used as the ``mcp_server``
+			label for workflow topology events.
+		tool_name: Name of the tool to invoke.
+		arguments: Tool arguments; defaults to ``{}``.
+		agent_id: Human-readable agent name for event emission.
+		source: Stable source id for event emission / correlation.
+		workflow_name: Optional workflow identity fallback for event emission.
+		instance_id: Optional workflow instance id fallback for event emission.
+		message_timeout: Optional per-call client timeout (seconds). When
+			omitted the agntcy-app-sdk default applies.
+		use_shared_secret: When True, attach ``SLIM_SHARED_SECRET`` to the
+			transport identity.
+		transport_name: Transport registration name on the bus.
+		list_tools_first: When True, log the server's advertised tools before
+			calling (diagnostic parity with the original weather path).
+		extract_text: When True, return the tool result's text content
+			(evaluated inside the client context so streamed results are safe);
+			otherwise return the raw tool result.
+		factory: Optional pre-built factory (mainly for reuse/testing); a fresh
+			factory is created per call when omitted.
+
+	Returns:
+		The raw MCP tool result, or its text content when ``extract_text`` is
+		set.
+	"""
+	factory = factory or _build_factory()
+
+	transport_kwargs: dict[str, Any] = {
+		"endpoint": mcp_endpoint,
+		"name": transport_name,
+	}
+	if use_shared_secret:
+		transport_kwargs["shared_secret_identity"] = os.getenv("SLIM_SHARED_SECRET")
+
+	transport_instance = factory.create_transport(mcp_transport, **transport_kwargs)
+
+	# create_client is keyword-only; message_timeout is only passed when set so
+	# callers that don't need it inherit the SDK default.
+	client_kwargs: dict[str, Any] = {"topic": topic, "transport": transport_instance}
+	if message_timeout is not None:
+		client_kwargs["message_timeout"] = message_timeout
+
+	client = await factory.mcp().create_client(**client_kwargs)
+	client = wrap_mcp_client(
+		client,
+		agent_id=agent_id,
+		mcp_server=topic,
+		source=source,
+		workflow_name=workflow_name,
+		instance_id=instance_id,
+	)
+
+	async with client as session:
+		if list_tools_first:
+			listing = await session.list_tools()
+			logger.info(
+				"Available MCP tools on %s: %s",
+				topic,
+				[tool.name for tool in listing.tools],
+			)
+
+		result = await session.call_tool(name=tool_name, arguments=arguments or {})
+		if extract_text:
+			return await _extract_text_content(result)
+		return result

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_client.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_client.py
@@ -1,0 +1,196 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for common.mcp_client.call_mcp_tool.
+
+This is the single entry point every Lungo MCP tool call flows through, so the
+agntcy-app-sdk contract is asserted here in one place: create_client is
+keyword-only, call_tool is invoked as name=/arguments=, and the transport
+shared-secret / timeout options behave as documented. Result normalization
+(raw vs text, single vs streamed) is covered too.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from common.mcp_client import client as client_mod
+
+_UNSET = object()
+
+
+class _FakeSession:
+    """Async-context MCP session standing in for the agntcy SDK client."""
+
+    def __init__(self, tool_result, tools=None):
+        self._tool_result = tool_result
+        self._tools = tools or []
+        self.call_args = None
+        self.list_tools_calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def list_tools(self):
+        self.list_tools_calls += 1
+        return SimpleNamespace(tools=self._tools)
+
+    async def call_tool(self, name, arguments):
+        self.call_args = (name, arguments)
+        return self._tool_result
+
+
+def _fake_factory(captured, session):
+    """Build a fake AgntcyFactory recording transport/client construction."""
+
+    def create_transport(transport, **kwargs):
+        captured["transport_positional"] = transport
+        captured["transport_kwargs"] = kwargs
+        return "transport-sentinel"
+
+    async def create_client(*, topic=None, transport=None, message_timeout=_UNSET, **extra):
+        captured["topic"] = topic
+        captured["transport"] = transport
+        captured["message_timeout"] = message_timeout
+        captured["extra_kwargs"] = extra
+        return session
+
+    mcp_accessor = MagicMock()
+    mcp_accessor.create_client = create_client
+
+    factory = MagicMock()
+    factory.create_transport.side_effect = create_transport
+    factory.mcp.return_value = mcp_accessor
+    return factory
+
+
+def _text_result(text):
+    return SimpleNamespace(content=[SimpleNamespace(text=text)])
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_wrap():
+    """wrap_mcp_client is exercised elsewhere; keep it a no-op here."""
+    with patch.object(client_mod, "wrap_mcp_client", side_effect=lambda c, **_: c):
+        yield
+
+
+async def _run(captured, session, **overrides):
+    factory = _fake_factory(captured, session)
+    kwargs = dict(
+        topic="lungo_weather_service",
+        tool_name="get_forecast",
+        arguments={"location": "colombia"},
+        agent_id="Colombia Coffee Farm",
+        source="colombia_coffee_farm",
+        factory=factory,
+    )
+    kwargs.update(overrides)
+    return await client_mod.call_mcp_tool(**kwargs)
+
+
+async def test_uses_keyword_create_client_and_call_tool():
+    captured = {}
+    session = _FakeSession(_text_result("sunny"))
+
+    result = await _run(captured, session)
+
+    assert captured["topic"] == "lungo_weather_service"
+    assert captured["transport"] == "transport-sentinel"
+    assert captured["extra_kwargs"] == {}
+    # call_tool must be invoked as name=/arguments= (the consolidated contract).
+    assert session.call_args == ("get_forecast", {"location": "colombia"})
+    # Raw result returned when extract_text is not set.
+    assert result is session._tool_result
+
+
+async def test_shared_secret_attached_when_enabled(monkeypatch):
+    monkeypatch.setenv("SLIM_SHARED_SECRET", "top-secret")
+    captured = {}
+    session = _FakeSession(_text_result("sunny"))
+
+    await _run(captured, session, use_shared_secret=True)
+
+    assert captured["transport_kwargs"]["shared_secret_identity"] == "top-secret"
+
+
+async def test_shared_secret_omitted_when_disabled():
+    captured = {}
+    session = _FakeSession(_text_result("sunny"))
+
+    await _run(captured, session, use_shared_secret=False)
+
+    assert "shared_secret_identity" not in captured["transport_kwargs"]
+
+
+async def test_message_timeout_passed_only_when_set():
+    captured_default = {}
+    await _run(captured_default, _FakeSession(_text_result("x")))
+    assert captured_default["message_timeout"] is _UNSET
+
+    captured_set = {}
+    await _run(captured_set, _FakeSession(_text_result("x")), message_timeout=45)
+    assert captured_set["message_timeout"] == 45
+
+
+async def test_transport_name_forwarded():
+    captured = {}
+    await _run(
+        captured,
+        _FakeSession(_text_result("x")),
+        transport_name="default/default/fast_mcp_client",
+    )
+    assert captured["transport_kwargs"]["name"] == "default/default/fast_mcp_client"
+
+
+async def test_list_tools_first_lists_before_calling():
+    captured = {}
+    session = _FakeSession(
+        _text_result("sunny"),
+        tools=[SimpleNamespace(name="get_forecast")],
+    )
+
+    await _run(captured, session, list_tools_first=True)
+
+    assert session.list_tools_calls == 1
+    assert session.call_args == ("get_forecast", {"location": "colombia"})
+
+
+async def test_extract_text_returns_content_text():
+    captured = {}
+    session = _FakeSession(_text_result("Temperature: 25C"))
+
+    result = await _run(captured, session, extract_text=True)
+
+    assert result == "Temperature: 25C"
+
+
+async def test_extract_text_handles_missing_content():
+    captured = {}
+    session = _FakeSession(SimpleNamespace(content=[]))
+
+    result = await _run(captured, session, extract_text=True)
+
+    assert result == "No content returned from tool."
+
+
+async def test_extract_text_aggregates_streamed_chunks():
+    captured = {}
+
+    async def _stream():
+        for piece in ("Hello, ", "world"):
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content=piece))]
+            )
+
+    session = _FakeSession(_stream())
+
+    result = await _run(captured, session, extract_text=True)
+
+    assert result == "Hello, world"

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/mcp_servers/test_payment_client.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/mcp_servers/test_payment_client.py
@@ -3,13 +3,16 @@
 
 """Unit tests for agents.mcp_servers.utils.invoke_payment_mcp_tool.
 
-Guards the payment MCP client call. agntcy-app-sdk create_client is keyword-only;
-a positional protocol arg or wrong topic keyword breaks before any network activity.
+The payment helper is now a thin wrapper over the shared
+``common.mcp_client.call_mcp_tool`` primitive. These tests guard the
+payment-specific behavior: the identity-auth gate, delegation with the correct
+payment arguments, and mapping auth failures to ``AuthError``. The shared MCP
+client contract itself is covered in tests/unit/common/test_mcp_client.py.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from agents.exceptions import AuthError
@@ -17,43 +20,6 @@ from agents.mcp_servers import utils
 
 _AGENT_ID = "Colombia Coffee Farm"
 _SOURCE = "colombia_coffee_farm"
-
-
-class _FakeClientSession:
-    """Async context manager standing in for an MCP client session."""
-
-    def __init__(self, tool_result):
-        self._tool_result = tool_result
-        self.called_with = None
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *exc):
-        return False
-
-    async def call_tool(self, name, arguments):
-        self.called_with = (name, arguments)
-        return self._tool_result
-
-
-def _factory_with_recording_client(captured, tool_result):
-    """Fake AgntcyFactory that records how create_client was called."""
-    session = _FakeClientSession(tool_result)
-
-    async def create_client(*, topic=None, transport=None, **kwargs):
-        captured["topic"] = topic
-        captured["transport"] = transport
-        captured["extra_kwargs"] = kwargs
-        return session
-
-    mcp_accessor = MagicMock()
-    mcp_accessor.create_client = create_client
-
-    factory = MagicMock()
-    factory.create_transport.return_value = "transport-sentinel"
-    factory.mcp.return_value = mcp_accessor
-    return factory, session
 
 
 @pytest.fixture
@@ -64,7 +30,7 @@ def identity_auth_on(monkeypatch):
 async def test_returns_empty_when_identity_auth_disabled(monkeypatch):
     monkeypatch.delenv("IDENTITY_AUTH_ENABLED", raising=False)
 
-    with patch.object(utils, "AgntcyFactory") as factory_cls:
+    with patch.object(utils, "call_mcp_tool") as call_mcp_tool:
         result = await utils.invoke_payment_mcp_tool(
             "create_payment",
             agent_id=_AGENT_ID,
@@ -72,46 +38,70 @@ async def test_returns_empty_when_identity_auth_disabled(monkeypatch):
         )
 
     assert result == {}
-    factory_cls.assert_not_called()
+    call_mcp_tool.assert_not_called()
 
 
-async def test_create_client_uses_keyword_topic(identity_auth_on):
+async def test_delegates_to_call_mcp_tool_with_payment_args(identity_auth_on):
     captured = {}
     expected = {"ok": True, "status": "payment created"}
-    factory, session = _factory_with_recording_client(captured, expected)
 
-    with (
-        patch.object(utils, "AgntcyFactory", return_value=factory),
-        patch.object(utils, "wrap_mcp_client", side_effect=lambda client, **_: client),
-    ):
+    async def fake_call_mcp_tool(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    with patch.object(utils, "call_mcp_tool", side_effect=fake_call_mcp_tool):
         result = await utils.invoke_payment_mcp_tool(
             "create_payment",
             agent_id=_AGENT_ID,
             source=_SOURCE,
+            workflow_name="Test Workflow Alpha",
+            instance_id="instance://00000000-0000-4000-8000-000000000001",
         )
 
-    assert captured["topic"] == "lungo_payment_service"
-    assert captured["transport"] == "transport-sentinel"
-    assert captured["extra_kwargs"] == {}
-    assert session.called_with == ("create_payment", {})
     assert result == expected
+    assert captured["topic"] == "lungo_payment_service"
+    assert captured["tool_name"] == "create_payment"
+    assert captured["agent_id"] == _AGENT_ID
+    assert captured["source"] == _SOURCE
+    assert captured["workflow_name"] == "Test Workflow Alpha"
+    assert captured["instance_id"] == "instance://00000000-0000-4000-8000-000000000001"
+    # Payment-specific transport config preserved through consolidation.
+    assert captured["use_shared_secret"] is False
+    assert captured["transport_name"] == "default/default/fast_mcp_client"
 
 
-async def test_authentication_failure_is_wrapped_as_auth_error(identity_auth_on):
-    factory, session = _factory_with_recording_client({}, {})
-
-    async def unauthorized(name, arguments):
+@pytest.mark.parametrize(
+    "tool_name, expected_fragment",
+    [
+        ("create_payment", "creating a payment"),
+        ("list_transactions", "listing transactions"),
+    ],
+)
+async def test_authentication_failure_is_wrapped_as_auth_error(
+    identity_auth_on, tool_name, expected_fragment
+):
+    async def unauthorized(**kwargs):
         raise RuntimeError("Authentication failed for the payment service")
 
-    session.call_tool = unauthorized
-
-    with (
-        patch.object(utils, "AgntcyFactory", return_value=factory),
-        patch.object(utils, "wrap_mcp_client", side_effect=lambda client, **_: client),
-    ):
-        with pytest.raises(AuthError):
+    with patch.object(utils, "call_mcp_tool", side_effect=unauthorized):
+        with pytest.raises(AuthError) as exc_info:
             await utils.invoke_payment_mcp_tool(
-                "list_transactions",
+                tool_name,
+                agent_id=_AGENT_ID,
+                source=_SOURCE,
+            )
+
+    assert expected_fragment in str(exc_info.value)
+
+
+async def test_non_auth_error_propagates_unchanged(identity_auth_on):
+    async def boom(**kwargs):
+        raise RuntimeError("transport exploded")
+
+    with patch.object(utils, "call_mcp_tool", side_effect=boom):
+        with pytest.raises(RuntimeError, match="transport exploded"):
+            await utils.invoke_payment_mcp_tool(
+                "create_payment",
                 agent_id=_AGENT_ID,
                 source=_SOURCE,
             )


### PR DESCRIPTION
# Description

### Context about which agents call MCP

It's only Colombia.

* **Transport**: `agntcy-app-sdk` AgntcyFactory over SLIM/NATS (chosen by `DEFAULT_MESSAGE_TRANSPORT`), not plain HTTP. MCP servers and clients meet on named topics: `lungo_weather_service` and `lungo_payment_service`.
* **Observability**: Every client is wrapped with `wrap_mcp_client` (`common/mcp_event_middleware`) so MCP tool calls are emitted as topology events, correlated to the supervisor's workflow_name/workflow_instance_id.
* **Who calls what**:
  * Weather (`get_forecast`) → Colombia's `_get_weather_forecast` node (inline client).
  * Payment (`create_payment`, `list_transactions`) → Colombia's `_orders_node` via `invoke_payment_mcp_tool`, gated on `IDENTITY_AUTH_ENABLED`.
  * Brazil and Vietnam → neither; they only use LLM-backed local logic.

### Problem

Lungo's Colombia farm called MCP servers two different, independently maintained ways — weather via an inline hand-rolled client, payment via a separate helper — with divergent `create_client`/`call_tool` invocation contracts. This duplication is what let a `call_tool` signature regression break the payment chain without touching weather.

### Fix

Route every MCP tool call through one primitive, `common.mcp_client.call_mcp_tool`, which owns the agntcy-app-sdk contract (keyword-only `create_client`, `call_tool(name=, arguments=))`, client lifecycle, transport resolution, and result normalization. Per-server differences (topic, timeout, shared-secret, tool listing) are now just arguments.

  * `invoke_payment_mcp_tool` is a thin wrapper keeping only payment policy (auth gate + AuthError mapping).
  * Colombia's weather node collapses to a single `call_mcp_tool(...)` call.
  * Both MCP servers import transport config directly from the shared source of truth.
  * Added tests asserting the unified contract; existing suites pass.


I tested this locally by running through most suggested prompts.

## Issue Link

Fixes #679 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
