### PR TITLE
feat(lungo): do not panic on non-preferred transport setup failure

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/farm_server.py
@@ -14,6 +14,7 @@ from a2a.types import AgentCard
 from agents.farms.brazil.agent_executor import FarmAgentExecutor
 from agents.farms.brazil.card import AGENT_CARD
 from agntcy_app_sdk.factory import AgntcyFactory
+from agntcy_app_sdk.semantic.a2a.transport_types import normalize_transport
 from config.config import OTEL_SDK_DISABLED
 from dotenv import load_dotenv
 
@@ -29,9 +30,12 @@ async def serve_all_a2a_interfaces(
 ):
     """Serve the Brazil Coffee Farm agent across all A2A transports defined in its AgentCard.
 
-    Creates an AgntcyFactory application session and registers every transport
-    interface declared in the card's ``additional_interfaces``, which include:
-
+    Each advertised interface is started in its own session so a broker that is
+    unavailable at startup (e.g. NATS) cannot abort the others. A startup failure
+    on the card's ``preferred_transport`` is fatal; failures on any other transport
+    are logged and skipped so the agent still comes up on the transports that are
+    healthy.
+    The card's ``additional_interfaces`` typically include:
     - **slimrpc** - point-to-point transport for direct client-agent communication
     - **slim** - SLIM-based group messaging and pub/sub transport
     - **nats** - NATS-based pub/sub transport for broadcasting to multiple subscribers
@@ -46,12 +50,62 @@ async def serve_all_a2a_interfaces(
         agent_card: The ``AgentCard`` describing this agent's capabilities,
             skills, and transport interfaces.
     """
+    interfaces = agent_card.additional_interfaces or []
+    if not interfaces:
+        raise ValueError("agent_card.additional_interfaces is empty; nothing to serve")
 
-    session = factory.create_app_session()
+    preferred = normalize_transport(agent_card.preferred_transport or "")
+    advertised = {normalize_transport(i.transport) for i in interfaces}
+    if preferred and preferred not in advertised:
+        logger.warning(
+            "preferred_transport %r is not advertised in additional_interfaces %s; "
+            "no transport will be treated as required at startup",
+            agent_card.preferred_transport,
+            sorted(advertised),
+        )
 
-    await session.add_a2a_card(agent_card, request_handler).start(keep_alive=False)
+    started = []
+    for interface in interfaces:
+        transport = normalize_transport(interface.transport)
+        is_preferred = bool(preferred) and transport == preferred
+
+        # Serve only this interface in its own session; skipping the other
+        # advertised transports keeps a single failing transport isolated.
+        session = factory.create_app_session()
+        builder = session.add_a2a_card(agent_card, request_handler).with_factory(
+            factory
+        )
+        for other in advertised - {transport}:
+            builder = builder.skip(other)
+
+        try:
+            await builder.start(keep_alive=False)
+        except Exception as exc:
+            if is_preferred:
+                logger.error(
+                    "Preferred transport %r failed to start; shutting down: %s",
+                    interface.transport,
+                    exc,
+                )
+                raise
+            logger.error(
+                "Transport %r failed to start; continuing without it: %s",
+                interface.transport,
+                exc,
+            )
+            continue
+
+        started.append(session)
+        logger.info("Serving %s on %s", interface.transport, interface.url)
+
+    if not started:
+        raise RuntimeError("No transport interfaces could be started")
+
     logger.info("Agent ready")
-    await session.start_all_sessions(keep_alive=True)
+
+    # Keep the process alive; reuse a live session's keep-alive loop so
+    # signal-based graceful shutdown continues to work.
+    await started[0].start_all_sessions(keep_alive=True)
 
 
 async def main():

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/farm_server.py
@@ -14,6 +14,7 @@ from a2a.types import AgentCard
 from agents.farms.colombia.agent_executor import FarmAgentExecutor
 from agents.farms.colombia.card import AGENT_CARD
 from agntcy_app_sdk.factory import AgntcyFactory
