### PR TITLE
feat(lungo): add vertically resizable agent chat panel

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatArea.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatArea.tsx
@@ -22,7 +22,7 @@ import type { HttpRequestTarget } from "@/urls"
 import { CanvasMode } from "@/types/patternDoc"
 import { streamPatternChat } from "./streamPatternChat"
 
-/** Panel expanded/collapsed by the chat header minimize control. */
+/** Scrollable message thread region between header and composer. */
 export const CHAT_MESSAGE_PANEL_ID = "chat-message-panel"
 
 interface ChatAreaProps {
@@ -51,6 +51,8 @@ interface ChatAreaProps {
   canvasMode?: CanvasMode
   selectedReferencePattern?: string | null
   patternChatSessionId?: string | null
+  /** When false, the chat shell sizes to its composer content only. */
+  fillHeight?: boolean
 }
 
 const ChatArea: React.FC<ChatAreaProps> = ({
@@ -79,10 +81,10 @@ const ChatArea: React.FC<ChatAreaProps> = ({
   canvasMode,
   selectedReferencePattern,
   patternChatSessionId,
+  fillHeight = true,
 }) => {
   const [content, setContent] = useState<string>("")
   const [loading, setLoading] = useState<boolean>(false)
-  const [isMinimized, setIsMinimized] = useState<boolean>(false)
   const messagePanelRef = useRef<HTMLDivElement>(null)
   const threadContentRef = useRef<HTMLDivElement>(null)
   const { sendPatternMessage } = usePatternChatAPI()
@@ -90,29 +92,14 @@ const ChatArea: React.FC<ChatAreaProps> = ({
   useScrollPanelOnContentResize(
     messagePanelRef,
     threadContentRef,
-    Boolean(currentUserMessage) && !isMinimized,
+    Boolean(currentUserMessage),
   )
 
-  const handleMinimize = () => {
-    setIsMinimized(true)
-  }
-
-  const handleRestore = () => {
-    setIsMinimized(false)
-  }
-
   const handleSuggestedPromptSelect = (query: string) => {
-    if (isMinimized) {
-      setIsMinimized(false)
-    }
     setContent(query)
   }
 
   const processMessage = async (): Promise<void> => {
-    if (isMinimized) {
-      setIsMinimized(false)
-    }
-
     if (
       canvasMode === CanvasMode.PATTERN_DOC &&
       selectedReferencePattern &&
@@ -173,24 +160,22 @@ const ChatArea: React.FC<ChatAreaProps> = ({
         position: "relative",
         display: "flex",
         width: "100%",
-        height: "100%",
-        maxHeight: "100%",
+        height: fillHeight ? "100%" : "auto",
+        maxHeight: fillHeight ? "100%" : "none",
         minHeight: 0,
         flexDirection: "column",
         boxSizing: "border-box",
         overflow: "hidden",
-        borderTop: "1px solid",
-        borderColor: "divider",
         backgroundColor: (theme) => theme.palette.action.selected,
+        ...(!fillHeight
+          ? { borderTop: "1px solid", borderColor: "divider" }
+          : {}),
       }}
     >
       {currentUserMessage ? (
         <Box sx={{ flexShrink: 0, width: "100%" }}>
           <ChatHeader
-            onMinimize={isMinimized ? handleRestore : handleMinimize}
             onClearConversation={onClearConversation}
-            isMinimized={isMinimized}
-            messagePanelId={CHAT_MESSAGE_PANEL_ID}
             horizontalPadding={chatHorizontalPadding}
           />
         </Box>
@@ -201,10 +186,9 @@ const ChatArea: React.FC<ChatAreaProps> = ({
         id={CHAT_MESSAGE_PANEL_ID}
         role="region"
         aria-label="Chat messages"
-        aria-hidden={isMinimized ? true : undefined}
         sx={{
-          flex: "1 1 auto",
-          minHeight: 0,
+          flex: fillHeight ? "1 1 auto" : "0 0 auto",
+          minHeight: fillHeight ? 0 : undefined,
           width: "100%",
           overflowY: "auto",
           overflowX: "hidden",
@@ -225,13 +209,12 @@ const ChatArea: React.FC<ChatAreaProps> = ({
             width: "100%",
             px: chatHorizontalPadding,
             py: currentUserMessage ? 1 : 0,
-            display: isMinimized ? "none" : "flex",
+            display: "flex",
           }}
         >
           {currentUserMessage ? (
             <ChatAreaMessageThread
               currentUserMessage={currentUserMessage}
-              isMinimized={isMinimized}
               showProgressTracker={showProgressTracker}
               showAuctionStreaming={showAuctionStreaming}
               showRecruiterStreaming={showRecruiterStreaming}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatAreaMessageThread.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatAreaMessageThread.tsx
@@ -26,7 +26,6 @@ import GrafanaSessionLink from "./GrafanaSessionLink"
 
 export interface ChatAreaMessageThreadProps {
   currentUserMessage: string
-  isMinimized: boolean
   showProgressTracker: boolean
   showAuctionStreaming: boolean
   showRecruiterStreaming: boolean
@@ -45,7 +44,6 @@ export interface ChatAreaMessageThreadProps {
 
 const ChatAreaMessageThread: React.FC<ChatAreaMessageThreadProps> = ({
   currentUserMessage,
-  isMinimized,
   showProgressTracker,
   showAuctionStreaming,
   showRecruiterStreaming,
@@ -65,8 +63,7 @@ const ChatAreaMessageThread: React.FC<ChatAreaMessageThreadProps> = ({
   const hasAgentFinalResponse =
     showFinalResponse &&
     !hasApiError &&
-    (isAgentLoading || Boolean(agentResponse?.response?.trim())) &&
-    !isMinimized
+    (isAgentLoading || Boolean(agentResponse?.response?.trim()))
 
   return (
     <Stack
@@ -91,53 +88,47 @@ const ChatAreaMessageThread: React.FC<ChatAreaMessageThreadProps> = ({
         </StatusMessage>
       ) : null}
 
-      {!isMinimized && currentUserMessage.trim() ? (
+      {currentUserMessage.trim() ? (
         <UserMessage content={currentUserMessage} />
       ) : null}
 
-      {showProgressTracker && (
-        <Box sx={{ width: "100%", display: isMinimized ? "none" : "block" }}>
-          <GroupCommunicationFeed
-            isVisible={!isMinimized && showProgressTracker}
-            onComplete={onStreamComplete}
-            onSenderHighlight={onSenderHighlight}
-            graphConfig={graphConfig}
-            prompt={currentUserMessage}
-            executionKey={executionKey}
-            apiError={hasApiError}
-            observabilitySessionId={observabilitySessionId}
-          />
-        </Box>
-      )}
+      {showProgressTracker ? (
+        <GroupCommunicationFeed
+          isVisible={showProgressTracker}
+          onComplete={onStreamComplete}
+          onSenderHighlight={onSenderHighlight}
+          graphConfig={graphConfig}
+          prompt={currentUserMessage}
+          executionKey={executionKey}
+          apiError={hasApiError}
+          observabilitySessionId={observabilitySessionId}
+        />
+      ) : null}
 
-      {showAuctionStreaming && (
-        <Box sx={{ width: "100%", display: isMinimized ? "none" : "block" }}>
-          <AuctionStreamingFeed
-            isVisible={!isMinimized && showAuctionStreaming}
-            prompt={currentUserMessage}
-            apiError={hasApiError}
-            auctionStreamingState={auctionState}
-            onSenderHighlight={onSenderHighlight}
-            graphConfig={graphConfig}
-            observabilitySessionId={observabilitySessionId}
-          />
-        </Box>
-      )}
+      {showAuctionStreaming ? (
+        <AuctionStreamingFeed
+          isVisible={showAuctionStreaming}
+          prompt={currentUserMessage}
+          apiError={hasApiError}
+          auctionStreamingState={auctionState}
+          onSenderHighlight={onSenderHighlight}
+          graphConfig={graphConfig}
+          observabilitySessionId={observabilitySessionId}
+        />
+      ) : null}
 
-      {showRecruiterStreaming && (
-        <Box sx={{ width: "100%", display: isMinimized ? "none" : "block" }}>
-          <RecruiterStreamingFeed
-            isVisible={!isMinimized && showRecruiterStreaming}
-            prompt={currentUserMessage}
-            apiError={hasApiError}
-            recruiterStreamingState={recruiterState}
-            onStreamComplete={onStreamComplete}
-            onSenderHighlight={onSenderHighlight}
-            graphConfig={graphConfig}
-            observabilitySessionId={observabilitySessionId}
-          />
-        </Box>
-      )}
+      {showRecruiterStreaming ? (
+        <RecruiterStreamingFeed
+          isVisible={showRecruiterStreaming}
+          prompt={currentUserMessage}
+          apiError={hasApiError}
+          recruiterStreamingState={recruiterState}
+          onStreamComplete={onStreamComplete}
+          onSenderHighlight={onSenderHighlight}
+          graphConfig={graphConfig}
+          observabilitySessionId={observabilitySessionId}
+        />
+      ) : null}
 
       {hasAgentFinalResponse ? (
         <Message icon={<ChatAgentAvatar />}>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatHeader.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatHeader.tsx
@@ -5,8 +5,6 @@
 
 import React from "react"
 import DeleteOutline from "@mui/icons-material/DeleteOutline"
-import UnfoldLess from "@mui/icons-material/UnfoldLess"
-import UnfoldMore from "@mui/icons-material/UnfoldMore"
 import type { Theme } from "@mui/material/styles"
 import { Box, IconButton, Tooltip } from "@open-ui-kit/core"
 
@@ -29,19 +27,12 @@ function chatHeaderIconButtonSx(theme: Theme) {
 }
 
 interface ChatHeaderProps {
-  onMinimize?: () => void
   onClearConversation?: () => void
-  isMinimized?: boolean
-  /** ID of the expandable message panel controlled by the minimize button. */
-  messagePanelId?: string
   horizontalPadding?: { xs: number; sm: number; md: number; lg: number }
 }
 
 const ChatHeader: React.FC<ChatHeaderProps> = ({
-  onMinimize,
   onClearConversation,
-  isMinimized = false,
-  messagePanelId,
   horizontalPadding = { xs: 2, sm: 4, md: 8, lg: 15 },
 }) => {
   return (
@@ -50,43 +41,22 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
         display: "flex",
         width: "100%",
         alignItems: "center",
-        justifyContent: "space-between",
+        justifyContent: "flex-end",
         px: horizontalPadding,
         py: 1,
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center" }}>
-        {onMinimize ? (
-          <Tooltip title={isMinimized ? "Maximize" : "Minimize"}>
-            <IconButton
-              onClick={onMinimize}
-              aria-label={isMinimized ? "Maximize" : "Minimize"}
-              aria-expanded={!isMinimized}
-              aria-controls={messagePanelId}
-              sx={chatHeaderIconButtonSx}
-            >
-              {isMinimized ? (
-                <UnfoldMore aria-hidden />
-              ) : (
-                <UnfoldLess aria-hidden />
-              )}
-            </IconButton>
-          </Tooltip>
-        ) : null}
-      </Box>
-      <Box sx={{ display: "flex", alignItems: "center" }}>
-        {onClearConversation ? (
-          <Tooltip title="Clear conversation">
-            <IconButton
-              onClick={onClearConversation}
-              aria-label="Clear conversation"
-              sx={chatHeaderIconButtonSx}
-            >
-              <DeleteOutline />
-            </IconButton>
-          </Tooltip>
-        ) : null}
-      </Box>
+      {onClearConversation ? (
+        <Tooltip title="Clear conversation">
+          <IconButton
+            onClick={onClearConversation}
+            aria-label="Clear conversation"
+            sx={chatHeaderIconButtonSx}
+          >
+            <DeleteOutline />
+          </IconButton>
+        </Tooltip>
+      ) : null}
     </Box>
   )
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatPanelSeparator.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatPanelSeparator.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import React from "react"
+
+import ResizablePanelSeparator from "@/components/layout/ResizablePanelSeparator"
+
+type ChatPanelSeparatorProps = {
+  disabled?: boolean
+}
+
+const ChatPanelSeparator: React.FC<ChatPanelSeparatorProps> = ({
+  disabled = false,
+}) => (
+  <ResizablePanelSeparator
+    id="chat-panel-separator"
+    aria-label="Resize agent chat"
+    orientation="vertical"
+    disabled={disabled}
+  />
+)
+
+export default ChatPanelSeparator

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/chatPanelLayout.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/chatPanelLayout.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Resizable graph/chat panel ids and size constraints (react-resizable-panels).
+ */
+
+import {
+  RESIZABLE_PANEL_MAX_SIZE,
+  RESIZABLE_PANEL_MIN_SIZE,
+} from "@/components/layout/resizablePanelLayout"
+
+export const MAIN_VERTICAL_GROUP_ID = "main-vertical"
+
+export const GRAPH_PANEL_ID = "graph"
+export const CHAT_PANEL_ID = "chat"
+
+/** Room for header, composer, and a short scrollable message area. */
+export const CHAT_MIN_SIZE = "12rem"
+
+export const CHAT_MAX_SIZE = RESIZABLE_PANEL_MAX_SIZE
+
+/** Keeps at least a quarter of the main column for the graph when chat is tall. */
+export const GRAPH_MIN_SIZE = RESIZABLE_PANEL_MIN_SIZE
+
+export const CHAT_PANEL_AUTO_SIZE_MAX_ATTEMPTS = 10

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/SidebarPanelSeparator.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/SidebarPanelSeparator.tsx
@@ -4,39 +4,14 @@
  **/
 
 import React from "react"
-import { Separator } from "react-resizable-panels"
-import { alpha, styled } from "@mui/material/styles"
 
-const StyledSeparator = styled(Separator)(({ theme }) => {
-  const isLight = theme.palette.mode === "light"
-  const restingOpacity = isLight ? 0.18 : 0.22
-  const hoverOpacity = isLight ? 0.32 : 0.38
-
-  return {
-    flexShrink: 0,
-    width: 4,
-    margin: 0,
-    padding: 0,
-    border: 0,
-    backgroundColor: alpha(theme.palette.text.primary, restingOpacity),
-    cursor: "col-resize",
-    transition: theme.transitions.create("background-color", {
-      duration: theme.transitions.duration.shortest,
-    }),
-    "&:hover": {
-      backgroundColor: alpha(theme.palette.text.primary, hoverOpacity),
-    },
-    "&:focus-visible": {
-      outline: `2px solid ${theme.palette.primary.main}`,
-      outlineOffset: -2,
-    },
-  }
-})
+import ResizablePanelSeparator from "@/components/layout/ResizablePanelSeparator"
 
 const SidebarPanelSeparator: React.FC = () => (
-  <StyledSeparator
+  <ResizablePanelSeparator
     id="sidebar-panel-separator"
     aria-label="Resize workflow catalog"
+    orientation="horizontal"
   />
 )
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/sidebarPanelLayout.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/sidebarPanelLayout.ts
@@ -5,6 +5,11 @@
  * Resizable app-shell panel ids and size constraints (react-resizable-panels).
  **/
 
+import {
+  RESIZABLE_PANEL_MAX_SIZE,
+  RESIZABLE_PANEL_MIN_SIZE,
+} from "@/components/layout/resizablePanelLayout"
+
 export const APP_SHELL_PANEL_GROUP_ID = "app-shell"
 
 export const SIDEBAR_PANEL_ID = "sidebar"
@@ -13,7 +18,7 @@ export const MAIN_PANEL_ID = "main"
 /** Matches the previous fixed drawer width. */
 export const SIDEBAR_DEFAULT_SIZE = "16.5rem"
 export const SIDEBAR_MIN_SIZE = "12rem"
-export const SIDEBAR_MAX_SIZE = "75%"
+export const SIDEBAR_MAX_SIZE = RESIZABLE_PANEL_MAX_SIZE
 
 /** Keeps at least a quarter of the shell for graph + chat when the sidebar is wide. */
-export const MAIN_MIN_SIZE = "25%"
+export const MAIN_MIN_SIZE = RESIZABLE_PANEL_MIN_SIZE

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/layout/ResizablePanelSeparator.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/layout/ResizablePanelSeparator.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Themed drag handle between react-resizable-panels Panel siblings.
+ */
+
+import React from "react"
+import { Separator } from "react-resizable-panels"
+import { alpha, styled } from "@mui/material/styles"
+
+import { RESIZABLE_PANEL_SEPARATOR_SIZE_PX } from "./resizablePanelLayout"
+
+export type ResizablePanelGroupOrientation = "horizontal" | "vertical"
+
+export type ResizablePanelSeparatorProps = {
+  id: string
+  "aria-label": string
+  orientation: ResizablePanelGroupOrientation
+  disabled?: boolean
+}
+
+const StyledSeparator = styled(Separator, {
+  shouldForwardProp: (prop) =>
+    prop !== "resizeEnabled" && prop !== "orientation",
+})<{
+  orientation: ResizablePanelGroupOrientation
+  resizeEnabled?: boolean
+}>(({ theme, orientation, resizeEnabled = true }) => {
+  const isLight = theme.palette.mode === "light"
+  const restingOpacity = isLight ? 0.18 : 0.22
+  const hoverOpacity = isLight ? 0.32 : 0.38
+  const isHorizontalGroup = orientation === "horizontal"
+
+  return {
+    flexShrink: 0,
+    ...(isHorizontalGroup
+      ? { width: RESIZABLE_PANEL_SEPARATOR_SIZE_PX }
+      : { height: RESIZABLE_PANEL_SEPARATOR_SIZE_PX }),
+    margin: 0,
+    padding: 0,
+    border: 0,
+    backgroundColor: alpha(theme.palette.text.primary, restingOpacity),
+    cursor: resizeEnabled
+      ? isHorizontalGroup
+        ? "col-resize"
+        : "row-resize"
+      : "default",
+    pointerEvents: resizeEnabled ? "auto" : "none",
+    transition: theme.transitions.create("background-color", {
+      duration: theme.transitions.duration.shortest,
+    }),
+    "&:hover": {
+      backgroundColor: alpha(
+        theme.palette.text.primary,
+        resizeEnabled ? hoverOpacity : restingOpacity,
+      ),
+    },
+    "&:focus-visible": {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: -2,
+    },
+  }
+})
+
+const ResizablePanelSeparator: React.FC<ResizablePanelSeparatorProps> = ({
+  id,
+  "aria-label": ariaLabel,
+  orientation,
+  disabled = false,
+}) => (
+  <StyledSeparator
+    id={id}
+    aria-label={ariaLabel}
+    disabled={disabled}
+    orientation={orientation}
+    resizeEnabled={!disabled}
+  />
+)
+
+export default ResizablePanelSeparator

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/layout/resizablePanelLayout.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/layout/resizablePanelLayout.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shared react-resizable-panels layout tokens.
+ */
+
+/** Drag handle thickness in pixels (horizontal or vertical separator). */
+export const RESIZABLE_PANEL_SEPARATOR_SIZE_PX = 4
+
+/** Max share of a split group for the resizable panel (sidebar or chat). */
+export const RESIZABLE_PANEL_MAX_SIZE = "75%"
+
+/** Min share kept for the adjacent panel (main column or graph). */
+export const RESIZABLE_PANEL_MIN_SIZE = "25%"

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useChatPanelContentSize.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useChatPanelContentSize.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Sizes the chat panel from the rendered ChatArea content height, then enables
+ * fill-height layout so drag-resize can grow the scrollable message region.
+ */
+
+import { useLayoutEffect, useState, type RefObject } from "react"
+import type { PanelImperativeHandle } from "react-resizable-panels"
+import { CHAT_PANEL_AUTO_SIZE_MAX_ATTEMPTS } from "@/components/Chat/chatPanelLayout"
+
+type UseChatPanelContentSizeOptions = {
+  enabled: boolean
+  chatPanelRef: RefObject<PanelImperativeHandle | null>
+  chatContentRef: RefObject<HTMLElement | null>
+}
+
+export function useChatPanelContentSize({
+  enabled,
+  chatPanelRef,
+  chatContentRef,
+}: UseChatPanelContentSizeOptions) {
+  const [contentSized, setContentSized] = useState(false)
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setContentSized(false)
+      return
+    }
+
+    if (contentSized) {
+      return
+    }
+
+    let cancelled = false
+    let attempts = 0
+    let frameId = 0
+
+    const tryResizeToContent = () => {
+      if (cancelled) return
+
+      const chatPanel = chatPanelRef.current
+      const chatContent = chatContentRef.current
+      if (!chatPanel || !chatContent) {
+        scheduleRetry()
+        return
+      }
+
+      const height = Math.ceil(chatContent.getBoundingClientRect().height)
+      if (height <= 0) {
+        scheduleRetry()
+        return
+      }
+
+      try {
+        chatPanel.resize(`${height}px`)
+        if (!cancelled) {
+          setContentSized(true)
+        }
+      } catch {
+        scheduleRetry()
+      }
+    }
+
+    const scheduleRetry = () => {
+      if (cancelled || attempts >= CHAT_PANEL_AUTO_SIZE_MAX_ATTEMPTS) {
+        return
+      }
+
+      attempts += 1
+      frameId = window.requestAnimationFrame(tryResizeToContent)
+    }
+
+    frameId = window.requestAnimationFrame(tryResizeToContent)
+
+    return () => {
+      cancelled = true
+      window.cancelAnimationFrame(frameId)
+    }
+  }, [chatContentRef, chatPanelRef, contentSized, enabled])
+
+  return {
+    contentSized,
+    fillHeight: enabled && contentSized,
+  }
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useChatPanelContentSize.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/useChatPanelContentSize.ts
@@ -12,12 +12,21 @@ import { CHAT_PANEL_AUTO_SIZE_MAX_ATTEMPTS } from "@/components/Chat/chatPanelLa
 
 type UseChatPanelContentSizeOptions = {
   enabled: boolean
+  /** When this value changes, panel height is re-measured from chat content. */
+  remeasureKey?: unknown
+  /**
+   * When false (composer-only), measure intrinsic scroll height and do not
+   * stretch the chat shell to the panel (avoids feedback with persisted flex).
+   */
+  fillPanelHeight?: boolean
   chatPanelRef: RefObject<PanelImperativeHandle | null>
   chatContentRef: RefObject<HTMLElement | null>
 }
 
 export function useChatPanelContentSize({
   enabled,
+  remeasureKey,
+  fillPanelHeight = true,
   chatPanelRef,
   chatContentRef,
 }: UseChatPanelContentSizeOptions) {
@@ -29,9 +38,7 @@ export function useChatPanelContentSize({
       return
     }
 
-    if (contentSized) {
-      return
-    }
+    setContentSized(false)
 
     let cancelled = false
     let attempts = 0
@@ -47,7 +54,11 @@ export function useChatPanelContentSize({
         return
       }
 
-      const height = Math.ceil(chatContent.getBoundingClientRect().height)
+      const height = Math.ceil(
+        fillPanelHeight
+          ? chatContent.getBoundingClientRect().height
+          : chatContent.scrollHeight,
+      )
       if (height <= 0) {
         scheduleRetry()
         return
@@ -78,10 +89,10 @@ export function useChatPanelContentSize({
       cancelled = true
       window.cancelAnimationFrame(frameId)
     }
-  }, [chatContentRef, chatPanelRef, contentSized, enabled])
+  }, [chatContentRef, chatPanelRef, enabled, fillPanelHeight, remeasureKey])
 
   return {
     contentSized,
-    fillHeight: enabled && contentSized,
+    fillHeight: enabled && contentSized && fillPanelHeight,
   }
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
@@ -6,13 +6,28 @@
  **/
 
 import React, { useMemo, useRef } from "react"
-import { Group, Panel, useDefaultLayout } from "react-resizable-panels"
+import {
+  Group,
+  Panel,
+  useDefaultLayout,
+  usePanelRef,
+} from "react-resizable-panels"
 import { Box } from "@open-ui-kit/core"
 import { skipLinkSx } from "@/utils/a11ySx"
 import Navigation from "@/components/Navigation/Navigation"
 import CanvasSwitch from "@/components/MainArea/CanvasSwitch"
 import ErrorBoundary from "@/errors/ui/ErrorBoundary"
 import ChatArea from "@/components/Chat/ChatArea"
+import ChatPanelSeparator from "@/components/Chat/ChatPanelSeparator"
+import {
+  CHAT_MAX_SIZE,
+  CHAT_MIN_SIZE,
+  CHAT_PANEL_ID,
+  GRAPH_MIN_SIZE,
+  GRAPH_PANEL_ID,
+  MAIN_VERTICAL_GROUP_ID,
+} from "@/components/Chat/chatPanelLayout"
+import { useChatPanelContentSize } from "@/hooks/useChatPanelContentSize"
 import Sidebar from "@/components/Sidebar/Sidebar"
 import SidebarPanelSeparator from "@/components/Sidebar/SidebarPanelSeparator"
 import {
@@ -101,6 +116,69 @@ const RootPage: React.FC = () => {
     panelIds: [SIDEBAR_PANEL_ID, MAIN_PANEL_ID],
   })
 
+  const hasChatMessages = Boolean(currentUserMessage?.trim())
+  const chatPanelRef = usePanelRef()
+  const { fillHeight: chatPanelFillHeight } = useChatPanelContentSize({
+    enabled: hasChatMessages,
+    chatPanelRef,
+    chatContentRef: chatRef,
+  })
+
+  const {
+    defaultLayout: mainVerticalDefaultLayout,
+    onLayoutChanged: onMainVerticalLayoutChanged,
+  } = useDefaultLayout({
+    id: MAIN_VERTICAL_GROUP_ID,
+    panelIds: hasChatMessages
+      ? [GRAPH_PANEL_ID, CHAT_PANEL_ID]
+      : [GRAPH_PANEL_ID],
+  })
+
+  const chatAreaProps = {
+    isBottomLayout: true as const,
+    canvasMode,
+    selectedReferencePattern,
+    patternChatSessionId,
+    onPatternChatSuccess: () => setAiReplied(true),
+    suggestedPromptsRequest,
+    showProgressTracker:
+      canvasMode !== CanvasMode.PATTERN_DOC && showProgressTracker,
+    showAuctionStreaming:
+      canvasMode !== CanvasMode.PATTERN_DOC && showAuctionStreaming,
+    showRecruiterStreaming:
+      canvasMode !== CanvasMode.PATTERN_DOC && showRecruiterStreaming,
+    showFinalResponse,
+    onStreamComplete: handleStreamComplete,
+    onSenderHighlight: handleSenderHighlight,
+    graphConfig,
+    onSendPrompt: handleSendPrompt,
+    onUserInput: handleUserInput,
+    onApiResponse: handleApiResponse,
+    onClearConversation: handleClearConversation,
+    currentUserMessage,
+    agentResponse,
+    executionKey,
+    isAgentLoading,
+    apiErrorMessage,
+    chatRef,
+    fillHeight: hasChatMessages ? chatPanelFillHeight : false,
+    auctionState: {
+      events,
+      status,
+      error,
+    },
+    recruiterState: {
+      events: recruiterEvents,
+      status: recruiterStatus,
+      error: recruiterError,
+      sessionId: recruiterSessionId,
+      finalMessage: recruiterFinalMessage,
+      agentRecords: recruiterAgentRecords,
+      evaluationResults: recruiterEvaluationResults,
+      selectedAgent: recruiterSelectedAgent,
+    },
+  }
+
   return (
     <Box
       sx={{
@@ -166,118 +244,120 @@ const RootPage: React.FC = () => {
             >
               <GraphCanvasLayoutContext.Provider value={graphCanvasLayout}>
                 <Box
-                  component="section"
-                  aria-label="Workflow graph"
-                  ref={graphSectionRef}
-                  sx={{
-                    position: "relative",
-                    flex: "1 1 50%",
-                    minHeight: "50%",
-                    minWidth: 0,
-                    overflow: "hidden",
-                  }}
-                >
-                  <ErrorBoundary
-                    source="WorkflowGraph"
-                    fallbackTitle="Graph unavailable"
-                    compact
-                    resetKeys={[
-                      selectedWorkflowSummary?.name,
-                      canvasMode,
-                      selectedReferencePattern,
-                    ]}
-                  >
-                    <CanvasSwitch
-                      canvasMode={canvasMode}
-                      selectedReferencePattern={selectedReferencePattern}
-                      patternDocState={patternDocState}
-                      pattern={selectedPattern}
-                      selectedWorkflowSummary={selectedWorkflowSummary}
-                      workflowCatalogLoading={workflowCatalogLoading}
-                      workflowCatalogError={workflowCatalogError}
-                      onLiveGraphConfig={setLiveGraphConfig}
-                      buttonClicked={buttonClicked}
-                      setButtonClicked={setButtonClicked}
-                      aiReplied={aiReplied}
-                      chatHeight={chatHeightValue}
-                      isExpanded={isExpanded}
-                      groupCommResponseReceived={groupCommResponseReceived}
-                      onNodeHighlight={handleNodeHighlightSetup}
-                      selectedAgentCid={
-                        typeof recruiterSelectedAgent?.cid === "string"
-                          ? recruiterSelectedAgent.cid
-                          : null
-                      }
-                    />
-                  </ErrorBoundary>
-                </Box>
-                <Box
-                  component="section"
-                  aria-label="Agent chat"
                   sx={{
                     display: "flex",
-                    width: "100%",
-                    flex: "0 1 auto",
-                    flexShrink: 0,
                     flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "flex-start",
-                    gap: 0,
-                    p: 0,
-                    maxHeight: "50%",
-                    minWidth: 0,
+                    width: "100%",
+                    height: "100%",
+                    minHeight: 0,
                     overflow: "hidden",
                   }}
                 >
-                  <ChatArea
-                    isBottomLayout={true}
-                    canvasMode={canvasMode}
-                    selectedReferencePattern={selectedReferencePattern}
-                    patternChatSessionId={patternChatSessionId}
-                    onPatternChatSuccess={() => setAiReplied(true)}
-                    suggestedPromptsRequest={suggestedPromptsRequest}
-                    showProgressTracker={
-                      canvasMode !== CanvasMode.PATTERN_DOC &&
-                      showProgressTracker
-                    }
-                    showAuctionStreaming={
-                      canvasMode !== CanvasMode.PATTERN_DOC &&
-                      showAuctionStreaming
-                    }
-                    showRecruiterStreaming={
-                      canvasMode !== CanvasMode.PATTERN_DOC &&
-                      showRecruiterStreaming
-                    }
-                    showFinalResponse={showFinalResponse}
-                    onStreamComplete={handleStreamComplete}
-                    onSenderHighlight={handleSenderHighlight}
-                    graphConfig={graphConfig}
-                    onSendPrompt={handleSendPrompt}
-                    onUserInput={handleUserInput}
-                    onApiResponse={handleApiResponse}
-                    onClearConversation={handleClearConversation}
-                    currentUserMessage={currentUserMessage}
-                    agentResponse={agentResponse}
-                    executionKey={executionKey}
-                    isAgentLoading={isAgentLoading}
-                    apiErrorMessage={apiErrorMessage}
-                    chatRef={chatRef}
-                    auctionState={{
-                      events,
-                      status,
-                      error,
-                    }}
-                    recruiterState={{
-                      events: recruiterEvents,
-                      status: recruiterStatus,
-                      error: recruiterError,
-                      sessionId: recruiterSessionId,
-                      finalMessage: recruiterFinalMessage,
-                      agentRecords: recruiterAgentRecords,
-                      evaluationResults: recruiterEvaluationResults,
-                      selectedAgent: recruiterSelectedAgent,
-                    }}
-                  />
+                  <Group
+                    id={MAIN_VERTICAL_GROUP_ID}
+                    orientation="vertical"
+                    defaultLayout={mainVerticalDefaultLayout}
+                    onLayoutChanged={onMainVerticalLayoutChanged}
+                    style={{ flex: 1, minHeight: 0, width: "100%" }}
+                  >
+                    <Panel
+                      id={GRAPH_PANEL_ID}
+                      minSize={hasChatMessages ? GRAPH_MIN_SIZE : undefined}
+                      defaultSize={hasChatMessages ? undefined : "100%"}
+                    >
+                      <Box
+                        component="section"
+                        aria-label="Workflow graph"
+                        ref={graphSectionRef}
+                        sx={{
+                          position: "relative",
+                          width: "100%",
+                          height: "100%",
+                          minWidth: 0,
+                          minHeight: 0,
+                          overflow: "hidden",
+                        }}
+                      >
+                        <ErrorBoundary
+                          source="WorkflowGraph"
+                          fallbackTitle="Graph unavailable"
+                          compact
+                          resetKeys={[
+                            selectedWorkflowSummary?.name,
+                            canvasMode,
+                            selectedReferencePattern,
+                          ]}
+                        >
+                          <CanvasSwitch
+                            canvasMode={canvasMode}
+                            selectedReferencePattern={selectedReferencePattern}
+                            patternDocState={patternDocState}
+                            pattern={selectedPattern}
+                            selectedWorkflowSummary={selectedWorkflowSummary}
+                            workflowCatalogLoading={workflowCatalogLoading}
+                            workflowCatalogError={workflowCatalogError}
+                            onLiveGraphConfig={setLiveGraphConfig}
+                            buttonClicked={buttonClicked}
+                            setButtonClicked={setButtonClicked}
+                            aiReplied={aiReplied}
+                            chatHeight={chatHeightValue}
+                            isExpanded={isExpanded}
+                            groupCommResponseReceived={
+                              groupCommResponseReceived
+                            }
+                            onNodeHighlight={handleNodeHighlightSetup}
+                            selectedAgentCid={
+                              typeof recruiterSelectedAgent?.cid === "string"
+                                ? recruiterSelectedAgent.cid
+                                : null
+                            }
+                          />
+                        </ErrorBoundary>
+                      </Box>
+                    </Panel>
+                    {hasChatMessages ? (
+                      <>
+                        <ChatPanelSeparator />
+                        <Panel
+                          id={CHAT_PANEL_ID}
+                          panelRef={chatPanelRef}
+                          minSize={CHAT_MIN_SIZE}
+                          maxSize={CHAT_MAX_SIZE}
+                        >
+                          <Box
+                            component="section"
+                            aria-label="Agent chat"
+                            sx={{
+                              display: "flex",
+                              width: "100%",
+                              height: chatPanelFillHeight ? "100%" : "auto",
+                              minWidth: 0,
+                              minHeight: 0,
+                              flexDirection: "column",
+                              overflow: "hidden",
+                            }}
+                          >
+                            <ChatArea {...chatAreaProps} />
+                          </Box>
+                        </Panel>
+                      </>
+                    ) : null}
+                  </Group>
+                  {!hasChatMessages ? (
+                    <Box
+                      component="section"
+                      aria-label="Agent chat"
+                      sx={{
+                        display: "flex",
+                        width: "100%",
+                        flexShrink: 0,
+                        flexDirection: "column",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <ChatArea {...chatAreaProps} />
+                    </Box>
+                  ) : null}
                 </Box>
               </GraphCanvasLayoutContext.Provider>
             </Box>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
@@ -119,7 +119,9 @@ const RootPage: React.FC = () => {
   const hasChatMessages = Boolean(currentUserMessage?.trim())
   const chatPanelRef = usePanelRef()
   const { fillHeight: chatPanelFillHeight } = useChatPanelContentSize({
-    enabled: hasChatMessages,
+    enabled: true,
+    remeasureKey: hasChatMessages,
+    fillPanelHeight: hasChatMessages,
     chatPanelRef,
     chatContentRef: chatRef,
   })
@@ -129,9 +131,7 @@ const RootPage: React.FC = () => {
     onLayoutChanged: onMainVerticalLayoutChanged,
   } = useDefaultLayout({
     id: MAIN_VERTICAL_GROUP_ID,
-    panelIds: hasChatMessages
-      ? [GRAPH_PANEL_ID, CHAT_PANEL_ID]
-      : [GRAPH_PANEL_ID],
+    panelIds: [GRAPH_PANEL_ID, CHAT_PANEL_ID],
   })
 
   const chatAreaProps = {
@@ -315,49 +315,30 @@ const RootPage: React.FC = () => {
                         </ErrorBoundary>
                       </Box>
                     </Panel>
-                    {hasChatMessages ? (
-                      <>
-                        <ChatPanelSeparator />
-                        <Panel
-                          id={CHAT_PANEL_ID}
-                          panelRef={chatPanelRef}
-                          minSize={CHAT_MIN_SIZE}
-                          maxSize={CHAT_MAX_SIZE}
-                        >
-                          <Box
-                            component="section"
-                            aria-label="Agent chat"
-                            sx={{
-                              display: "flex",
-                              width: "100%",
-                              height: chatPanelFillHeight ? "100%" : "auto",
-                              minWidth: 0,
-                              minHeight: 0,
-                              flexDirection: "column",
-                              overflow: "hidden",
-                            }}
-                          >
-                            <ChatArea {...chatAreaProps} />
-                          </Box>
-                        </Panel>
-                      </>
-                    ) : null}
-                  </Group>
-                  {!hasChatMessages ? (
-                    <Box
-                      component="section"
-                      aria-label="Agent chat"
-                      sx={{
-                        display: "flex",
-                        width: "100%",
-                        flexShrink: 0,
-                        flexDirection: "column",
-                        overflow: "hidden",
-                      }}
+                    <ChatPanelSeparator disabled={!hasChatMessages} />
+                    <Panel
+                      id={CHAT_PANEL_ID}
+                      panelRef={chatPanelRef}
+                      minSize={hasChatMessages ? CHAT_MIN_SIZE : undefined}
+                      maxSize={CHAT_MAX_SIZE}
                     >
-                      <ChatArea {...chatAreaProps} />
-                    </Box>
-                  ) : null}
+                      <Box
+                        component="section"
+                        aria-label="Agent chat"
+                        sx={{
+                          display: "flex",
+                          width: "100%",
+                          height: chatPanelFillHeight ? "100%" : "auto",
+                          minWidth: 0,
+                          minHeight: 0,
+                          flexDirection: "column",
+                          overflow: "hidden",
+                        }}
+                      >
+                        <ChatArea {...chatAreaProps} />
+                      </Box>
+                    </Panel>
+                  </Group>
                 </Box>
               </GraphCanvasLayoutContext.Provider>
             </Box>


### PR DESCRIPTION
# Description

This change improves the lungo main layout so the **agent chat can be resized vertically** against the workflow graph, similar to the existing horizontal sidebar split.

**Behavior**

- When the user has sent a message, the main column uses a **vertical `react-resizable-panels` group** (graph above, chat below) with a drag handle (`ChatPanelSeparator`).
- The chat panel **starts sized to its content** via `useChatPanelContentSize`, then switches to **fill-height** so dragging the separator grows or shrinks the scrollable message region.
- Min/max constraints live in `chatPanelLayout.ts` (e.g. minimum chat height, graph keeps at least ~25% of the column).
- The chat header **minimize/maximize control is removed**; expanding the conversation is done by dragging the separator instead of toggling collapse in the header.

**Refactor**

- Shared **`ResizablePanelSeparator`** (and `resizablePanelLayout` constants) extracted from the sidebar separator and reused for both sidebar and chat dividers.

**Scope:** lungo frontend only (`RootPage`, `ChatArea`, layout components/hooks). No API or backend changes.

## Issue Link

Fixes #653

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

## Manual test plan

1. Open lungo with no messages — chat stays composer-only; no vertical separator.
2. Send a prompt — separator appears; drag up/down to resize graph vs chat.
3. Confirm message thread scrolls when chat is tall and content overflows.
4. Clear conversation — vertical chat panel and separator disappear; graph uses full height.
5. Sidebar horizontal resize still works (shared separator component).
