### PR TITLE
feat(Corto): do not panic on non-preferred transport setup failure

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/farm/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/corto/farm/farm_server.py
@@ -26,9 +26,9 @@ async def serve_multi_transport(agent_card, request_handler):
 
     Each advertised interface is started in its own session so a broker that
     is unavailable at startup (e.g. NATS) cannot abort the others. A startup
-    failure on the card's ``preferred_transport`` is fatal (the process exits
-    and Kubernetes restarts it); failures on any other transport are logged
-    and skipped so the agent still comes up on the transports that are healthy.
+    failure on the card's ``preferred_transport`` is fatal; failures on any other
+    transport are logged and skipped so the agent still comes up on the transports
+    that are healthy.
     """
     interfaces = agent_card.additional_interfaces or []
     if not interfaces:

--- a/coffeeAGNTCY/coffee_agents/corto/farm/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/corto/farm/farm_server.py
@@ -8,6 +8,7 @@ from a2a.server.apps import A2AStarletteApplication
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.tasks import InMemoryTaskStore
 from agntcy_app_sdk.factory import AgntcyFactory
+from agntcy_app_sdk.semantic.a2a.transport_types import normalize_transport
 from config.config import DEFAULT_MESSAGE_TRANSPORT, FARM_AGENT_HOST, FARM_AGENT_PORT
 from dotenv import load_dotenv
 from farm.agent_executor import FarmAgentExecutor
@@ -20,11 +21,71 @@ logger = logging.getLogger("corto.farm.server")
 factory = AgntcyFactory("corto.farm_agent", enable_tracing=True)
 
 
-async def serve_slim(agent_card, request_handler):
-    session = factory.create_app_session()
-    await session.add_a2a_card(agent_card, request_handler).start(keep_alive=False)
+async def serve_multi_transport(agent_card, request_handler):
+    """Serve the agent on every transport advertised in its AgentCard.
+
+    Each advertised interface is started in its own session so a broker that
+    is unavailable at startup (e.g. NATS) cannot abort the others. A startup
+    failure on the card's ``preferred_transport`` is fatal (the process exits
+    and Kubernetes restarts it); failures on any other transport are logged
+    and skipped so the agent still comes up on the transports that are healthy.
+    """
+    interfaces = agent_card.additional_interfaces or []
+    if not interfaces:
+        raise ValueError("agent_card.additional_interfaces is empty; nothing to serve")
+
+    preferred = normalize_transport(agent_card.preferred_transport or "")
+    advertised = {normalize_transport(i.transport) for i in interfaces}
+    if preferred and preferred not in advertised:
+        logger.warning(
+            "preferred_transport %r is not advertised in additional_interfaces %s; "
+            "no transport will be treated as required at startup",
+            agent_card.preferred_transport,
+            sorted(advertised),
+        )
+
+    started = []
+    for interface in interfaces:
+        transport = normalize_transport(interface.transport)
+        is_preferred = bool(preferred) and transport == preferred
+
+        # Serve only this interface in its own session; skipping the other
+        # advertised transports keeps a single failing transport isolated.
+        session = factory.create_app_session()
+        builder = session.add_a2a_card(agent_card, request_handler).with_factory(
+            factory
+        )
+        for other in advertised - {transport}:
+            builder = builder.skip(other)
+
+        try:
+            await builder.start(keep_alive=False)
+        except Exception as exc:
+            if is_preferred:
+                logger.error(
+                    "Preferred transport %r failed to start; shutting down: %s",
+                    interface.transport,
+                    exc,
+                )
+                raise
+            logger.error(
+                "Transport %r failed to start; continuing without it: %s",
+                interface.transport,
+                exc,
+            )
+            continue
+
+        started.append(session)
+        logger.info("Serving %s on %s", interface.transport, interface.url)
+
+    if not started:
+        raise RuntimeError("No transport interfaces could be started")
+
     logger.info("Agent ready")
-    await session.start_all_sessions(keep_alive=True)
+
+    # Keep the process alive; reuse a live session's keep-alive loop so
+    # signal-based graceful shutdown continues to work.
+    await started[0].start_all_sessions(keep_alive=True)
 
 
 async def main():
@@ -45,7 +106,7 @@ async def main():
         )
         await Server(config).serve()
     else:
-        await serve_slim(AGENT_CARD, request_handler)
+        await serve_multi_transport(AGENT_CARD, request_handler)
 
 
 if __name__ == "__main__":

--- a/coffeeAGNTCY/coffee_agents/corto/tests/unit/farm/test_serve_multi_transport.py
+++ b/coffeeAGNTCY/coffee_agents/corto/tests/unit/farm/test_serve_multi_transport.py
@@ -1,0 +1,136 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the farm server's fault-tolerant multi-transport serving.
+
+A startup failure on the card's ``preferred_transport`` must be fatal, while
+a failure on any other advertised transport must be logged and skipped so a
+single unavailable broker (e.g. NATS) cannot take the whole agent down.
+"""
+
+import pytest
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
+from agntcy_app_sdk.semantic.a2a.transport_types import normalize_transport
+
+import farm.farm_server as farm_server
+
+
+def _make_card(preferred: str = "slim") -> AgentCard:
+    return AgentCard(
+        name="Test Farm",
+        description="test card",
+        version="1.0.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=AgentCapabilities(streaming=True),
+        skills=[AgentSkill(id="s", name="s", description="d", tags=["t"])],
+        preferred_transport=preferred,
+        url="slim://localhost:46357/topic",
+        additional_interfaces=[
+            AgentInterface(transport="slim", url="slim://localhost:46357/topic"),
+            AgentInterface(transport="jsonrpc", url="http://0.0.0.0:9999/"),
+            AgentInterface(transport="nats", url="nats://localhost:4222/topic"),
+        ],
+    )
+
+
+class _FakeBuilder:
+    def __init__(self, session: "_FakeSession", card: AgentCard):
+        self._session = session
+        self._card = card
+        self._skips: set[str] = set()
+
+    def with_factory(self, _factory):
+        return self
+
+    def skip(self, transport_type: str):
+        self._skips.add(normalize_transport(transport_type))
+        return self
+
+    async def start(self, *, keep_alive: bool = False):
+        advertised = {
+            normalize_transport(i.transport)
+            for i in self._card.additional_interfaces
+        }
+        served = advertised - self._skips
+        assert len(served) == 1, f"expected exactly one served transport, got {served}"
+        transport = next(iter(served))
+        self._session.served_transport = transport
+        if transport in self._session._fail_transports:
+            raise RuntimeError(f"{transport} broker unavailable")
+
+
+class _FakeSession:
+    def __init__(self, fail_transports: set[str]):
+        self._fail_transports = fail_transports
+        self.served_transport: str | None = None
+        self.start_all_called_with: bool | None = None
+
+    def add_a2a_card(self, card: AgentCard, _handler):
+        return _FakeBuilder(self, card)
+
+    async def start_all_sessions(self, keep_alive: bool = False):
+        self.start_all_called_with = keep_alive
+
+
+class _FakeFactory:
+    def __init__(self, fail_transports: set[str]):
+        self._fail_transports = fail_transports
+        self.sessions: list[_FakeSession] = []
+
+    def create_app_session(self) -> _FakeSession:
+        session = _FakeSession(self._fail_transports)
+        self.sessions.append(session)
+        return session
+
+
+@pytest.fixture
+def patch_factory(monkeypatch):
+    def _install(fail_transports: set[str]) -> _FakeFactory:
+        fake = _FakeFactory(set(fail_transports))
+        monkeypatch.setattr(farm_server, "factory", fake)
+        return fake
+
+    return _install
+
+
+async def test_non_preferred_transport_failure_is_tolerated(patch_factory):
+    # NATS is down; SLIM (preferred) and jsonrpc are healthy.
+    fake = patch_factory({"natspatterns"})
+    card = _make_card(preferred="slim")
+
+    # Must NOT raise even though the NATS interface fails to start.
+    await farm_server.serve_multi_transport(card, request_handler=object())
+
+    # One session created per advertised interface, in card order.
+    assert [s.served_transport for s in fake.sessions] == [
+        "slimpatterns",
+        "jsonrpc",
+        "natspatterns",
+    ]
+
+    # The keep-alive loop is entered on the first healthy session (SLIM),
+    # never on the failed NATS session.
+    slim_session, jsonrpc_session, nats_session = fake.sessions
+    assert slim_session.start_all_called_with is True
+    assert jsonrpc_session.start_all_called_with is None
+    assert nats_session.start_all_called_with is None
+
+
+async def test_preferred_transport_failure_is_fatal(patch_factory):
+    # SLIM is the preferred transport and it is down -> must crash.
+    patch_factory({"slimpatterns"})
+    card = _make_card(preferred="slim")
+
+    with pytest.raises(RuntimeError, match="broker unavailable"):
+        await farm_server.serve_multi_transport(card, request_handler=object())
+
+
+async def test_all_transports_failing_raises(patch_factory):
+    # Preferred is not advertised, so nothing is "required"; but if every
+    # transport fails to start the agent still cannot serve -> raise.
+    patch_factory({"slimpatterns", "jsonrpc", "natspatterns"})
+    card = _make_card(preferred="unknown-transport")
+
+    with pytest.raises(RuntimeError, match="No transport interfaces could be started"):
+        await farm_server.serve_multi_transport(card, request_handler=object())


