### PR TITLE
feat: add IoC CFN docker-compose and .env.example updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,8 @@ node_modules/
 
 # Frontend, UI, JS, TS, etc.
 **/*.tsbuildinfo
+
+# Any `.secrets` bind-mount dir under lungo: keep the directory tracked
+# (via .gitkeep) but never commit any real secret material placed inside.
+/coffeeAGNTCY/coffee_agents/lungo/**/.secrets/*
+!/coffeeAGNTCY/coffee_agents/lungo/**/.secrets/.gitkeep

--- a/coffeeAGNTCY/coffee_agents/lungo/.env.example
+++ b/coffeeAGNTCY/coffee_agents/lungo/.env.example
@@ -7,6 +7,8 @@ PYTHONPATH=.
 # Set the COMPOSE_PROFILES variable to specify which services to run with Docker Compose.
 # Include "observability" to start the observability stack (clickhouse, grafana, mce-api-layer, metrics-computation-engine); omit it to run without that stack.
 # The "otel-collector" service has become part of the default docker compose profile.
+# Add "ioc" to start the IoC (Internet of Cognition) CFN stack (see ioc/compose.yaml and the IoC section below).
+# The "ioc" mgmt plane uses host port 9000; Lungo's observability ClickHouse was moved to host 9100 so both can run together.
 COMPOSE_PROFILES=farms,logistics,recruiter,observability,frontend
 
 #============================
@@ -123,3 +125,88 @@ WORKFLOW_API_URL=http://agentic-workflows-api:9105
 # These values do NOT coincide with the default values in the otel-collector-config.yaml file (the defaults are for "nop" exporters and pipelines).
 # OTELCOL_EXPORTERS_CFG_FILE=/etc/otel/cfg_exporters-2-clickhouse.yaml
 # OTELCOL_PIPELINES_CFG_FILE=/etc/otel/cfg_pipelines-2-clickhouse.yaml