+from agntcy_app_sdk.semantic.a2a.transport_types import normalize_transport
 from common.workflow_utils.inflight import register_cleanup_span_processor
 from config.config import OTEL_SDK_DISABLED
 from dotenv import load_dotenv
@@ -34,9 +35,12 @@ async def serve_all_a2a_interfaces(
 ):
     """Serve the Colombia Coffee Farm agent across all A2A transports defined in its AgentCard.
 
-    Creates an AgntcyFactory application session and registers every transport
-    interface declared in the card's ``additional_interfaces``, which include:
-
+    Each advertised interface is started in its own session so a broker that is
+    unavailable at startup (e.g. NATS) cannot abort the others. A startup failure
+    on the card's ``preferred_transport`` is fatal; failures on any other transport
+    are logged and skipped so the agent still comes up on the transports that are
+    healthy.
+    The card's ``additional_interfaces`` typically include:
     - **slimrpc** - point-to-point transport for direct client-agent communication
     - **slim** - SLIM-based group messaging and pub/sub transport
     - **nats** - NATS-based pub/sub transport for broadcasting to multiple subscribers
@@ -51,12 +55,62 @@ async def serve_all_a2a_interfaces(
         agent_card: The ``AgentCard`` describing this agent's capabilities,
             skills, and transport interfaces.
     """
+    interfaces = agent_card.additional_interfaces or []
+    if not interfaces:
+        raise ValueError("agent_card.additional_interfaces is empty; nothing to serve")
 
-    session = factory.create_app_session()
+    preferred = normalize_transport(agent_card.preferred_transport or "")
+    advertised = {normalize_transport(i.transport) for i in interfaces}
+    if preferred and preferred not in advertised:
+        logger.warning(
+            "preferred_transport %r is not advertised in additional_interfaces %s; "
+            "no transport will be treated as required at startup",
+            agent_card.preferred_transport,
+            sorted(advertised),
+        )
 
-    await session.add_a2a_card(agent_card, request_handler).start(keep_alive=False)
+    started = []
+    for interface in interfaces:
+        transport = normalize_transport(interface.transport)
+        is_preferred = bool(preferred) and transport == preferred
+
+        # Serve only this interface in its own session; skipping the other
+        # advertised transports keeps a single failing transport isolated.
+        session = factory.create_app_session()
+        builder = session.add_a2a_card(agent_card, request_handler).with_factory(
+            factory
+        )
+        for other in advertised - {transport}:
+            builder = builder.skip(other)
+
+        try:
+            await builder.start(keep_alive=False)
+        except Exception as exc:
+            if is_preferred:
+                logger.error(
+                    "Preferred transport %r failed to start; shutting down: %s",
+                    interface.transport,
+                    exc,
+                )
+                raise
+            logger.error(
+                "Transport %r failed to start; continuing without it: %s",
+                interface.transport,
+                exc,
+            )
+            continue
+
+        started.append(session)
+        logger.info("Serving %s on %s", interface.transport, interface.url)
+
+    if not started:
+        raise RuntimeError("No transport interfaces could be started")
+
     logger.info("Agent ready")
-    await session.start_all_sessions(keep_alive=True)
+
+    # Keep the process alive; reuse a live session's keep-alive loop so
+    # signal-based graceful shutdown continues to work.
+    await started[0].start_all_sessions(keep_alive=True)
 
 
 async def main():

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/farm_server.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/farm_server.py
@@ -14,6 +14,7 @@ from a2a.types import AgentCard
 from agents.farms.vietnam.agent_executor import FarmAgentExecutor
 from agents.farms.vietnam.card import AGENT_CARD
 from agntcy_app_sdk.factory import AgntcyFactory
+from agntcy_app_sdk.semantic.a2a.transport_types import normalize_transport
 from config.config import OTEL_SDK_DISABLED
 from dotenv import load_dotenv
 
