### PR TITLE
feat(ci): add helm template render step and --strict helm lint flag

### DIFF
--- a/.github/workflows/helm-package-reusable.yaml
+++ b/.github/workflows/helm-package-reusable.yaml
@@ -55,7 +55,14 @@ jobs:
           version: "3.18.3"
 
       - name: Helm lint
-        run: helm lint ${{ inputs.path }} --with-subcharts
+        # The --strict flag promotes lint warnings to failures.
+        run: helm lint ${{ inputs.path }} --with-subcharts --strict
+
+      - name: Helm template (render check)
+        # Fully render the chart to catch templating issues (nil dereferences,
+        # bad function calls, invalid rendered YAML) that `helm lint` alone
+        # does not surface.
+        run: helm template lint-check ${{ inputs.path }} > /dev/null
 
       - name: Package Helm Chart
         id: package


### PR DESCRIPTION
# Description

Added `--strict` (promotes lint warnings to failures) and a `helm template` render step, which is the key addition for catching templating issues that `helm lint` misses. Both run before packaging.

## Issue Link

Fixes #689 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