+
+# =============================
+# IoC (Internet of Cognition) CFN Settings — `ioc` profile
+# =============================
+# Consumed by ioc/compose.yaml (included from docker-compose.yaml). Enable with the `ioc`
+# profile. Replace every "CHANGE ME" value before using outside local development.
+# Docs / upstream .env.example: https://github.com/outshift-open/ioc-cfn-mgmt-backend-svc
+#
+# CONVENTION: these mirror the upstream .env.example 1:1, but every name carries an `IOC_`
+# prefix so the vars can live in Lungo's shared .env without colliding with (or leaking into)
+# Lungo's own services. Names already prefixed upstream (IOC_KNOWLEDGE_DB*) are kept as-is.
+# When upstream adds/renames a var, apply the same change here with the `IOC_` prefix.
+# Grouping and comments below follow the upstream .env.example layout. Upstream vars that our
+# ioc/compose.yaml does NOT consume (because they only apply when running the services outside
+# Docker, or are hardcoded in the compose file) are carried as commented "not consumed" entries
+# so this file stays a faithful, diffable mirror of upstream without changing runtime behavior.
+
+## Docker Compose Environment Configuration
+# Platform for the prebuilt IoC images: linux/arm64 (Apple Silicon) or linux/amd64 (Intel/AMD).
+IOC_DOCKER_DEFAULT_PLATFORM=linux/arm64
+# IOC_IMAGE_TAG=main   # not consumed: ioc/compose.yaml pins explicit image versions.
+
+## Database Configuration
+# Upstream POSTGRES_* target the mgmt service when run OUTSIDE Docker (against a local Postgres).
+# In compose, host/db/ports are hardcoded, so only USER/PASSWORD are wired (ioc-cfn-svc -> cfn_cp);
+# they MUST match the IOC_KNOWLEDGE_DB_* creds below (the DB is created with those).
+IOC_POSTGRES_USER=postgresUser
+IOC_POSTGRES_PASSWORD=postgresPW              # CHANGE ME
+# IOC_POSTGRES_DB=cfn_mgmt              # not consumed: mgmt plane hardcodes cfn_mgmt in compose.
+# IOC_POSTGRES_HOST=localhost           # not consumed: compose uses the DB service name.
+# IOC_POSTGRES_PORT=5433                # not consumed: in-container Postgres port is 5432.
+# IOC_POSTGRES_HOST_PORT=5433           # not consumed: host port is IOC_KNOWLEDGE_DB_PORT (5456).
+# IOC_POSTGRES_CONTAINER_PORT=5432      # not consumed: fixed at 5432 in compose.
+
+## IoC Knowledge DB Configuration (Postgres + AgensGraph + pgvector)
+# Backs the ioc-knowledge-db, cfn_mgmt and cfn_cp databases.
+IOC_KNOWLEDGE_DB=ioc-knowledge-db
+IOC_KNOWLEDGE_DB_USER=postgresUser
+IOC_KNOWLEDGE_DB_PASSWORD=postgresPW          # CHANGE ME
+IOC_KNOWLEDGE_DB_PORT=5456
+# IOC_KNOWLEDGE_DB_GRAPH_UI_PORT=5457  # only for the (commented-out) graph DB viewer in compose.
+IOC_EMBEDDING_VECTOR_SIZE=384
+# IOC_DB_ECHO=False                    # not consumed: app-level SQL debug, not passed by compose.
+
+## Application Configuration (mgmt plane :9000)
+# IOC_LOG_LEVEL=INFO
+IOC_ADMIN_USER_PASSWORD=admin                 # CHANGE ME (initial admin password)
+IOC_CFN_DEV_MODE=False
+# IOC_CFN_SVC_URL=http://ioc-cfn-svc:9002
+# IOC_MEMORY_PROVIDER_ID=de54dacb-60ab-476a-9e83-64e09f867358
+# Upstream-optional, not consumed by compose: IOC_APP_NAME, IOC_IMAGE_NAME, IOC_PORT, IOC_DEBUG,
+# IOC_DEFAULT_PAGE_SIZE, IOC_MAX_PAGE_SIZE.
+
+## Memory Provider Encryption Key
+# Upstream auto-generates .secrets/encryption.key on first run; our compose bind-mounts
+# ./ioc/.secrets read-only into ioc-cfn-mgmt-plane-svc. To supply a key via env instead,
+# uncomment below AND add `- MEMORY_PROVIDER_ENCRYPTION_KEY=${IOC_MEMORY_PROVIDER_ENCRYPTION_KEY}`
+# to that service. Generate: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# IOC_MEMORY_PROVIDER_ENCRYPTION_KEY=
+
+## IoC Mgmt UI Configuration (:9001)
+# IOC_NEXTAUTH_URL=http://localhost:9001
+IOC_NEXTAUTH_SECRET=your_nextauth_secret_here # CHANGE ME
+# IOC_NEXT_PUBLIC_CFN_UI_API_BASE_URL=http://localhost:9000  # not consumed: hardcoded in compose.
+
+## IoC CFN Service Configuration (:9002 HTTP, :9009 MCP)
+# IOC_MGMT_URL=http://ioc-cfn-mgmt-plane-svc:9000
+IOC_CFN_NAME="My Cognition Fabric Node"
+# IOC_CFN_IP=
+IOC_HEARTBEAT_INTERVAL_SECONDS=5
+# IOC_SERVICE_NAME=ioc-cfn-svc
+# IOC_DB_NAME=cfn_cp
+# IOC_DB_SSL_MODE=disable   # not consumed: not passed by compose (image default applies).
+# IOC_MCP_ENABLED=false     # not consumed: not passed by compose.
+# IOC_MCP_PORT=9002         # not consumed: compose fixes the CFN MCP container port at 9001 (host 9009).
+
+## IoC Cognition Engine Configuration (:9004)
+# Map to LLM_PROVIDER / LLM_BASE_URL / LLM_API_KEY / LLM_MODEL inside the container.
+# IOC_LLM_PROVIDER maps to upstream's LLM_PROVIDER, which is referenced in the upstream
+# docker-compose.yml (ioc-cfn-svc: ${LLM_PROVIDER:-azure-openai}) but not listed in their
+# .env.example (it has a default). Optional; defaults to azure-openai.
+# IOC_LLM_PROVIDER=azure-openai
+IOC_LLM_BASE_URL=https://litellm.example.com  # CHANGE ME
+IOC_LLM_API_KEY=sk-your-api-key-here          # CHANGE ME
+IOC_LLM_MODEL=openai/azure/gpt-4o             # CHANGE ME

