### PR TITLE
fix(corto,lungo): fix transport env var lazy load

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/common/a2a_transport_config.py
+++ b/coffeeAGNTCY/coffee_agents/corto/common/a2a_transport_config.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import os
 
+import config.config
 from agntcy_app_sdk.semantic.a2a import (
     ClientConfig,
     NatsTransportConfig,
     SlimTransportConfig,
 )
-from config.config import NATS_SERVER, SLIM_SERVER
 
 
 def build_a2a_client_config(
@@ -31,14 +31,14 @@ def build_a2a_client_config(
         raise ValueError("SLIM_SHARED_SECRET environment variable must be set")
 
     slim_config = SlimTransportConfig(
-        endpoint=f"http://{SLIM_SERVER}",
+        endpoint=f"http://{config.config.SLIM_SERVER}",
         name=f"{namespace}/{group}/{agent_name}",
         shared_secret_identity=slim_shared_secret,
     )
     if include_nats:
         return ClientConfig(
             slim_config=slim_config,
-            nats_config=NatsTransportConfig(endpoint=NATS_SERVER),
+            nats_config=NatsTransportConfig(endpoint=config.config.NATS_SERVER),
         )
     return ClientConfig(
         slim_config=slim_config,

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/card.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/brazil/card.py
@@ -3,8 +3,8 @@
 
 import os
 
+import config.config
 from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
-from config.config import NATS_SERVER, SLIM_SERVER
 
 PORT = os.getenv("FARM_AGENT_PORT", "9999")
 AGENT_ID = "brazil_coffee_farm"
@@ -32,15 +32,17 @@ AGENT_CARD = AgentCard(
     skills=[AGENT_SKILL],
     supportsAuthenticatedExtendedCard=False,
     preferred_transport="slim",
-    url=f"slim://{SLIM_SERVER}/lungo/agents/{AGENT_ID}",
+    url=f"slim://{config.config.SLIM_SERVER}/lungo/agents/{AGENT_ID}",
     additional_interfaces=[
         # slim-based group messaging and pub/sub transport
         AgentInterface(
-            transport="slim", url=f"slim://{SLIM_SERVER}/lungo/agents/{AGENT_ID}"
+            transport="slim",
+            url=f"slim://{config.config.SLIM_SERVER}/lungo/agents/{AGENT_ID}",
         ),
         # nats-based pub/sub transport for broadcasting to multiple subscriber
         AgentInterface(
-            transport="nats", url=f"nats://{NATS_SERVER}/lungo/agents/{AGENT_ID}"
+            transport="nats",
+            url=f"nats://{config.config.NATS_SERVER}/lungo/agents/{AGENT_ID}",
         ),
         # jsonrpc endpoint for direct client-agent communication over http
         AgentInterface(transport="jsonrpc", url=f"http://0.0.0.0:{PORT}"),

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/card.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/card.py
@@ -3,8 +3,8 @@
 
 import os
 
+import config.config
 from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
-from config.config import NATS_SERVER, SLIM_SERVER
 
 PORT = os.getenv("FARM_AGENT_PORT", "9998")
 AGENT_ID = "colombia_coffee_farm"
@@ -32,17 +32,17 @@ AGENT_CARD = AgentCard(
     skills=[AGENT_SKILL],
     supportsAuthenticatedExtendedCard=False,
     preferred_transport="slim",
-    url=f"slim://{SLIM_SERVER}/lungo/agents/colombia_coffee_farm",
+    url=f"slim://{config.config.SLIM_SERVER}/lungo/agents/colombia_coffee_farm",
     additional_interfaces=[
         # slim-based group messaging and pub/sub transport
         AgentInterface(
             transport="slim",
-            url=f"slim://{SLIM_SERVER}/lungo/agents/colombia_coffee_farm",
+            url=f"slim://{config.config.SLIM_SERVER}/lungo/agents/colombia_coffee_farm",
         ),
         # nats-based pub/sub transport for broadcasting to multiple subscriber
         AgentInterface(
             transport="nats",
-            url=f"nats://{NATS_SERVER}/lungo/agents/colombia_coffee_farm",
+            url=f"nats://{config.config.NATS_SERVER}/lungo/agents/colombia_coffee_farm",
         ),
         # jsonrpc endpoint for direct client-agent communication over http
         AgentInterface(transport="jsonrpc", url=f"http://0.0.0.0:{PORT}"),

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/card.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/vietnam/card.py
@@ -3,8 +3,8 @@
 
 import os
 
+import config.config
 from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
-from config.config import NATS_SERVER, SLIM_SERVER
 
 PORT = os.getenv("FARM_AGENT_PORT", "9997")
 AGENT_ID = "vietnam_coffee_farm"
@@ -32,15 +32,17 @@ AGENT_CARD = AgentCard(
     skills=[AGENT_SKILL],
     supportsAuthenticatedExtendedCard=False,
     preferred_transport="slim",
-    url=f"slim://{SLIM_SERVER}/lungo/agents/{AGENT_ID}",
+    url=f"slim://{config.config.SLIM_SERVER}/lungo/agents/{AGENT_ID}",
     additional_interfaces=[
         # slim-based group messaging and pub/sub transport
         AgentInterface(
-            transport="slim", url=f"slim://{SLIM_SERVER}/lungo/agents/{AGENT_ID}"
+            transport="slim",
+            url=f"slim://{config.config.SLIM_SERVER}/lungo/agents/{AGENT_ID}",
         ),
         # nats-based pub/sub transport for broadcasting to multiple subscriber
         AgentInterface(
-            transport="nats", url=f"nats://{NATS_SERVER}/lungo/agents/{AGENT_ID}"
+            transport="nats",
+            url=f"nats://{config.config.NATS_SERVER}/lungo/agents/{AGENT_ID}",
         ),
         # jsonrpc endpoint for direct client-agent communication over http
         AgentInterface(transport="jsonrpc", url=f"http://0.0.0.0:{PORT}"),

--- a/coffeeAGNTCY/coffee_agents/lungo/common/a2a_transport_config.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/a2a_transport_config.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import os
 
+import config.config
 from agntcy_app_sdk.semantic.a2a import (
     ClientConfig,
     NatsTransportConfig,
     SlimTransportConfig,
 )
-from config.config import NATS_SERVER, SLIM_SERVER
 
 
 def build_a2a_client_config(
@@ -31,14 +31,14 @@ def build_a2a_client_config(
         raise ValueError("SLIM_SHARED_SECRET environment variable must be set")
 
     slim_config = SlimTransportConfig(
-        endpoint=f"http://{SLIM_SERVER}",
+        endpoint=f"http://{config.config.SLIM_SERVER}",
         name=f"{namespace}/{group}/{agent_name}",
         shared_secret_identity=slim_shared_secret,
     )
     if include_nats:
         return ClientConfig(
             slim_config=slim_config,
-            nats_config=NatsTransportConfig(endpoint=NATS_SERVER),
+            nats_config=NatsTransportConfig(endpoint=config.config.NATS_SERVER),
         )
     return ClientConfig(
         slim_config=slim_config,


### PR DESCRIPTION
# Description

The transform env loading expected the env vars to be preloaded because it selectively imported the loaded env vars instead of the full config module that would do the dotenv loading.
This affected local runs.
I changed it so we are loading the full module so dotenv is loaded.
We have to revise the config interface to make this less error-prone in the future.

## Issue Link

Link the primary issue in the PR description using `#` (e.g. `Fixes #123`). This enables two‑way linking.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
