### PR TITLE
fix(corto): align Corto use of transport env vars to lungo

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.7"
 description: A Helm chart for the Corto Exchange Server
 name: corto-exchange
-version: 0.2.0
+version: 0.2.1

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/templates/configmap.tpl.yaml
@@ -12,4 +12,6 @@ data:
   LLM_MODEL: "{{ .Values.config.llmModel }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
+  SLIM_SERVER: "{{ .Values.config.slimServer }}"
+  NATS_SERVER: "{{ .Values.config.natsServer }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/exchange/values.yaml
@@ -22,6 +22,8 @@ config:
   llmModel: ""
   transportServerEndpoint: ""
   defaultMessageTransport: ""
+  slimServer: ""
+  natsServer: ""
   otlpHttpEndpoint: ""
   corsAllowedOrigins: ""
   slimSharedSecret: ""

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/farm/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/farm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.5"
 description: A Helm chart for farm server
 name: corto-farm
-version: 0.2.0
+version: 0.2.1

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/farm/templates/configmap.tpl.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/farm/templates/configmap.tpl.yaml
@@ -11,4 +11,6 @@ data:
   LLM_MODEL: "{{ .Values.config.llmModel }}"
   TRANSPORT_SERVER_ENDPOINT: "{{ .Values.config.transportServerEndpoint }}"
   DEFAULT_MESSAGE_TRANSPORT: "{{ .Values.config.defaultMessageTransport }}"
+  SLIM_SERVER: "{{ .Values.config.slimServer }}"
+  NATS_SERVER: "{{ .Values.config.natsServer }}"
   OTLP_HTTP_ENDPOINT: "{{ .Values.config.otlpHttpEndpoint }}"

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/farm/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/farm/values.yaml
@@ -22,6 +22,8 @@ config:
   llmModel: ""
   transportServerEndpoint: ""
   defaultMessageTransport: ""
+  slimServer: ""
+  natsServer: ""
   otlpHttpEndpoint: ""
   slimSharedSecret: ""
 #  llmStreaming: False

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/Chart.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: corto-local-cluster
 description: A Helm chart for deploying Corto services in a local cluster
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.0"
 dependencies:
   - name: slim

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/config-overrides.yaml.gotmpl
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/config-overrides.yaml.gotmpl
@@ -18,6 +18,8 @@
     identityApiServerUrl: "https://api.agent-identity.outshift.com"
     transportServerEndpoint: "http://corto-local-cluster-slim:46357"
     defaultMessageTransport: "SLIM"
+    slimServer: "corto-local-cluster-slim:46357"
+    natsServer: "corto-local-cluster-nats:4222"
   externalSecrets:
     secretStoreName: local-secret-store
     secretStoreKind: ClusterSecretStore
@@ -26,7 +28,12 @@
         remoteRef:
           key: my-local-secret
           property: AZURE_API_KEY
+      - secretKey: SLIM_SHARED_SECRET
+        remoteRef:
+          key: my-local-secret
+          property: SLIM_SHARED_SECRET
 {{- end }}
 
 localExternalSecret:
   azureApiKey: {{ env "AZURE_API_KEY" | quote }}
+  slimSharedSecret: {{ env "SLIM_SHARED_SECRET" | default "slim-shared-secret-REPLACE_WITH_RANDOM_32PLUS_CHARS" | quote }}

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/templates/external-secret/local-secret.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/templates/external-secret/local-secret.yaml
@@ -6,3 +6,5 @@ metadata:
 type: Opaque
 stringData:
   AZURE_API_KEY: "{{ .Values.localExternalSecret.azureApiKey }}"
+  # Must match the SLIM gateway password; consumed by ExternalSecret-backed charts as SLIM_SHARED_SECRET.
+  SLIM_SHARED_SECRET: "{{ .Values.localExternalSecret.slimSharedSecret }}"

--- a/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/values.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/deployment/helm/local-cluster/values.yaml
@@ -33,7 +33,6 @@ nats:
 corto-exchange:
   config:
     corsAllowedOrigins: "http://localhost:3000,http://127.0.0.1:3000"
-    slimSharedSecret: "slim-shared-secret-REPLACE_WITH_RANDOM_32PLUS_CHARS"
 
 corto-ui:
   environment: local
@@ -41,3 +40,8 @@ corto-ui:
     env:
       data:
         VITE_EXCHANGE_APP_API_URL: http://localhost:30080
+
+# Populated by helmfile / config-overrides.yaml.gotmpl for local dev; defaults avoid nil when templating alone.
+localExternalSecret:
+  azureApiKey: ""
+  slimSharedSecret: "slim-shared-secret-REPLACE_WITH_RANDOM_32PLUS_CHARS"


### PR DESCRIPTION
# Description

The Corto helm charts don't deal with the `SLIM_SERVER`, `NATS_SERVER` and `SLIM_SHARED_SECRET` env variables either at all (for the first 2) or not in the way that Lungo does (for the last one).
This leads to problems in K8s envs where we don't rely on the `.env` files used for local development.
Without these we get connection failures between `corto-exchange` and `corto-farm`, and the messages bus like
```
slim connect{service_id=slim/global-bindings-service-0}: transport error
  -> tcp connect error
  -> Connection refused (os error 111)
```

This PR aims to address this. Proper testing will come in the dev env once the updated charts are available.

## Issue Link

Follow up to https://github.com/agntcy/coffeeAgntcy/issues/670 after the testing done after https://github.com/agntcy/coffeeAgntcy/pull/693.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