--- a/coffeeAGNTCY/coffee_agents/lungo/README.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/README.md
@@ -620,6 +620,8 @@ Observability requires both the `observability` profile (either in `COMPOSE_PROF
      - **User/Password:** `admin` / `admin`
    - If already present, select the **ClickHouse** datasource (pre-configured in the Docker Compose setup).
 
+   > **Note:** `clickhouse-server:9000` is the in-cluster address (Docker service name + container port) used by Grafana and the otel-collector over the Compose network — leave this as-is. If you need to reach ClickHouse's native TCP port **from the host** (e.g. `clickhouse-client` on your machine), use **`localhost:9100`**. The host port was moved off `9000` to avoid clashing with the IoC management plane (`ioc` profile); the HTTP interface remains on `localhost:8123`.
+
    ![Screenshot: ClickHouse Datasource](images/grafana_clickhouse_datasource.png)
    ![Screenshot: ClickHouse Connection](images/grafana_clickhouse_connection.png)
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docker-compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker-compose.yaml
@@ -1,3 +1,9 @@
+# IoC (Internet of Cognition) CFN infrastructure, kept in its own file and pulled in here.
+# Its services all live in the `ioc` profile. Enable them by adding `ioc` to COMPOSE_PROFILES
+# (or `--profile ioc`). See ioc/compose.yaml and the IoC section of .env / .env.example.
+include:
+  - ioc/compose.yaml
+
 services:
   brazil-farm-server:
     build:
@@ -271,7 +277,10 @@ services:
     image: clickhouse/clickhouse-server
     container_name: lungo-clickhouse-server
     ports:
-      - "9000:9000"
+      # Host 9100 -> container 9000 (ClickHouse native TCP). Host side moved off 9000 to avoid
+      # clashing with the IoC management plane (ioc profile). In-cluster clients still use
+      # clickhouse-server:9000 over the Docker network, so only host access changed.
+      - "9100:9000"
       - "8123:8123"
     environment:
       CLICKHOUSE_USER: admin

--- a/coffeeAGNTCY/coffee_agents/lungo/ioc/.secrets/.gitkeep
+++ b/coffeeAGNTCY/coffee_agents/lungo/ioc/.secrets/.gitkeep
@@ -1,0 +1,4 @@
+# Keeps the .secrets directory so the ioc-cfn-mgmt-plane-svc bind mount
+# (./.secrets:/home/app/.secrets:ro) has a valid host path.
+# Do not commit real secrets here. The management service can also take a
+# MEMORY_PROVIDER_ENCRYPTION_KEY env var instead of a key file.

--- a/coffeeAGNTCY/coffee_agents/lungo/ioc/README.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/ioc/README.md
@@ -1,0 +1,93 @@
+# IoC (Internet of Cognition) CFN stack
+
+Local Docker Compose setup for the IoC Cognition Fabric Node (CFN) dependencies, integrated
+into Lungo. Adapted from the upstream project:
+<https://github.com/outshift-open/ioc-cfn-mgmt-backend-svc>
+
+`compose.yaml` is pulled into `lungo/docker-compose.yaml` via the top-level `include:`
+directive, so it loads as its own Compose project (this folder is its project directory) and
+its services merge into the Lungo model. All services live in a single **`ioc` profile**.
+
+## Run
+
+From `lungo/`:
+
+```bash
+COMPOSE_PROFILES=ioc docker compose up      # or add `ioc` to COMPOSE_PROFILES in .env
+docker compose --profile ioc up             # equivalent one-off
+docker compose --profile ioc down
+```
+
+Configuration comes from the **IoC section of `lungo/.env`** (copy `lungo/.env.example`).
+Replace every `CHANGE ME` value before using this outside local development.
+
+| Service | Host port | Notes |
+|---|---|---|
+| `ioc-knowledge-memory-svc-db` | 5456 → 5432 | Postgres + AgensGraph + pgvector; hosts `cfn_mgmt` + `cfn_cp` |
+| `ioc-cfn-mgmt-plane-svc` | 9000 | Management plane backend |
+| `ioc-cfn-mgmt-plane-ui` | 9001 | Management plane UI |
+| `ioc-cfn-svc` | 9002 (HTTP), 9009 → 9001 (MCP) | Cognition Fabric Node |
+| `ioc-knowledge-memory-svc` | 9003 | Graph + vector memory |
+| `ioc-cfn-cognition-engines` | 9004 | Cognitive services |
+
+> **Ports:** `ioc-cfn-mgmt-plane-svc` uses host `9000`. Lungo's `observability` ClickHouse
+> was moved to host `9100` (container port unchanged at `9000`), so `ioc` and `observability`
+> can run together.
+
+## Maintenance contract
+
+`compose.yaml` intentionally mirrors the upstream `docker-compose.yml` so upstream changes
+map here 1:1. Only **three** deliberate, mechanical deviations are applied:
+
+1. **`IOC_` prefix on every interpolated variable.** Upstream `${FOO}` becomes `${IOC_FOO}`.
+   Variables already prefixed upstream (`IOC_KNOWLEDGE_DB*`) are left as-is — never
+   double-prefixed. **Container-side names (the `LLM_MODEL=` left-hand side) and all `:-`
+   defaults are kept exactly as upstream.** The prefix namespaces these vars so they can live
+   in Lungo's shared `.env` without colliding with — or leaking into — Lungo's own services
+   (which load `.env` via `env_file`).
+2. **`build:` blocks dropped** — no IoC source in this repo, so we use the published images only.
+3. **Single `ioc` profile** (per issue #700) instead of upstream's `full-stack` /
+   `mgmt-plane` / `data-plane` profiles.
+
+### Env-file translation rule (`.env` / `.env.example`)
+
+The IoC section of `lungo/.env` and `lungo/.env.example` mirrors the upstream **`.env.example`**
+(same section grouping and order) under one translation rule:
+
+- **Prefix every variable with `IOC_`** (names already prefixed upstream, `IOC_KNOWLEDGE_DB*`,
+  are kept as-is — never double-prefixed).
+- **Keep a var active (uncommented) only if `compose.yaml` actually interpolates it.** Every
+  other upstream var is carried as a **commented `# not consumed: <reason>` entry** so the file
+  stays a faithful, diffable mirror without changing runtime behavior. A var is "not consumed"
+  when it is hardcoded in `compose.yaml` (e.g. `POSTGRES_DB`, `MCP_PORT`), only applies to
+  running a service outside Docker (e.g. `POSTGRES_PORT`, `POSTGRES_HOST_PORT`), or is an
+  app-internal knob compose never passes (e.g. `DB_ECHO`, `DB_SSL_MODE`, `DEFAULT_PAGE_SIZE`).
+
+The mirror also works in reverse: a var that upstream references only in `docker-compose.yml`
+(not their `.env.example`) is still carried here — see the `IOC_LLM_PROVIDER` note below.
+
+### To re-sync with upstream
+
+1. Diff upstream `docker-compose.yml` against this file (ignoring the three deviations above).
+2. Apply each change here, prefixing any new `${VAR}` interpolation with `IOC_`.
+3. Diff upstream `.env.example` against the IoC section of `lungo/.env(.example)` and apply the
+   **env-file translation rule** above: prefix with `IOC_`, keep active only what `compose.yaml`
+   interpolates, and carry the rest as commented `# not consumed` entries. Keep `.env` and
+   `.env.example` in lockstep.
+4. Validate: `cd lungo && docker compose --profile ioc config -q`.
+
+### Note on `IOC_LLM_PROVIDER`
+
+`IOC_LLM_PROVIDER` maps to upstream's `LLM_PROVIDER`, which the upstream **`docker-compose.yml`**
+references on `ioc-cfn-svc` as `${LLM_PROVIDER:-azure-openai}`. It is *not* listed in the
+upstream `.env.example` (their example omits it because it has a default), but it is a real
+compose variable, so we carry it as a documented knob. Because it defaults to `azure-openai`,
+it is optional.
+
+## Files
+
+- `compose.yaml` — the IoC services (`ioc` profile).
+- `scripts/init-multi-db.sh` — creates the `cfn_mgmt` and `cfn_cp` databases on first DB init.
+- `.secrets/` — bind-mounted read-only into `ioc-cfn-mgmt-plane-svc`. Keep empty (a `.gitkeep`
+  holds the path); do not commit real secrets here. The management service can instead take a
+  `MEMORY_PROVIDER_ENCRYPTION_KEY` env var.

--- a/coffeeAGNTCY/coffee_agents/lungo/ioc/compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/ioc/compose.yaml
@@ -1,0 +1,258 @@
+# IoC (Internet of Cognition) - CFN infrastructure for coffeeAGNTCY / Lungo.
+#
+# Adapted from https://github.com/outshift-open/ioc-cfn-mgmt-backend-svc (docker-compose.yml).
+# Pulled into lungo/docker-compose.yaml via the top-level `include:` directive, so it loads as
+# its own Compose project with THIS folder (lungo/ioc/) as its project directory. Relative
+# paths below (scripts/, .secrets/) resolve against lungo/ioc/.
+#
+# MAINTENANCE CONTRACT (keep this file easy to re-sync with upstream):
+#   This file mirrors the upstream docker-compose.yml as closely as possible so upstream
+#   changes map here 1:1. Only three deliberate, mechanical deviations are applied:
+#     1. Every interpolated variable is namespaced with an `IOC_` prefix, i.e. upstream
+#        `${FOO}` becomes `${IOC_FOO}`. Variables already prefixed upstream (IOC_KNOWLEDGE_DB*)
+#        are left as-is (never double-prefixed). Container-side variable names (the left-hand
+#        side, e.g. `LLM_MODEL=`) and all `:-` defaults are kept EXACTLY as upstream.
+#        The prefix keeps these vars from colliding with / leaking into Lungo services, which
+#        load the shared .env via `env_file`.
+#     2. `build:` blocks are dropped (no IoC source in this repo) — published images only.
+#     3. All services share a single `ioc` profile (per issue #700) instead of upstream's
+#        full-stack / mgmt-plane / data-plane profiles.
+#   When upstream updates, diff their docker-compose.yml and re-apply changes here following
+#   rule (1). The matching env vars live in lungo/.env(.example) under the IoC section.
+#
+# Start (from lungo/):  COMPOSE_PROFILES=ioc docker compose up   |   docker compose --profile ioc up
+#
+# NOTE: ioc-cfn-mgmt-plane-svc publishes host port 9000. Lungo's `observability` ClickHouse
+# was moved to host port 9100 (container port stays 9000) so `ioc` and `observability` can run
+# together.
+
+services:
+  # Backing database for the IoC Knowledge Memory service.
+  # Graph (AgensGraph) + pgvector + Postgres. Hosts both cfn_mgmt and cfn_cp databases.
+  # Host port 5456 -> container 5432 (avoids clashing with a local Postgres on 5432).
+  ioc-knowledge-memory-svc-db:
+    image: ghcr.io/outshift-open/ioc-knowledge-memory-svc-db:0.2.1
+    platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+    container_name: ioc-knowledge-memory-svc-db
+    profiles:
+      - ioc
+    environment:
+      POSTGRES_DB: ${IOC_KNOWLEDGE_DB:-ioc-knowledge-db}
+      POSTGRES_USER: ${IOC_KNOWLEDGE_DB_USER}
+      POSTGRES_PASSWORD: ${IOC_KNOWLEDGE_DB_PASSWORD}
+    ports:
+      - "${IOC_KNOWLEDGE_DB_PORT:-5456}:5432"
+    volumes:
+      - ioc_knowledge_db_data:/var/lib/postgresql/data
+      - ./scripts/init-multi-db.sh:/docker-entrypoint-initdb.d/init-multi-db.sh:ro
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -h localhost -p 5432 -U ${IOC_KNOWLEDGE_DB_USER} -d ${IOC_KNOWLEDGE_DB:-ioc-knowledge-db}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # Graph Database Viewer - AgensGraph UI (optional).
+  # Uncomment to browse the graph DB at http://localhost:5457.
+  # ioc-graph-db-viewer:
+  #   image: skaiworldwide/agviewer:latest
+  #   platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+  #   container_name: ioc-graph-db-viewer
+  #   profiles:
+  #     - ioc
+  #   ports:
+  #     - "5457:3000"
+  #   environment:
+  #     - DB_HOST=ioc-knowledge-memory-svc-db
+  #     - DB_PORT=5432
+  #     - DB_USER=${IOC_KNOWLEDGE_DB_USER}
+  #     - DB_PASSWORD=${IOC_KNOWLEDGE_DB_PASSWORD}
+  #     - DB_NAME=${IOC_KNOWLEDGE_DB:-ioc-knowledge-db}
+  #   restart: unless-stopped
+  #   depends_on:
+  #     ioc-knowledge-memory-svc-db:
+  #       condition: service_healthy
+
+  # Management Plane Backend - FastAPI backend for workspaces, users, CFN nodes.
+  # Upstream also has a `build:` block; dropped here (no IoC source in this repo).
+  ioc-cfn-mgmt-plane-svc:
+    image: ghcr.io/outshift-open/ioc-cfn-mgmt-plane-svc:v0.2.0
+    platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+    container_name: ioc-cfn-mgmt-plane-svc
+    profiles:
+      - ioc
+    ports:
+      - "9000:9000"
+    environment:
+      - SERVICE_NAME=ioc-cfn-mgmt-plane-svc
+      - APPLICATION_VERSION=dev
+      - LOG_LEVEL=${IOC_LOG_LEVEL:-INFO}
+      - ADMIN_USER_PASSWORD=${IOC_ADMIN_USER_PASSWORD}
+      - POSTGRES_HOST=ioc-knowledge-memory-svc-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=cfn_mgmt
+      - POSTGRES_USER=${IOC_KNOWLEDGE_DB_USER}
+      - POSTGRES_PASSWORD=${IOC_KNOWLEDGE_DB_PASSWORD}
+      - PORT=9000
+      - CFN_DEV_MODE=${IOC_CFN_DEV_MODE}
+      - CFN_SVC_URL=${IOC_CFN_SVC_URL:-http://ioc-cfn-svc:9002}
+    volumes:
+      - ./.secrets:/home/app/.secrets:ro
+    restart: unless-stopped
+    depends_on:
+      ioc-knowledge-memory-svc-db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://ioc-cfn-mgmt-plane-svc:9000/api/internal/diagnostics/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Management Plane UI - Next.js frontend, http://localhost:9001.
+  ioc-cfn-mgmt-plane-ui:
+    image: ghcr.io/outshift-open/ioc-cfn-mgmt-plane-ui:v0.2.0
+    platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+    container_name: ioc-cfn-mgmt-plane-ui
+    profiles:
+      - ioc
+    ports:
+      - "9001:9001"
+    environment:
+      - NODE_ENV=production
+      - PORT=9001
+      - CFN_UI_API_BASE_URL=http://ioc-cfn-mgmt-plane-svc:9000
+      - NEXT_PUBLIC_CFN_UI_API_BASE_URL=http://localhost:9000
+      - NEXTAUTH_URL=${IOC_NEXTAUTH_URL:-http://localhost:9001}
+      - NEXTAUTH_SECRET=${IOC_NEXTAUTH_SECRET}
+    restart: unless-stopped
+    depends_on:
+      ioc-cfn-mgmt-plane-svc:
+        condition: service_healthy
+
+  # Knowledge Memory Service - Graph + Vector memory storage, http://localhost:9003.
+  ioc-knowledge-memory-svc:
+    image: ghcr.io/outshift-open/ioc-knowledge-memory-svc:v0.2.5
+    platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+    container_name: ioc-knowledge-memory-svc
+    profiles:
+      - ioc
+    ports:
+      - "9003:9003"
+    environment:
+      - SERVICE_NAME=ioc-knowledge-memory-svc
+      - APPLICATION_VERSION=dev
+      - LOG_LEVEL=${IOC_LOG_LEVEL:-INFO}
+      - MEMORY_PROVIDER_REGISTRATION_URL=http://ioc-cfn-mgmt-plane-svc:9000
+      - MEMORY_PROVIDER_ID=${IOC_MEMORY_PROVIDER_ID:-de54dacb-60ab-476a-9e83-64e09f867358}
+      - IOC_KNOWLEDGE_DB_HOST=ioc-knowledge-memory-svc-db
+      - IOC_KNOWLEDGE_DB=${IOC_KNOWLEDGE_DB:-ioc-knowledge-db}
+      - IOC_KNOWLEDGE_DB_USER=${IOC_KNOWLEDGE_DB_USER}
+      - IOC_KNOWLEDGE_DB_PASSWORD=${IOC_KNOWLEDGE_DB_PASSWORD}
+      - IOC_KNOWLEDGE_DB_PORT=5432
+      - EMBEDDING_VECTOR_SIZE=${IOC_EMBEDDING_VECTOR_SIZE:-384}
+    restart: unless-stopped
+    depends_on:
+      ioc-knowledge-memory-svc-db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:9003/api/internal/diagnostics/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # CFN Service - Cognition Fabric Node. HTTP on 9002, MCP on host 9009 -> container 9001.
+  ioc-cfn-svc:
+    image: ghcr.io/outshift-open/ioc-cfn-svc:v0.2.1
+    platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+    container_name: ioc-cfn-svc
+    profiles:
+      - ioc
+    restart: unless-stopped
+    ports:
+      - "9002:9002"
+      - "9009:9001"
+    environment:
+      - LOG_LEVEL=${IOC_LOG_LEVEL:-INFO}
+      - MGMT_URL=${IOC_MGMT_URL:-http://ioc-cfn-mgmt-plane-svc:9000}
+      - CFN_NAME=${IOC_CFN_NAME:-cfn-new}
+      - CFN_IP=${IOC_CFN_IP:-Not Set}
+      - HEARTBEAT_INTERVAL_SECONDS=${IOC_HEARTBEAT_INTERVAL_SECONDS:-10}
+      - SERVICE_NAME=${IOC_SERVICE_NAME:-ioc-cfn-svc}
+      - DB_NAME=${IOC_DB_NAME:-cfn_cp}
+      # Upstream wires DB_USER/DB_PASSWORD from POSTGRES_USER/POSTGRES_PASSWORD, which must
+      # equal the IOC_KNOWLEDGE_DB_* creds the DB is created with. Mirrored 1:1 (prefixed).
+      - DB_USER=${IOC_POSTGRES_USER}
+      - DB_PASSWORD=${IOC_POSTGRES_PASSWORD}
+      - DB_HOST=ioc-knowledge-memory-svc-db
+      - DB_PORT=5432
+      - CALLBACK_URL=http://ioc-cfn-svc:9002
+      - KNOWLEDGE_MEMORY_SVC_URL=http://ioc-knowledge-memory-svc:9003
+      - LLM_PROVIDER=${IOC_LLM_PROVIDER:-azure-openai}
+      - COGNITION_ENGINE_SVC_URL=http://ioc-cfn-cognition-engines:9004
+      - MCP_PORT=9001
+    depends_on:
+      ioc-knowledge-memory-svc:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:9002/api/internal/diagnostics/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Cognition Engines - the cognitive services, http://localhost:9004.
+  ioc-cfn-cognition-engines:
+    image: ghcr.io/outshift-open/ioc-cfn-cognition-engines:v0.2.1
+    platform: ${IOC_DOCKER_DEFAULT_PLATFORM:-linux/arm64}
+    container_name: ioc-cfn-cognition-engines
+    profiles:
+      - ioc
+    ports:
+      - "9004:9004"
+    restart: unless-stopped
+    environment:
+      - LLM_BASE_URL=${IOC_LLM_BASE_URL}
+      - LLM_API_KEY=${IOC_LLM_API_KEY}
+      - LLM_MODEL=${IOC_LLM_MODEL}
+      - ENABLE_DEDUP=true
+      # CE lifecycle management - auto-registration and heartbeat.
+      - CFN_URL=http://ioc-cfn-svc:9002
+      - COGNITION_ENGINE_HOST=ioc-cfn-cognition-engines
+      - COGNITION_ENGINE_PORT=9004
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9004/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      ioc-cfn-svc:
+        condition: service_healthy
+
+volumes:
+  ioc_knowledge_db_data:

--- a/coffeeAGNTCY/coffee_agents/lungo/ioc/scripts/init-multi-db.sh
+++ b/coffeeAGNTCY/coffee_agents/lungo/ioc/scripts/init-multi-db.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Create the additional databases needed by the IoC management and CFN services.
+# Runs inside the ioc-knowledge-memory-svc-db container on first init only.
+psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<-EOSQL
+	CREATE DATABASE cfn_mgmt;
+	CREATE DATABASE cfn_cp;
+EOSQL
+
+echo "Databases 'cfn_mgmt' and 'cfn_cp' created successfully"


### PR DESCRIPTION
# Description

This PR adds an integration for the **IoC management service** (https://github.com/outshift-open/ioc-cfn-mgmt-backend-svc) in Lungo's `docker-compose.yaml`.

This PR takes the files at https://github.com/outshift-open/ioc-cfn-mgmt-backend-svc/blob/main/docker-compose.yml and https://github.com/outshift-open/ioc-cfn-mgmt-backend-svc/blob/main/.env.example (and some script from the same repo) and uses them in Lungo while staying as close as possible to the sources so that future updates are easier to make. There are plenty of "optimizations" that the LLMs wanted to make but I felt they would come with a significant penalty in maintainability from upstream.

For the `.env.example` file, I tried to keep it very close but still had to rename all vars with an `IOC_` prefix.

The Docker compose file has an import now and that `ioc` import has the `build` sections from upstream removed because we are not building the images since we don't have the code, we just use the published images.
There was also a port overlap for TCP `9000` and I decided to **move Clickhouse off of 9000** (only for the Docker host port (**not the in-container port**), otherwise it is not needed because the overlaping ports are not competing for the same socket in other deployment scenarios) because the IoC stuff has more ports in that range (9000, 9001, 9002, etc) and I favored keeping those together.

I also added a `README.md` to document the translation process and rules that should be followed again.

The IoC mgmt plane UI shows all components as "green"/"online".
I also tested with the scripts from Cody and Patrik that the ticket has in it. Note: the shared memory script needed some modifications because `ioc-cfn-mas-client-lib` in the latest release (0.3.1) only exposes `forward_l9_message`. There is no `query_shared_memories method`, so `recall()` could never work against the real SDK.
I copied the script outputs at the end of this description. Reviewers should inspect those too to confirm correctness.

## Issue Link

Fixes #700 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass


---
### Semantic Alignment script output
```
[brazil] accept
[colombia] accept
[round 1] status: ongoing
[brazil] accept
[colombia] accept
[round 1] status: agreed

--- Alignment Summary ---
Status      : agreed
Rounds      : 1  |  Retries: 1

Final Agreement:
  commodity price range for coffee beans: Set a fixed range between $1.80 and $2.20 per pound to ensure stability and affordability.
  USD per pound: Establish a fixed price of $2.10 per pound to ensure consistent income for farmers.

Validation:
  Coherence         : 0.6
  Alignment score   : 0.708
  Cognitive align   : 0.55
  Recommendation    : accept  (severity: low)
  Needs intervention: False

Cross-issue conflicts (1):
  - commodity price range for coffee beans and USD per pound: The fixed price of $2.10 per pound does not align with the agreed range of $1.80-$2.20 per pound, creating a practical inconsistency.
-------------------------
```

### Shared Memory script output
```
============================================================
  AUCTION — Isolated agents
============================================================
  mode: isolated
  winner: brazil_farm
  price: 2.1
  reason: first pub/sub reply wins — ignores better later bids and history
  all_bids: [{'farm': 'brazil_farm', 'price_usd_lb': 2.1, 'quality_score': 0.82, 'delivery_days': 14}, {'farm': 'colombia_farm', 'price_usd_lb': 2.05, 'quality_score': 0.91, 'delivery_days': 10}, {'farm': 'vietnam_farm', 'price_usd_lb': 1.95, 'quality_score': 0.78, 'delivery_days': 18}]

[setup] workspace=2ef1af2b-79a7-47d5-b482-815de664911c mas=370c4c6a-bfb6-4315-8887-99458e98ea6f agents=4
[auction_supervisor] shared memory recall: These paths provide information on farm participation, auction wins, and average quality, directly addressing performance and quality....

============================================================
  AUCTION — CFN shared memory
============================================================
  mode: cfn_shared_memory
  winner: colombia_farm
  price: 2.05
  reason: all bids retained + historical recall informs scoring
  all_bids: [{'farm': 'brazil_farm', 'price_usd_lb': 2.1, 'quality_score': 0.82, 'delivery_days': 14}, {'farm': 'colombia_farm', 'price_usd_lb': 2.05, 'quality_score': 0.91, 'delivery_days': 10}, {'farm': 'vietnam_farm', 'price_usd_lb': 1.95, 'quality_score': 0.78, 'delivery_days': 18}]
  recall_snippet: These paths provide information on farm participation, auction wins, and average quality, directly addressing performance and quality.

============================================================
  SUMMARY: IoC CFN shared memory vs isolated agents
============================================================
  Auction   : isolated picks first/fast bid; CFN recalls history → better winner
  Production: replace mock agents with coffeeAgntcy A2A/SLIM + A2AInstrumentor
```