@@ -29,9 +30,12 @@ async def serve_all_a2a_interfaces(
 ):
     """Serve the Vietnam Coffee Farm agent across all A2A transports defined in its AgentCard.
 
-    Creates an AgntcyFactory application session and registers every transport
-    interface declared in the card's ``additional_interfaces``, which include:
-
+    Each advertised interface is started in its own session so a broker that is
+    unavailable at startup (e.g. NATS) cannot abort the others. A startup failure
+    on the card's ``preferred_transport`` is fatal; failures on any other transport
+    are logged and skipped so the agent still comes up on the transports that are
+    healthy.
+    The card's ``additional_interfaces`` typically include:
     - **slimrpc** - point-to-point transport for direct client-agent communication
     - **slim** - SLIM-based group messaging and pub/sub transport
     - **nats** - NATS-based pub/sub transport for broadcasting to multiple subscribers
@@ -46,12 +50,62 @@ async def serve_all_a2a_interfaces(
         agent_card: The ``AgentCard`` describing this agent's capabilities,
             skills, and transport interfaces.
     """
+    interfaces = agent_card.additional_interfaces or []
+    if not interfaces:
+        raise ValueError("agent_card.additional_interfaces is empty; nothing to serve")
 
-    session = factory.create_app_session()
+    preferred = normalize_transport(agent_card.preferred_transport or "")
+    advertised = {normalize_transport(i.transport) for i in interfaces}
+    if preferred and preferred not in advertised:
+        logger.warning(
+            "preferred_transport %r is not advertised in additional_interfaces %s; "
+            "no transport will be treated as required at startup",
+            agent_card.preferred_transport,
+            sorted(advertised),
+        )
 
-    await session.add_a2a_card(agent_card, request_handler).start(keep_alive=False)
+    started = []
+    for interface in interfaces:
+        transport = normalize_transport(interface.transport)
+        is_preferred = bool(preferred) and transport == preferred
+
+        # Serve only this interface in its own session; skipping the other
+        # advertised transports keeps a single failing transport isolated.
+        session = factory.create_app_session()
+        builder = session.add_a2a_card(agent_card, request_handler).with_factory(
+            factory
+        )
+        for other in advertised - {transport}:
+            builder = builder.skip(other)
+
+        try:
+            await builder.start(keep_alive=False)
+        except Exception as exc:
+            if is_preferred:
+                logger.error(
+                    "Preferred transport %r failed to start; shutting down: %s",
+                    interface.transport,
+                    exc,
+                )
+                raise
+            logger.error(
+                "Transport %r failed to start; continuing without it: %s",
+                interface.transport,
+                exc,
+            )
+            continue
+
+        started.append(session)
+        logger.info("Serving %s on %s", interface.transport, interface.url)
+
+    if not started:
+        raise RuntimeError("No transport interfaces could be started")
+
     logger.info("Agent ready")