### PR DESCRIPTION
# Description

Github Issue with more outputs and explanations of the problem: https://github.com/agntcy/coffeeAgntcy/issues/716

This PR proposes to update the code so that transport methods that are not the `preferred_transport` (in A2A card terms) / `DEFAULT_MESSAGE_TRANSPORT` (in env var terms for our agents) DO NOT crash the agents any more if they cannot be established.

Let's first do this on Corto and then, when we decide on a solution we like, apply it to Lungo as well because Lungo's agents have the same behavior.

### Tests

I tested this locally with docker-compose. In a setup where SLIM is preferred and present but the NATS server is missing, the `farm-server` Corto container logs:
```
farm-server              | 2026-07-27T10:02:32.429087Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
... ... ... ...
farm-server              | 2026-07-27T10:03:24.628312Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
farm-server              | 2026-07-27T10:03:26.637259Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
farm-server              | 2026-07-27T10:03:26.637526Z [error    ] Transport 'nats' failed to start; continuing without it: nats: no servers available for connection [corto.farm.server]

farm-server              | 2026-07-27T10:03:26.637581Z [info     ] Agent ready                    [corto.farm.server]
```



### Caveat 1: SLIM

Your feedback in review is very welcomed on this topic too.

SLIM's `connect_async` (in the compiled `slim_bindings` Rust client) retries the broker connection indefinitely and never raises, so `await builder.start()` for the preferred SLIM interface would block forever — the "preferred failure is fatal" branch never gets a chance to fire when SLIM is targetted by it.
In simpler terms: SLIM's reconnect retries forever so it never "raises" an exception.
It just goes and goes forever with logs like these (in a setup with a `preferred_transport` of SLIM but not present!):
```
farm-server              | 2026-07-27T10:20:07.189006Z  WARN slim connect{service_id=slim/global-bindings-service-0}: slim_config::grpc::client: 908: Transport error encountered. Retrying... error=transport error
farm-server              | Caused by:
farm-server              |   -> dns error
farm-server              |   -> dns error
farm-server              |   -> failed to lookup address information: Name or service not known
```

There could be solutions to this but they could be more general than we might like. 

One idea, for example: Since the retry loop yields to the event loop between attempts, a bounded `asyncio.wait_for` (wrapped around the `start()` call) can interrupt it.
Details: say we were to define a env var that dictates how long any transport can take to set up (let's maybe call it `TRANSPORT_STARTUP_TIMEOUT`) (maybe defaults to a minute or so); then each transport's `start()` is wrapped in `syncio.wait_for(..., timeout=TRANSPORT_STARTUP_TIMEOUT)`. A timeout on the `preferred_transport` is fatal (process exits → gets restarted); a timeout on any other transport is logged and skipped. The existing behavior is preserved for transports that raise on their own (e.g. NATS) assuming the timeout doesn't happen first.

## Issue Link

Fixes #716 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
