### PR TITLE
Backend enrichment

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/auction-supervisor-agent.json
@@ -1,7 +1,9 @@
 {
   "version": "1.0.0",
   "annotations": {
-    "a2a.supports_authenticated_extended_card": "false"
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.agentDirectoryCid": "/baeareicltg46rvjhqxd6pn47z5du3rgxoynvct6poeknf5tyemsxygwdrq",
+    "lungo.identityAppSlug": "auction-supervisor"
   },
   "description": "An AI agent that supervises and reports on coffee auctions.",
   "domains": [

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/brazil-coffee-farm.json
@@ -1,4 +1,11 @@
 {
+  "annotations": {
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.agentDirectoryCid": "/baeareigpu5jgm3xrkouspfacgvq65i25cz63nnseqatu5davp35jenwlla",
+    "lungo.hasBadgeOverride": "false",
+    "lungo.hasPolicyOverride": "false",
+    "lungo.verificationStatusOverride": "failed"
+  },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"
   ],

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/colombia-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/colombia-coffee-farm.json
@@ -1,4 +1,9 @@
 {
+  "annotations": {
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.agentDirectoryCid": "/baeareiaqub6mci5mnt3iqagxfodfmjym36nshdmjmnzofcdilp7374rwlm",
+    "lungo.identityAppSlug": "colombia-coffee-farm"
+  },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"
   ],

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/payment-mcp-server.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/payment-mcp-server.json
@@ -1,9 +1,9 @@
 {
   "annotations": {
     "a2a.supports_authenticated_extended_card": "false",
-    "lungo.identityAppSlug": "payment-mcp-server",
     "lungo.hasBadgeOverride": "true",
     "lungo.hasPolicyOverride": "false"
+    "lungo.identityAppSlug": "payment-mcp-server",
   },
   "version": "1.0.0",
   "description": "An MCP server agent for payment operations (create payments and list transactions).",

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/payment-mcp-server.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/payment-mcp-server.json
@@ -1,6 +1,9 @@
 {
   "annotations": {
-    "a2a.supports_authenticated_extended_card": "false"
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.identityAppSlug": "payment-mcp-server",
+    "lungo.hasBadgeOverride": "true",
+    "lungo.hasPolicyOverride": "false"
   },
   "version": "1.0.0",
   "description": "An MCP server agent for payment operations (create payments and list transactions).",

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json
@@ -2,8 +2,8 @@
   "annotations": {
     "a2a.supports_authenticated_extended_card": "false",
     "lungo.agentDirectoryCid": "/baeareiheas5bdad2wuurvpvqonuq4ry2u6vdzw4hikrnzssebchjojjr5m",
-    "lungo.identityAppSlug": "vietnam-coffee-farm",
     "lungo.hasPolicyOverride": "false"
+    "lungo.identityAppSlug": "vietnam-coffee-farm",
   },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/vietnam-coffee-farm.json
@@ -1,4 +1,10 @@
 {
+  "annotations": {
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.agentDirectoryCid": "/baeareiheas5bdad2wuurvpvqonuq4ry2u6vdzw4hikrnzssebchjojjr5m",
+    "lungo.identityAppSlug": "vietnam-coffee-farm",
+    "lungo.hasPolicyOverride": "false"
+  },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"
   ],

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/weather-mcp-server.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/auction/oasf/agents/weather-mcp-server.json
@@ -1,6 +1,8 @@
 {
   "annotations": {
-    "a2a.supports_authenticated_extended_card": "false"
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.agentDirectoryCid": "/baeareibpoftgep62se35oxuiu3d27cuqef2loupupxdd3xozotxk3mrhhe",
+    "lungo.verificationStatusOverride": "failed"
   },
   "version": "1.0.0",
   "description": "An MCP server agent for weather forecasting operations.",

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/accountant-agent.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/accountant-agent.json
@@ -1,4 +1,9 @@
 {
+  "annotations": {
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.hasBadgeOverride": "false",
+    "lungo.hasPolicyOverride": "false"
+  },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"
   ],

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/logistics-supervisor-agent.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/logistics-supervisor-agent.json
@@ -1,7 +1,9 @@
 {
   "version": "1.0.0",
   "annotations": {
-    "a2a.supports_authenticated_extended_card": "false"
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.hasBadgeOverride": "false",
+    "lungo.hasPolicyOverride": "false"
   },
   "description": "An AI agent that supervises and tracks coffee logistics and shipments.",
   "domains": [

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/shipping-agent.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/shipping-agent.json
@@ -1,4 +1,9 @@
 {
+  "annotations": {
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.hasBadgeOverride": "false",
+    "lungo.hasPolicyOverride": "false"
+  },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"
   ],

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/tatooine-farm-agent.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/logistics/oasf/agents/tatooine-farm-agent.json
@@ -1,4 +1,9 @@
 {
+  "annotations": {
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.hasBadgeOverride": "false",
+    "lungo.hasPolicyOverride": "false"
+  },
   "authors": [
     "agntcy/coffee-agntcy-maintainers"
   ],

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/recruiter/oasf/agents/recruiter.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/supervisors/recruiter/oasf/agents/recruiter.json
@@ -1,6 +1,8 @@
 {
   "annotations": {
-    "a2a.supports_authenticated_extended_card": "false"
+    "a2a.supports_authenticated_extended_card": "false",
+    "lungo.hasBadgeOverride": "false",
+    "lungo.hasPolicyOverride": "false"
   },
   "version": "1.0.0",
   "description": "An AI agent that recruits and delegates capability discovery.",

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/agent_ui_enrichment.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/agent_ui_enrichment.py
@@ -1,0 +1,159 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cache Lungo UI fields from OASF record annotations and enrich topology JSON."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_AGENT_UI_BY_STABLE_AGENT_UUID: dict[str, AgentUiEnrichment] = {}
+
+
+@dataclass(frozen=True)
+class AgentUiEnrichment:
+    agent_directory_cid: str | None = None
+    identity_app_slug: str | None = None
+    has_badge_override: bool | None = None
+    has_policy_override: bool | None = None
+    verification_status_override: str | None = None
+
+
+def _parse_bool(value: str) -> bool | None:
+    lowered = value.strip().lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    return None
+
+
+def _enrichment_from_annotations(
+    annotations: dict[str, Any],
+    *,
+    agent_label: str,
+) -> AgentUiEnrichment:
+    cid = annotations.get("lungo.agentDirectoryCid")
+    identity = annotations.get("lungo.identityAppSlug")
+    badge_raw = annotations.get("lungo.hasBadgeOverride")
+    policy_raw = annotations.get("lungo.hasPolicyOverride")
+    verification = annotations.get("lungo.verificationStatusOverride")
+
+    has_badge: bool | None = None
+    if isinstance(badge_raw, str):
+        has_badge = _parse_bool(badge_raw)
+        if has_badge is None:
+            logger.warning(
+                "Invalid lungo.hasBadgeOverride for agent %s: %r",
+                agent_label,
+                badge_raw,
+            )
+
+    has_policy: bool | None = None
+    if isinstance(policy_raw, str):
+        has_policy = _parse_bool(policy_raw)
+        if has_policy is None:
+            logger.warning(
+                "Invalid lungo.hasPolicyOverride for agent %s: %r",
+                agent_label,
+                policy_raw,
+            )
+
+    verification_status: str | None = None
+    if isinstance(verification, str) and verification.strip():
+        verification_status = verification.strip().lower()
+
+    return AgentUiEnrichment(
+        agent_directory_cid=cid.strip() if isinstance(cid, str) and cid.strip() else None,
+        identity_app_slug=(
+            identity.strip() if isinstance(identity, str) and identity.strip() else None
+        ),
+        has_badge_override=has_badge,
+        has_policy_override=has_policy,
+        verification_status_override=verification_status,
+    )
+
+
+def register_from_record(stable_agent_uuid: str, record: dict) -> None:
+    """Parse ``lungo.*`` annotations from a loaded OASF agent record."""
+    key = stable_agent_uuid.strip()
+    if not key:
+        return
+
+    name = record.get("name")
+    agent_label = name.strip() if isinstance(name, str) and name.strip() else key
+
+    annotations = record.get("annotations")
+    if not isinstance(annotations, dict):
+        _AGENT_UI_BY_STABLE_AGENT_UUID[key] = AgentUiEnrichment()
+        return
+
+    _AGENT_UI_BY_STABLE_AGENT_UUID[key] = _enrichment_from_annotations(
+        annotations,
+        agent_label=agent_label,
+    )
+
+
+def lookup_enrichment(stable_agent_uuid: str) -> AgentUiEnrichment | None:
+    return _AGENT_UI_BY_STABLE_AGENT_UUID.get(stable_agent_uuid.strip())
+
+
+def clear_agent_ui_cache() -> None:
+    """Test helper: reset cached enrichment."""
+    _AGENT_UI_BY_STABLE_AGENT_UUID.clear()
+
+
+def _stable_agent_uuid_from_wire(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        raw = value.get("root")
+    elif hasattr(value, "root"):
+        raw = value.root
+    else:
+        raw = value
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip().removeprefix("agent://").strip() or None
+
+
+def _merge_enrichment_into_node(node: dict[str, Any]) -> None:
+    stable_uuid = _stable_agent_uuid_from_wire(node.get("stable_agent_id"))
+    if not stable_uuid:
+        return
+    enrichment = lookup_enrichment(stable_uuid)
+    if enrichment is None:
+        return
+    if enrichment.agent_directory_cid is not None:
+        node["agent_directory_cid"] = enrichment.agent_directory_cid
+    if enrichment.identity_app_slug is not None:
+        node["identity_app_slug"] = enrichment.identity_app_slug
+    if enrichment.has_badge_override is not None:
+        node["has_badge_override"] = enrichment.has_badge_override
+    if enrichment.has_policy_override is not None:
+        node["has_policy_override"] = enrichment.has_policy_override
+    if enrichment.verification_status_override is not None:
+        node["verification_status_override"] = enrichment.verification_status_override
+
+
+def enrich_topology_dict(topology: dict[str, Any] | None) -> dict[str, Any]:
+    """Return topology with per-node Lungo UI fields merged from the cache."""
+    if not topology:
+        return {"nodes": [], "edges": []}
+    out = dict(topology)
+    nodes = out.get("nodes")
+    if isinstance(nodes, list):
+        enriched_nodes: list[Any] = []
+        for node in nodes:
+            if isinstance(node, dict):
+                node_copy = dict(node)
+                _merge_enrichment_into_node(node_copy)
+                enriched_nodes.append(node_copy)
+            else:
+                enriched_nodes.append(node)
+        out["nodes"] = enriched_nodes
+    return out

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/catalog_types.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/catalog_types.py
@@ -7,4 +7,21 @@ from __future__ import annotations
 
 from typing import Literal
 
+from schema.types import Workflow
+
 ChatApiTarget = Literal["exchange", "logistics", "discovery"]
+
+CHAT_API_TARGETS: frozenset[str] = frozenset({"exchange", "logistics", "discovery"})
+
+
+def parse_chat_api_target(raw: object) -> ChatApiTarget | None:
+    """Return a validated ``chat_api_target`` from catalog metadata, or ``None``."""
+    if isinstance(raw, str) and raw in CHAT_API_TARGETS:
+        return raw  # type: ignore[return-value]
+    return None
+
+
+def chat_api_target_from_workflow(wf: Workflow) -> ChatApiTarget | None:
+    """Read ``chat_api_target`` from ``Workflow.model_extra``."""
+    extra = wf.model_extra or {}
+    return parse_chat_api_target(extra.get("chat_api_target"))

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
@@ -5,7 +5,7 @@
 ```mermaid
 graph TD
     Transport["Transport: SLIM"]
-    Buyer["Buyer Logistics Agent"]
+    Buyer["Logistics Agent (Buyer)"]
     Farm["Tatooine Coffee Farm Agent"]
     Shipper["Shipper Agent"]
     Accountant["Accountant Agent"]
@@ -102,7 +102,7 @@ under a customer deadline.
 attribution apply. It frames this episode as **alliance-style logistics**—partners and internal roles that may question
 each other **in the open** yet stay inside a trusted envelope.
 
-**Buyer Logistics Agent** connects into **Transport** as the voice of the **customer promise**. It carries dates,
+**Logistics Agent** (`label_subtitle`: **Buyer**) connects into **Transport** as the voice of the **customer promise**. It carries dates,
 splits, substitutions, and the definition of “done” so the thread always remembers **what success means** for the person
 waiting on the other end.
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/peer_group.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/peer_group.md
@@ -5,7 +5,7 @@
 ```mermaid
 graph TD
     Transport["Transport: SLIM"]
-    Buyer["Buyer Logistics Agent"]
+    Buyer["Logistics Agent (Buyer)"]
     Farm["Tatooine Coffee Farm Agent"]
     Shipper["Shipper Agent"]
     Accountant["Accountant Agent"]

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/router.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/router.py
@@ -38,6 +38,11 @@ from api.agentic_workflows.instance_lifecycle import (
 from api.agentic_workflows.patterns import PATTERNS
 from api.agentic_workflows.pattern_chat import stream_one_turn
 from api.agentic_workflows.use_cases import USE_CASES
+from api.agentic_workflows.topology_enrichment import (
+    enrich_workflow_instance_topology,
+    enrich_workflow_topology,
+)
+from api.agentic_workflows.catalog_types import chat_api_target_from_workflow
 from api.agentic_workflows.workflow_capabilities import derive_workflow_capabilities
 from api.agentic_workflows.workflow_documentation import (
     load_parsed_workflow_documentation,
@@ -267,9 +272,9 @@ def create_agentic_workflows_router() -> APIRouter:
             )
 
         if topology_only:
-            return wf.model_copy(update={"instances": {}})
+            return enrich_workflow_topology(wf.model_copy(update={"instances": {}}))
 
-        return wf
+        return enrich_workflow_topology(wf)
 
     @router.get(
         "/agentic-workflows/{workflow_name}/documentation/",
@@ -426,7 +431,9 @@ def create_agentic_workflows_router() -> APIRouter:
                 status_code=404,
                 detail="Workflow instance not found",
             )
-        return inst
+        catalog_wf = get_workflows().get(workflow_name)
+        target = chat_api_target_from_workflow(catalog_wf) if catalog_wf else None
+        return enrich_workflow_instance_topology(inst, chat_api_target=target)
 
     @router.delete(
         "/agentic-workflows/{workflow_name}/instances/{workflow_instance_id}/",

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/starting_workflows.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/starting_workflows.json
@@ -4,6 +4,9 @@
     "pattern": "Supervisor",
     "use_case": "Coffee Agntcy",
     "scenario": "Purchasing",
+    "supports_sse": false,
+    "supports_streaming": false,
+    "chat_api_target": "exchange",
     "starting_topology": {
       "nodes": [
         {
@@ -141,6 +144,9 @@
     "pattern": "Supervisor",
     "use_case": "Coffee Agntcy",
     "scenario": "Purchasing",
+    "supports_sse": false,
+    "supports_streaming": true,
+    "chat_api_target": "exchange",
     "starting_topology": {
       "nodes": [
         {
@@ -278,6 +284,9 @@
     "pattern": "Peer Group",
     "use_case": "Coffee Agntcy",
     "scenario": "Order Fulfillment",
+    "supports_sse": true,
+    "supports_streaming": false,
+    "chat_api_target": "logistics",
     "starting_topology": {
       "nodes": [
         {
@@ -293,7 +302,8 @@
           "id": "node://3a000001-0001-4000-a001-000000000002",
           "operation": "read",
           "type": "customNode",
-          "label": "Buyer Logistics Agent",
+          "label": "Logistics Agent",
+          "label_subtitle": "Buyer",
           "size": { "width": 1.0, "height": 1.0 },
           "layer_index": 1,
           "position": { "x": 150, "y": 100 },
@@ -387,6 +397,9 @@
     "pattern": "Recruiter",
     "use_case": "Coffee Agntcy",
     "scenario": "Capability Discovery",
+    "supports_sse": false,
+    "supports_streaming": true,
+    "chat_api_target": "discovery",
     "starting_topology": {
       "nodes": [
         {

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/topology_enrichment.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/topology_enrichment.py
@@ -1,0 +1,55 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Apply topology UI enrichment to workflow API response models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.agentic_workflows.agent_ui_enrichment import enrich_topology_dict
+from api.agentic_workflows.catalog_types import ChatApiTarget, chat_api_target_from_workflow
+from api.agentic_workflows.transport_ui_enrichment import enrich_topology_transport
+from schema.types import Workflow, WorkflowInstance
+
+
+def _enrich_topology_payload(
+    topology: dict[str, Any] | None,
+    *,
+    chat_api_target: ChatApiTarget | None,
+) -> dict[str, Any]:
+    enriched = enrich_topology_dict(topology)
+    return enrich_topology_transport(enriched, chat_api_target=chat_api_target)
+
+
+def enrich_workflow_topology(wf: Workflow) -> Workflow:
+    data = wf.model_dump(mode="json")
+    target = chat_api_target_from_workflow(wf)
+    if isinstance(data.get("starting_topology"), dict):
+        data["starting_topology"] = _enrich_topology_payload(
+            data["starting_topology"],
+            chat_api_target=target,
+        )
+    instances = data.get("instances")
+    if isinstance(instances, dict):
+        for inst in instances.values():
+            if isinstance(inst, dict) and isinstance(inst.get("topology"), dict):
+                inst["topology"] = _enrich_topology_payload(
+                    inst["topology"],
+                    chat_api_target=target,
+                )
+    return Workflow.model_validate(data)
+
+
+def enrich_workflow_instance_topology(
+    inst: WorkflowInstance,
+    *,
+    chat_api_target: ChatApiTarget | None = None,
+) -> WorkflowInstance:
+    data = inst.model_dump(mode="json")
+    if isinstance(data.get("topology"), dict):
+        data["topology"] = _enrich_topology_payload(
+            data["topology"],
+            chat_api_target=chat_api_target,
+        )
+    return WorkflowInstance.model_validate(data)

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/transport_ui_enrichment.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/transport_ui_enrichment.py
@@ -1,0 +1,76 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve deployment message transport facts and enrich transport topology nodes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.agentic_workflows.catalog_types import ChatApiTarget
+from config.config import DEFAULT_MESSAGE_TRANSPORT
+
+_TRANSPORT_BY_TARGET: dict[ChatApiTarget, str] = {}
+
+_ENRICHABLE_TARGETS: frozenset[ChatApiTarget] = frozenset({"exchange", "logistics"})
+
+
+def init_transport_cache() -> None:
+    """Populate transport facts from lungo deployment config (v1: no HTTP fetch)."""
+    _TRANSPORT_BY_TARGET.clear()
+    _TRANSPORT_BY_TARGET["exchange"] = DEFAULT_MESSAGE_TRANSPORT.upper()
+    _TRANSPORT_BY_TARGET["logistics"] = "SLIM"
+
+
+def clear_transport_cache() -> None:
+    """Test helper: reset cached transport facts."""
+    _TRANSPORT_BY_TARGET.clear()
+
+
+def resolve_message_transport(chat_api_target: ChatApiTarget | None) -> str | None:
+    if chat_api_target is None:
+        return None
+    return _TRANSPORT_BY_TARGET.get(chat_api_target)
+
+
+def _transport_node_type(node: dict[str, Any]) -> bool:
+    node_type = node.get("type")
+    if node_type is None:
+        return False
+    if isinstance(node_type, str):
+        return node_type == "transportNode"
+    if hasattr(node_type, "root"):
+        return node_type.root == "transportNode"
+    return False
+
+
+def enrich_topology_transport(
+    topology: dict[str, Any],
+    *,
+    chat_api_target: ChatApiTarget | None,
+) -> dict[str, Any]:
+    """For each ``transportNode``, set ``message_transport`` and display ``label``."""
+    if chat_api_target not in _ENRICHABLE_TARGETS:
+        return topology
+
+    message_transport = resolve_message_transport(chat_api_target)
+    if not message_transport:
+        return topology
+
+    out = dict(topology)
+    nodes = out.get("nodes")
+    if not isinstance(nodes, list):
+        return out
+
+    enriched_nodes: list[Any] = []
+    for node in nodes:
+        if not isinstance(node, dict) or not _transport_node_type(node):
+            enriched_nodes.append(node)
+            continue
+        node_copy = dict(node)
+        node_copy["message_transport"] = message_transport
+        node_copy["label"] = f"Transport: {message_transport}"
+        enriched_nodes.append(node_copy)
+
+    out["nodes"] = enriched_nodes
+    return out

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflow_capabilities.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflow_capabilities.py
@@ -1,38 +1,27 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Derive catalog UI capabilities from workflow topology and name."""
+"""Read catalog UI capabilities from workflow metadata."""
 
 from __future__ import annotations
 
-from api.agentic_workflows.catalog_types import ChatApiTarget
+from api.agentic_workflows.catalog_types import ChatApiTarget, parse_chat_api_target
 from schema.types import Workflow
 
-_EXCHANGE_WORKFLOW_NAMES = frozenset(
-    {"Publish Subscribe", "Publish Subscribe Streaming"},
-)
 
-
-def _topology_has_group_node(wf: Workflow) -> bool:
-    for node in wf.starting_topology.nodes:
-        node_type = getattr(node, "type", None)
-        if isinstance(node_type, str) and node_type.lower() == "group":
-            return True
+def _bool_from_extra(extra: dict[str, object], key: str) -> bool:
+    value = extra.get(key)
+    if isinstance(value, bool):
+        return value
     return False
 
 
 def derive_workflow_capabilities(
     wf: Workflow,
 ) -> tuple[bool, bool, ChatApiTarget | None]:
-    """Return ``(supports_sse, supports_streaming, chat_api_target)`` for catalog UI."""
-    name = wf.name
-    supports_sse = _topology_has_group_node(wf)
-    supports_streaming = name == "A2A HTTP" or "Streaming" in name
-
-    if supports_sse:
-        return supports_sse, supports_streaming, "logistics"
-    if name == "A2A HTTP":
-        return supports_sse, supports_streaming, "discovery"
-    if name in _EXCHANGE_WORKFLOW_NAMES:
-        return supports_sse, supports_streaming, "exchange"
-    return supports_sse, supports_streaming, None
+    """Return ``(supports_sse, supports_streaming, chat_api_target)`` from catalog metadata."""
+    extra = wf.model_extra or {}
+    supports_sse = _bool_from_extra(extra, "supports_sse")
+    supports_streaming = _bool_from_extra(extra, "supports_streaming")
+    chat_api_target = parse_chat_api_target(extra.get("chat_api_target"))
+    return supports_sse, supports_streaming, chat_api_target

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflows.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/workflows.py
@@ -18,6 +18,8 @@ from uuid import uuid4
 import httpx
 from pydantic import ValidationError
 
+from api.agentic_workflows.agent_ui_enrichment import register_from_record
+from api.agentic_workflows.transport_ui_enrichment import init_transport_cache
 from common.stable_agent_id import stable_agent_uuid_for_name
 from schema.types import (
     AgentNode,
@@ -160,6 +162,7 @@ def set_starting_workflows() -> None:
         return
     with _INIT_LOCK:
         _STARTING_WORKFLOWS = _load_and_validate_starting_workflows_from_file(_STARTING_WORKFLOWS_FILE)
+        init_transport_cache()
         _INITIALIZED = True
 
 
@@ -177,6 +180,14 @@ def _load_and_validate_starting_workflows_from_file(target: Path) -> dict[str, W
         Mapping of workflow name to validated Workflow model.  Entries that
         fail Pydantic validation are logged and skipped so the server can
         still start with the remaining valid workflows.
+
+    Notes
+    -----
+    This function does **not** call ``init_transport_cache()``. Transport
+    enrichment facts are initialized only in ``set_starting_workflows()`` at
+    server startup. Tests that call this loader directly and assert transport
+    wire fields must use ``load_catalog_with_transport_cache()`` from
+    ``tests.unit.agentic_workflows.catalog_test_helpers``.
     """
     if target is None or not str(target).strip():
         raise ValueError("target path must not be empty")
@@ -215,9 +226,9 @@ def _load_and_validate_starting_workflows_from_file(target: Path) -> dict[str, W
                     # in the future these should become grounds for invalidating the workflow entirely.
                     try:
                         record = _load_agent_record_from_uri(node.agent_record_uri, base_path=target.parent)
-                        node.stable_agent_id = stable_agent_id_from_uuid(
-                            stable_agent_uuid_for_name(record["name"])
-                        )
+                        stable_uuid = stable_agent_uuid_for_name(record["name"])
+                        node.stable_agent_id = stable_agent_id_from_uuid(stable_uuid)
+                        register_from_record(str(stable_uuid), record)
                     # FileNotFoundError is a subclass of OSError.
                     except (FileNotFoundError, httpx.RequestError) as exc:
                         logger.warning("Failed to load agent record for node at index %d (id %s) in workflow at index %d (name %s) but will use the workflow anyhow: %s",

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
@@ -154,6 +154,8 @@ GET /agentic-workflows/?patterns=Supervisor&use_cases=Coffee%20Agntcy
 
 Each value is a `WorkflowSummary`: `name`, `pattern`, `use_case`, and `scenario` (a brief extra qualifier for the use-case), plus UI capability fields `supports_sse`, `supports_streaming`, and `chat_api_target` (`exchange`, `logistics`, or `discovery`; `null` when the workflow is not runnable in the Lungo UI). The map key always equals `WorkflowSummary.name`.
 
+**Source of truth:** runnable workflows declare `supports_sse`, `supports_streaming`, and `chat_api_target` in [`starting_workflows.json`](../api/agentic_workflows/starting_workflows.json). The list endpoint reads those fields from catalog metadata; it does not infer capabilities from workflow name or topology shape.
+
 ### `GET /agentic-workflows/{workflow_name}/documentation/` — workflow docs
 
 Returns the reference markdown for a catalog workflow, both as a single blob and split into sections at `##` headings (for TOC / anchored rendering). Backed by files under [`../api/agentic_workflows/docs/workflows/`](../api/agentic_workflows/docs/workflows).
@@ -201,6 +203,33 @@ A **topology** (`event_v1.json#/$defs/topology`) is an object with `nodes` and `
 **Node** (`#/$defs/regular_node`, required for a full node): `id` (`node://…`), `operation` (`create` | `read` | `update` | `delete`), `type` (e.g. `customNode`, `transportNode`, `group`), `label`, `size` (`{ width, height }`, relative layout sizing), and `layer_index`. `additionalProperties` is allowed (the starting catalog, for example, carries an extra `position: { x, y }`).
 
 An **agent node** (`#/$defs/agent_node`) additionally carries `agent_record_uri` (required) and `stable_agent_id` (`agent://…`). Nodes without agent extension fields are plain regular nodes; the schema keeps the two mutually exclusive via `anyOf`/`not`.
+
+#### Topology wire enrichment (GET workflow / instance only)
+
+`GET /agentic-workflows/{workflow_name}/` and `GET …/instances/{workflow_instance_id}/` merge optional UI fields onto topology nodes before returning JSON. Enrichment does **not** apply to the catalog list endpoint or to SSE event payloads.
+
+**Agent nodes** (from OASF `lungo.*` annotations on `agent_record_uri` targets, cached at catalog load):
+
+| Wire field | OASF annotation |
+|------------|-----------------|
+| `agent_directory_cid` | `lungo.agentDirectoryCid` |
+| `identity_app_slug` | `lungo.identityAppSlug` |
+| `has_badge_override` | `lungo.hasBadgeOverride` (`"true"` / `"false"`) |
+| `has_policy_override` | `lungo.hasPolicyOverride` |
+| `verification_status_override` | `lungo.verificationStatusOverride` |
+
+**Transport nodes** (`type: transportNode`) when catalog `chat_api_target` is `exchange` or `logistics`:
+
+| Wire field | Example | Notes |
+|------------|---------|-------|
+| `message_transport` | `"SLIM"` | Deployment message transport (`DEFAULT_MESSAGE_TRANSPORT` for exchange; `"SLIM"` for logistics) |
+| `label` | `"Transport: SLIM"` | Replaces the generic catalog `"Transport"` label |
+
+When `chat_api_target` is `discovery` or absent, transport nodes are returned unchanged.
+
+**GitHub URLs are not on the wire.** Clients derive repository links from `message_transport`, `supports_streaming`, and `chat_api_target` (frontend `urls.ts`; see PR E).
+
+Non-`topology_only` workflow GET also enriches each `instances.*.topology` projection the same way as `starting_topology`.
 
 **Edge** (`#/$defs/edge`, required for a full edge): `id` (`edge://…`), `operation`, `type`, `source` (`node://…`), `target` (`node://…`), `bidirectional` (boolean), and `weight` (number). `additionalProperties` is allowed.
 

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_agent_ui_enrichment.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_agent_ui_enrichment.py
@@ -1,0 +1,113 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for OASF annotation → topology UI enrichment."""
+
+from __future__ import annotations
+
+import logging
+from typing import NamedTuple
+
+import pytest
+from api.agentic_workflows.agent_ui_enrichment import (
+    clear_agent_ui_cache,
+    enrich_topology_dict,
+    register_from_record,
+)
+from common.stable_agent_id import stable_agent_uuid_for_name
+
+
+class EnrichCase(NamedTuple):
+    case_id: str
+    record: dict
+    agent_name: str
+    expected_keys: set[str]
+    expected_agent_directory_cid: str | None
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    clear_agent_ui_cache()
+    yield
+    clear_agent_ui_cache()
+
+
+_ENRICH_CASES: tuple[EnrichCase, ...] = (
+    EnrichCase(
+        case_id="brazil_overrides",
+        agent_name="Brazil Coffee Farm",
+        record={
+            "name": "Brazil Coffee Farm",
+            "annotations": {
+                "lungo.agentDirectoryCid": "/cid-brazil",
+                "lungo.hasBadgeOverride": "false",
+                "lungo.hasPolicyOverride": "false",
+                "lungo.verificationStatusOverride": "failed",
+            },
+        },
+        expected_keys={
+            "agent_directory_cid",
+            "has_badge_override",
+            "has_policy_override",
+            "verification_status_override",
+        },
+        expected_agent_directory_cid="/cid-brazil",
+    ),
+    EnrichCase(
+        case_id="auction_identity_only",
+        agent_name="Auction Supervisor agent",
+        record={
+            "name": "Auction Supervisor agent",
+            "annotations": {
+                "lungo.agentDirectoryCid": "/cid-auction",
+                "lungo.identityAppSlug": "auction-supervisor",
+            },
+        },
+        expected_keys={"agent_directory_cid", "identity_app_slug"},
+        expected_agent_directory_cid="/cid-auction",
+    ),
+)
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.case_id) for c in _ENRICH_CASES])
+def test_enrich_topology_dict_from_annotations(case: EnrichCase) -> None:
+    stable_uuid = str(stable_agent_uuid_for_name(case.agent_name))
+    register_from_record(stable_uuid, case.record)
+    topology = enrich_topology_dict(
+        {
+            "nodes": [
+                {
+                    "id": "node://00000000-0000-4000-a000-000000000001",
+                    "stable_agent_id": f"agent://{stable_uuid}",
+                    "type": "customNode",
+                    "label": "Test",
+                },
+            ],
+            "edges": [],
+        },
+    )
+    node = topology["nodes"][0]
+    assert case.expected_keys.issubset(set(node.keys()))
+    assert node.get("agent_directory_cid") == case.expected_agent_directory_cid
+    if "has_badge_override" in case.expected_keys:
+        assert node["has_badge_override"] is False
+
+
+def test_register_from_record_logs_invalid_bool_override(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    register_from_record(
+        "00000000-0000-4000-a000-000000000099",
+        {
+            "name": "Misconfigured Agent",
+            "annotations": {
+                "lungo.hasBadgeOverride": "not-a-bool",
+                "lungo.hasPolicyOverride": "maybe",
+            },
+        },
+    )
+    assert any(
+        "Invalid lungo.hasBadgeOverride" in record.message for record in caplog.records
+    )
+    assert any(
+        "Invalid lungo.hasPolicyOverride" in record.message for record in caplog.records
+    )

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_transport_ui_enrichment.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_transport_ui_enrichment.py
@@ -1,0 +1,85 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for transport topology wire enrichment."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import pytest
+from api.agentic_workflows.agent_ui_enrichment import clear_agent_ui_cache
+from api.agentic_workflows.transport_ui_enrichment import (
+    clear_transport_cache,
+    enrich_topology_transport,
+)
+from tests.unit.agentic_workflows.catalog_test_helpers import init_transport_cache_for_tests
+
+_TRANSPORT_NODE = {
+    "id": "node://00000000-0000-4000-a000-000000000099",
+    "operation": "read",
+    "type": "transportNode",
+    "label": "Transport",
+    "size": {"width": 1.0, "height": 1.0},
+    "layer_index": 2,
+}
+
+
+class TransportCase(NamedTuple):
+    case_id: str
+    chat_api_target: str | None
+    expected_message_transport: str | None
+    expected_label: str
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    clear_agent_ui_cache()
+    clear_transport_cache()
+    init_transport_cache_for_tests()
+    yield
+    clear_agent_ui_cache()
+    clear_transport_cache()
+
+
+_TRANSPORT_CASES: tuple[TransportCase, ...] = (
+    TransportCase(
+        case_id="group_messaging",
+        chat_api_target="logistics",
+        expected_message_transport="SLIM",
+        expected_label="Transport: SLIM",
+    ),
+    TransportCase(
+        case_id="publish_subscribe",
+        chat_api_target="exchange",
+        expected_message_transport="SLIM",
+        expected_label="Transport: SLIM",
+    ),
+    TransportCase(
+        case_id="a2a_http",
+        chat_api_target="discovery",
+        expected_message_transport=None,
+        expected_label="Transport",
+    ),
+    TransportCase(
+        case_id="placeholder",
+        chat_api_target=None,
+        expected_message_transport=None,
+        expected_label="Transport",
+    ),
+)
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.case_id) for c in _TRANSPORT_CASES])
+def test_enrich_topology_transport(case: TransportCase) -> None:
+    topology = enrich_topology_transport(
+        {"nodes": [_TRANSPORT_NODE], "edges": []},
+        chat_api_target=case.chat_api_target,  # type: ignore[arg-type]
+    )
+    node = topology["nodes"][0]
+    if case.expected_message_transport is None:
+        assert "message_transport" not in node
+        assert node["label"] == case.expected_label
+    else:
+        assert node["message_transport"] == case.expected_message_transport
+        assert node["label"] == case.expected_label

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_capabilities.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_capabilities.py
@@ -5,18 +5,15 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import NamedTuple
 
 import pytest
 from api.agentic_workflows.workflow_capabilities import derive_workflow_capabilities
 from api.agentic_workflows.workflows import _load_and_validate_starting_workflows_from_file
 from schema.types import Workflow
+from tests.unit.agentic_workflows.catalog_test_helpers import STARTING_WORKFLOWS_JSON
 
-_LUNGO_ROOT = Path(__file__).resolve().parents[4]
-_STARTING_WORKFLOWS_JSON = (
-    _LUNGO_ROOT / "api" / "agentic_workflows" / "starting_workflows.json"
-)
+_STARTING_WORKFLOWS_JSON = STARTING_WORKFLOWS_JSON
 
 _RUNNABLE_CATALOG_EXPECTATIONS: tuple[tuple[str, bool, bool, str | None], ...] = (
     ("Publish Subscribe", False, False, "exchange"),
@@ -46,6 +43,9 @@ _CAP_CASES: tuple[CapCase, ...] = (
             "pattern": "Supervisor",
             "use_case": "Purchasing",
             "scenario": "x",
+            "supports_sse": False,
+            "supports_streaming": False,
+            "chat_api_target": "exchange",
             "starting_topology": {"nodes": [], "edges": []},
             "instances": {},
         },
@@ -60,6 +60,9 @@ _CAP_CASES: tuple[CapCase, ...] = (
             "pattern": "Supervisor",
             "use_case": "Purchasing",
             "scenario": "x",
+            "supports_sse": False,
+            "supports_streaming": True,
+            "chat_api_target": "exchange",
             "starting_topology": {"nodes": [], "edges": []},
             "instances": {},
         },
@@ -74,6 +77,9 @@ _CAP_CASES: tuple[CapCase, ...] = (
             "pattern": "Supervisor",
             "use_case": "Order Fulfillment",
             "scenario": "x",
+            "supports_sse": True,
+            "supports_streaming": False,
+            "chat_api_target": "logistics",
             "starting_topology": {
                 "nodes": [
                     {
@@ -100,6 +106,9 @@ _CAP_CASES: tuple[CapCase, ...] = (
             "pattern": "Supervisor",
             "use_case": "Discovery",
             "scenario": "x",
+            "supports_sse": False,
+            "supports_streaming": True,
+            "chat_api_target": "discovery",
             "starting_topology": {"nodes": [], "edges": []},
             "instances": {},
         },

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_endpoints.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_endpoints.py
@@ -13,6 +13,7 @@ from api.agentic_workflows.router import create_agentic_workflows_router
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from schema.types import Workflow
+from tests.unit.agentic_workflows.catalog_test_helpers import load_catalog_with_transport_cache
 
 _FAKE_WORKFLOWS: dict[str, Workflow] = {
     wf.name: wf
@@ -23,6 +24,9 @@ _FAKE_WORKFLOWS: dict[str, Workflow] = {
                 "use_case": "Purchasing",
                 "scenario": "Publish Subscribe scenario",
                 "name": "Publish Subscribe",
+                "supports_sse": False,
+                "supports_streaming": False,
+                "chat_api_target": "exchange",
                 "starting_topology": {
                     "nodes": [
                         {
@@ -45,6 +49,9 @@ _FAKE_WORKFLOWS: dict[str, Workflow] = {
                 "use_case": "Order Fulfillment",
                 "scenario": "Group Logistics scenario",
                 "name": "Group Logistics",
+                "supports_sse": True,
+                "supports_streaming": False,
+                "chat_api_target": "logistics",
                 "starting_topology": {
                     "nodes": [
                         {
@@ -67,6 +74,9 @@ _FAKE_WORKFLOWS: dict[str, Workflow] = {
                 "use_case": "Order Fulfillment",
                 "scenario": "Publish Subscribe Streaming scenario",
                 "name": "Publish Subscribe Streaming",
+                "supports_sse": False,
+                "supports_streaming": True,
+                "chat_api_target": "exchange",
                 "starting_topology": {
                     "nodes": [
                         {
@@ -304,3 +314,73 @@ def test_get_agentic_workflow(case: DetailCase, client: TestClient) -> None:
 
     if case.outputs.instances_empty:
         assert data["instances"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Topology enrichment (real catalog)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def catalog_client(workflow_api_headers: dict[str, str]) -> TestClient:
+    catalog = load_catalog_with_transport_cache()
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    app.include_router(create_agentic_workflows_router())
+    with patch(_PATCH_TARGET, return_value=catalog):
+        with TestClient(app, headers=workflow_api_headers) as test_client:
+            yield test_client
+
+
+def _transport_nodes(topology: dict) -> list[dict]:
+    return [n for n in topology.get("nodes", []) if n.get("type") == "transportNode"]
+
+
+def _agent_nodes_with_stable_id(topology: dict) -> list[dict]:
+    return [n for n in topology.get("nodes", []) if n.get("stable_agent_id")]
+
+
+def test_get_group_messaging_topology_enriches_transport_node(
+    catalog_client: TestClient,
+) -> None:
+    resp = catalog_client.get(
+        "/agentic-workflows/Group Messaging/",
+        params={"topology_only": True},
+    )
+    assert resp.status_code == 200
+    transport_nodes = _transport_nodes(resp.json()["starting_topology"])
+    assert len(transport_nodes) == 1
+    node = transport_nodes[0]
+    assert node["message_transport"] == "SLIM"
+    assert node["label"] == "Transport: SLIM"
+
+
+def test_get_publish_subscribe_topology_enriches_transport_node(
+    catalog_client: TestClient,
+) -> None:
+    resp = catalog_client.get(
+        "/agentic-workflows/Publish Subscribe/",
+        params={"topology_only": True},
+    )
+    assert resp.status_code == 200
+    transport_nodes = _transport_nodes(resp.json()["starting_topology"])
+    assert len(transport_nodes) == 1
+    node = transport_nodes[0]
+    assert node["message_transport"] == "SLIM"
+    assert node["label"] == "Transport: SLIM"
+
+
+def test_get_publish_subscribe_topology_enriches_agent_wire_fields(
+    catalog_client: TestClient,
+) -> None:
+    resp = catalog_client.get(
+        "/agentic-workflows/Publish Subscribe/",
+        params={"topology_only": True},
+    )
+    assert resp.status_code == 200
+    agent_nodes = _agent_nodes_with_stable_id(resp.json()["starting_topology"])
+    assert agent_nodes
+    buyer = next(n for n in agent_nodes if n.get("label_subtitle") == "Buyer")
+    assert buyer.get("identity_app_slug") == "auction-supervisor"
+    assert buyer.get("agent_directory_cid") == (
+        "/baeareicltg46rvjhqxd6pn47z5du3rgxoynvct6poeknf5tyemsxygwdrq"
+    )

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_instance_state_endpoints.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_instance_state_endpoints.py
@@ -24,6 +24,7 @@ from common.workflow_instance_store import WorkflowInstanceStateStore
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from schema.types import Data, Event, Workflow, instance_id_from_uuid
+from tests.unit.agentic_workflows.catalog_test_helpers import load_catalog_with_transport_cache
 
 _PATCH_GET_WORKFLOWS = "api.agentic_workflows.router.get_workflows"
 
@@ -428,3 +429,43 @@ def test_post_instantiate_wrong_api_key_returns_401(
         with TestClient(app_with_store, headers=bad) as c:
             r = c.post("/agentic-workflows/InstTestWf/")
     assert r.status_code == 401
+
+
+@pytest.fixture()
+def catalog_store_client(workflow_api_headers: dict[str, str]) -> TestClient:
+    catalog = load_catalog_with_transport_cache()
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    store = WorkflowInstanceStateStore()
+    setattr(app.state, WORKFLOW_INSTANCE_STORE_ATTR, store)
+    app.include_router(create_agentic_workflows_router())
+    with patch(_PATCH_GET_WORKFLOWS, return_value=catalog):
+        with TestClient(app, headers=workflow_api_headers) as test_client:
+            try:
+                yield test_client
+            finally:
+                store.close()
+
+
+def test_get_instance_enriches_group_messaging_transport_node(
+    catalog_store_client: TestClient,
+) -> None:
+    wf_name = "Group Messaging"
+    post = catalog_store_client.post(f"/agentic-workflows/{wf_name}/")
+    assert post.status_code == 200, post.text
+    path_uuid = UUID(
+        post.json()["workflow_instance_id"].removeprefix("instance://")
+    )
+
+    got = catalog_store_client.get(
+        f"/agentic-workflows/{wf_name}/instances/{path_uuid}/"
+    )
+    assert got.status_code == 200
+    transport_nodes = [
+        node
+        for node in got.json()["topology"]["nodes"]
+        if node.get("type") == "transportNode"
+    ]
+    assert len(transport_nodes) == 1
+    node = transport_nodes[0]
+    assert node["message_transport"] == "SLIM"
+    assert node["label"] == "Transport: SLIM"

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/catalog_test_helpers.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/catalog_test_helpers.py
@@ -1,0 +1,49 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for unit tests that load ``starting_workflows.json`` directly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from api.agentic_workflows.transport_ui_enrichment import init_transport_cache
+from api.agentic_workflows.workflows import _load_and_validate_starting_workflows_from_file
+from schema.types import Workflow
+
+_LUNGO_ROOT = Path(__file__).resolve().parents[3]
+STARTING_WORKFLOWS_JSON = (
+    _LUNGO_ROOT / "api" / "agentic_workflows" / "starting_workflows.json"
+)
+
+
+def load_validated_starting_workflows_catalog(
+    target: Path | None = None,
+) -> dict[str, Workflow]:
+    """Load and validate the starting-workflows catalog without ``set_starting_workflows()``.
+
+    This mirrors the catalog load performed at server startup but does not mutate
+    the global ``_STARTING_WORKFLOWS`` cache.
+    """
+    return _load_and_validate_starting_workflows_from_file(target or STARTING_WORKFLOWS_JSON)
+
+
+def init_transport_cache_for_tests() -> None:
+    """Initialize transport enrichment facts for tests.
+
+    ``init_transport_cache()`` is only called from ``set_starting_workflows()`` at
+    server startup. Any test that loads the catalog via
+    ``load_validated_starting_workflows_catalog()`` and then asserts transport wire
+    enrichment (``message_transport``, ``Transport: …`` labels) must call this helper
+    or use ``load_catalog_with_transport_cache()`` first.
+    """
+    init_transport_cache()
+
+
+def load_catalog_with_transport_cache(
+    target: Path | None = None,
+) -> dict[str, Workflow]:
+    """Load the validated catalog and initialize transport enrichment for tests."""
+    catalog = load_validated_starting_workflows_catalog(target)
+    init_transport_cache_for_tests()
+    return catalog


### PR DESCRIPTION

# Description

In order to be able to remove all the leftover static mappings, the backend should store and send additional data about the nodes. These data fields are now added to the oasf and json files, and message transport was enriched to accommodate the new data fields.


## Issue Link
No issue link

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