-    await session.start_all_sessions(keep_alive=True)
+
+    # Keep the process alive; reuse a live session's keep-alive loop so
+    # signal-based graceful shutdown continues to work.
+    await started[0].start_all_sessions(keep_alive=True)
 
 
 async def main():

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/farms/test_serve_all_a2a_interfaces.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/farms/test_serve_all_a2a_interfaces.py
@@ -1,0 +1,152 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the farm servers' fault-tolerant multi-transport serving.
+
+A startup failure on the card's ``preferred_transport`` must be fatal, while
+a failure on any other advertised transport must be logged and skipped so a
+single unavailable broker (e.g. NATS) cannot take the whole agent down.
+
+The three coffee-farm servers (Brazil, Colombia, Vietnam) share the same
+``serve_all_a2a_interfaces`` implementation, so every case is parametrized
+across all three modules.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
+from agntcy_app_sdk.semantic.a2a.transport_types import normalize_transport
+
+FARM_SERVER_MODULES = [
+    "agents.farms.brazil.farm_server",
+    "agents.farms.colombia.farm_server",
+    "agents.farms.vietnam.farm_server",
+]
+
+
+def _make_card(preferred: str = "slim") -> AgentCard:
+    return AgentCard(
+        name="Test Farm",
+        description="test card",
+        version="1.0.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=AgentCapabilities(streaming=True),
+        skills=[AgentSkill(id="s", name="s", description="d", tags=["t"])],
+        preferred_transport=preferred,
+        url="slim://localhost:46357/topic",
+        additional_interfaces=[
+            AgentInterface(transport="slim", url="slim://localhost:46357/topic"),
+            AgentInterface(transport="nats", url="nats://localhost:4222/topic"),
+            AgentInterface(transport="jsonrpc", url="http://0.0.0.0:9999/"),
+        ],
+    )
+
+
+class _FakeBuilder:
+    def __init__(self, session: "_FakeSession", card: AgentCard):
+        self._session = session
+        self._card = card
+        self._skips: set[str] = set()
+
+    def with_factory(self, _factory):
+        return self
+
+    def skip(self, transport_type: str):
+        self._skips.add(normalize_transport(transport_type))
+        return self
+
+    async def start(self, *, keep_alive: bool = False):
+        advertised = {
+            normalize_transport(i.transport)
+            for i in self._card.additional_interfaces
+        }
+        served = advertised - self._skips
+        assert len(served) == 1, f"expected exactly one served transport, got {served}"
+        transport = next(iter(served))
+        self._session.served_transport = transport
+        if transport in self._session._fail_transports:
+            raise RuntimeError(f"{transport} broker unavailable")
+
+
+class _FakeSession:
+    def __init__(self, fail_transports: set[str]):
+        self._fail_transports = fail_transports
+        self.served_transport: str | None = None
+        self.start_all_called_with: bool | None = None
+
+    def add_a2a_card(self, card: AgentCard, _handler):
+        return _FakeBuilder(self, card)
+
+    async def start_all_sessions(self, keep_alive: bool = False):
+        self.start_all_called_with = keep_alive
+
+
+class _FakeFactory:
+    def __init__(self, fail_transports: set[str]):
+        self._fail_transports = fail_transports
+        self.sessions: list[_FakeSession] = []
+
+    def create_app_session(self) -> _FakeSession:
+        session = _FakeSession(self._fail_transports)
+        self.sessions.append(session)
+        return session
+
+
+@pytest.fixture
+def patch_factory(monkeypatch):
+    def _install(module_name: str, fail_transports: set[str]) -> _FakeFactory:
+        module = importlib.import_module(module_name)
+        fake = _FakeFactory(set(fail_transports))
+        monkeypatch.setattr(module, "factory", fake)
+        return module, fake
+
+    return _install
+
+
+@pytest.mark.parametrize("module_name", FARM_SERVER_MODULES)
+async def test_non_preferred_transport_failure_is_tolerated(patch_factory, module_name):
+    # NATS is down; SLIM (preferred) and jsonrpc are healthy.
+    module, fake = patch_factory(module_name, {"natspatterns"})
+    card = _make_card(preferred="slim")
+
+    # Must NOT raise even though the NATS interface fails to start.
+    await module.serve_all_a2a_interfaces(object(), card)
+
+    # One session created per advertised interface, in card order.
+    assert [s.served_transport for s in fake.sessions] == [
+        "slimpatterns",
+        "natspatterns",
+        "jsonrpc",
+    ]
+
+    # The keep-alive loop is entered on the first healthy session (SLIM),
+    # never on the failed NATS session.
+    slim_session, nats_session, jsonrpc_session = fake.sessions
+    assert slim_session.start_all_called_with is True
+    assert nats_session.start_all_called_with is None
+    assert jsonrpc_session.start_all_called_with is None
+
+
+@pytest.mark.parametrize("module_name", FARM_SERVER_MODULES)
+async def test_preferred_transport_failure_is_fatal(patch_factory, module_name):
+    # SLIM is the preferred transport and it is down -> must crash.
+    module, _fake = patch_factory(module_name, {"slimpatterns"})
+    card = _make_card(preferred="slim")
+
+    with pytest.raises(RuntimeError, match="broker unavailable"):
+        await module.serve_all_a2a_interfaces(object(), card)
+
+
+@pytest.mark.parametrize("module_name", FARM_SERVER_MODULES)
+async def test_all_transports_failing_raises(patch_factory, module_name):
+    # Preferred is not advertised, so nothing is "required"; but if every
+    # transport fails to start the agent still cannot serve -> raise.
+    module, _fake = patch_factory(module_name, {"slimpatterns", "natspatterns", "jsonrpc"})
+    card = _make_card(preferred="unknown-transport")
+
+    with pytest.raises(RuntimeError, match="No transport interfaces could be started"):
+        await module.serve_all_a2a_interfaces(object(), card)


### PR DESCRIPTION
# Description

This PR is a follow up on https://github.com/agntcy/coffeeAgntcy/pull/717 but for Lungo's farm agents.

The reasoning and caveats are the same as the ones outlined in the Corto PR and its associated issue.

###  Tests

I tested this locally with docker-compose. In a setup where SLIM is preferred and present but the NATS server is missing, the `colombia-farm-server`, `brazil-farm-server`, `vietnam-farm-server` Lungo container logs show:
```
... ... ...
colombia-farm-server   | 2026-07-27T17:21:02.623472Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
vietnam-farm-server    | 2026-07-27T17:21:04.236505Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
colombia-farm-server   | 2026-07-27T17:21:04.647560Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
brazil-farm-server     | 2026-07-27T17:21:04.648007Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
vietnam-farm-server    | 2026-07-27T17:21:06.253436Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
brazil-farm-server     | 2026-07-27T17:21:06.660533Z [error    ] NATS error: [Errno -2] Name or service not known [agntcy_app_sdk.transport.nats.transport]
... ... ...
brazil-farm-server     | 2026-07-27T17:21:57.034320Z [error    ] Transport 'nats' failed to start; continuing without it: nats: no servers available for connection [__main__]
brazil-farm-server     | 2026-07-27T17:21:57.037182Z [info     ] Serving interface              [agntcy_app_sdk.semantic.a2a.server.card_bootstrap] host=0.0.0.0 port=9999 session_id=http-2 transport=jsonrpc
brazil-farm-server     | 2026-07-27T17:21:57.142737Z [info     ] Serving jsonrpc on http://0.0.0.0:9999 [__main__]
brazil-farm-server     | 2026-07-27T17:21:57.142856Z [info     ] Agent ready                    [__main__]
... ... ...
colombia-farm-server   | 2026-07-27T17:21:57.033995Z [error    ] Transport 'nats' failed to start; continuing without it: nats: no servers available for connection [__main__]
colombia-farm-server   | 2026-07-27T17:21:57.037133Z [info     ] Serving interface              [agntcy_app_sdk.semantic.a2a.server.card_bootstrap] host=0.0.0.0 port=9998 session_id=http-2 transport=jsonrpc
colombia-farm-server   | 2026-07-27T17:21:57.134185Z [info     ] Serving jsonrpc on http://0.0.0.0:9998 [__main__]
colombia-farm-server   | 2026-07-27T17:21:57.134385Z [info     ] Agent ready
... ... ...
vietnam-farm-server    | 2026-07-27T17:21:58.656374Z [error    ] Transport 'nats' failed to start; continuing without it: nats: no servers available for connection [__main__]
vietnam-farm-server    | 2026-07-27T17:21:58.658219Z [info     ] Serving interface              [agntcy_app_sdk.semantic.a2a.server.card_bootstrap] host=0.0.0.0 port=9997 session_id=http-2 transport=jsonrpc
vietnam-farm-server    | 2026-07-27T17:21:58.731309Z [info     ] Serving jsonrpc on http://0.0.0.0:9997 [__main__]
vietnam-farm-server    | 2026-07-27T17:21:58.731402Z [info     ] Agent ready                    [__main__]
... ... ...
```

## Issue Link

Fixes #719 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
