### PR TITLE
docs: add origins to agentic pattern references

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY workflow introduced in [PR #570](https://github.com/agntcy/coffeeAgntcy/pull/570) and conceptually based on **Routing**
+for agent discovery from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Recruiter-style discovery** is a general pattern for **on-demand selection** in an ecosystem of many possible
 **agents, services, or tools**: one **recruiter** (or selector) turns a vague ask into **structured lookup**,
 **ranking**, and a **small, explainable answer**-who exists, what they offer, whether they are eligible-then hands

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/adversarial_review_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/adversarial_review_agents.md
@@ -17,6 +17,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Debate / Critic**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Adversarial review** is a way to force a **challenger voice** before expensive commitments: risk against optimism,
 policy against shortcuts, so decisions survive contact with someone whose role is to **disagree constructively**. The
 goal is not to stall forever, but to ensure assumptions and evidence are stress-tested while the trade space is still

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent-to-system_bridge.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent-to-system_bridge.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Tool Use**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 An **agent-to-system bridge** lets agents **invoke trusted external systems**-enterprise planning tools, emissions
 services, tariff or rate engines-as **first-class evidence** in a decision, instead of relying on prose memory or
 guessed numbers. The pattern treats integrations as part of the reasoning substrate: plans and arguments are expected to

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent_workflow_chain.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent_workflow_chain.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Prompt Chaining**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Agent workflow chain** means breaking a **complex goal into ordered agent steps**, each enriching **shared state** so
 later specialists inherit constraints instead of rediscovering what earlier steps already established. The shared record
 might hold quality floors, commercial bands, diligence flags, or other structured facts that every hop must respect.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/approval_gate_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/approval_gate_agent.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Human-in-the-Loop**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 An **approval gate** pauses automated flow when **stakes exceed autonomy**: bulk purchases, novel counterparties, or
 exceptions that would be painful if executed quietly. The pattern packages **what** is proposed, **why** it is
 justified, which **policy** applies, and what **changed** since the last checkpoint, then waits for **non-repudiable

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/composable_agent_service.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/composable_agent_service.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Agent as a Service**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Composable agent service** packages an agent like a **product**: discoverable in a catalog, **versioned interfaces**,
 declared expectations for reliability or latency-so procurement, operations, and reporting **reuse** the same capability
 instead of forking nearly identical copies that drift apart.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/coordinator_+_worker_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/coordinator_+_worker_agents.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Planner–Executor**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Coordinator and worker** arrangements **separate planning from execution**: one agent keeps the work breakdown,
 sequencing, and completion story while **specialists** perform **bounded slices** (warehouse, customs, carriers, or
 similar) without each owning the full saga end to end.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/decentralized_consensus_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/decentralized_consensus_agents.md
@@ -22,6 +22,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Swarm**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Decentralized consensus** aims to **reach agreement without a single permanent hub**: local agents exchange beliefs
 and evidence until a forecast, allocation, or similar outcome **converges** under explicit stopping rules. No one node
 is the eternal oracle; instead, the process is defined by **what may be published**, **how updates merge**, and **when

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/directory-based_dispatch.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/directory-based_dispatch.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Routing**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Directory-based dispatch** chooses the **next specialist from intent and context** instead of hard-wiring a single
 static path. When signals, tags, or confidence shift, a different expert may be the right callee; the pattern makes that
 **explicit and explainable** rather than a hidden branch table.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/economic_constraint_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/economic_constraint_agent.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Cost-Aware Agent**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 An **economic constraint agent** optimizes under **explicit budgets**-cost, time, carbon, or other currencies-so
 trade-offs are stated in the same units operations and finance already use. Decisions expose **Pareto fronts** (better
 on one axis, worse on another) instead of pretending a single fake optimum exists when objectives genuinely conflict.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/end-to-end_telemetry.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/end-to-end_telemetry.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Logging & Observability**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **End-to-end telemetry** traces **decisions and interactions across the whole chain**-from early inputs through
 fulfillment-so **correlation identifiers** stitch agent steps to real business objects and money movements. The point is
 continuity: an incident or dispute can be walked from origin to outcome without broken narrative.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/event_ledger_episodic_memory.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/event_ledger_episodic_memory.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Episodic Memory**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 An **event ledger** (episodic memory for agents) appends a **faithful history of decisions**-prompts, tool calls, policy
 checks-so teams can **replay** timelines after failure and see **which step** introduced a bad assumption. It is not a
 marketing narrative; it is an ordered record suitable for audit and debugging.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/feedback_loop.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/feedback_loop.md
@@ -19,6 +19,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Learning from Feedback**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 A **feedback loop** folds **human or system feedback**-scores, disputes, delivery outcomes-back into **routing and
 selection policy** so the next cycle behaves less like amnesia. Learning is explicit: feedback carries **attribution**
 (which supplier, which lane, which agent version), aggregates into features or parameters, and passes through **gates**

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY workflow introduced in [PR #570](https://github.com/agntcy/coffeeAgntcy/pull/570) and conceptually based on
+**Multi-Agent Collaboration** from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Group messaging and coordination** is a general arrangement when **several specialists** must **see the same
 conversation**, **answer one another**, and still have **one accountable place** that keeps order, permissions, and
 progress toward a shared goal. A **supervisor or moderator** opens a **shared channel**; **members** join as first-class

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/orchestrator_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/orchestrator_agent.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Supervisor / Manager**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 A **top-level orchestrator** coordinates, monitors, and governs **many workflows at once**: it resolves conflicts,
 watches health, and keeps **global policy** from dissolving into regional habit. It does not replace every local
 specialist; it provides a **single place** that sees parallel subgraphs (regions, lanes, product lines), merges status,

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/peer_group.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/peer_group.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY pattern abstraction introduced in [commit `4892cdc4`](https://github.com/agntcy/coffeeAgntcy/commit/4892cdc451ae1be3ae405bb31324cb1f61b94637) and conceptually based on
+**Multi-Agent Collaboration** from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 > **TODO** - full pattern-level write-up. This is a minimal stub so the pattern reference library has reachable
 > reference material for the **Peer Group** pattern; a follow-up issue will replace this with the proper authored
 > doc.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/performance_scoring_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/performance_scoring_agent.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Evaluation Agent**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 A **performance scoring agent** measures how well agentic runs meet **declared KPIs**-cost, time, carbon, quality, or
 whatever leadership actually names-so improvement budgets go to what **measurably** works, not to whoever tells the
 prettiest story. Scores are tied to **transparent formulas** and comparable inputs.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/policy-enforced_execution.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/policy-enforced_execution.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Guardrails**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Policy-enforced execution** **blocks or conditions actions** against explicit **trust and ethics rules**-labor,
 sanctions, sustainability, or whatever the company publishes as non-negotiable-so automated enthusiasm never overrides
 what the firm refuses to sign. “The model wanted to” is not a policy exception.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
@@ -23,6 +23,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY workflow introduced in [PR #570](https://github.com/agntcy/coffeeAgntcy/pull/570) and conceptually based on
+**Supervisor / Manager** from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Supervisor and workers** is a general arrangement for multi-agent work: **one coordinator** owns the end-to-end
 story-what to ask next, when to branch, how to merge or compare results, and where policy and retries live-while
 **specialist agents** each do a **bounded slice** (one region, one data source, one tool) and return answers upward.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe_streaming.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe_streaming.md
@@ -23,6 +23,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY streaming workflow introduced in [PR #570](https://github.com/agntcy/coffeeAgntcy/pull/570) and conceptually based on
+**Supervisor / Manager** from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Supervisor and workers** is a general arrangement for multi-agent work: **one coordinator** owns the end-to-end
 story-what to ask next, when to branch, how to merge or compare results, and where policy and retries live-while
 **specialist agents** each do a **bounded slice** (one region, one data source, one tool) and return answers upward.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/recruiter.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/recruiter.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY pattern abstraction introduced in [commit `4892cdc4`](https://github.com/agntcy/coffeeAgntcy/commit/4892cdc451ae1be3ae405bb31324cb1f61b94637) and conceptually based on
+**Routing** from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 > **TODO** - full pattern-level write-up. This is a minimal stub so the pattern reference library has reachable
 > reference material for the **Recruiter** pattern; a follow-up issue will replace this with the proper authored
 > doc.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/resilience_&_re-routing.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/resilience_&_re-routing.md
@@ -20,6 +20,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Fallback / Recovery**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Resilience and re-routing** recovers from failure by **switching agents or paths**: discover alternates, compensate
 partial work, and keep customer promises from collapsing because one carrier or one integration had a bad day. Recovery
 is **designed**, not heroic improvisation.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/secure_group_collaboration.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/secure_group_collaboration.md
@@ -20,6 +20,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Multi-Agent Collaboration**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 **Secure group collaboration** lets **several agents coordinate inside a trusted boundary**: authenticated membership,
 scoped messages, and attributable speech, so pricing and allocation feel like **intra-alliance work**, not an open
 public forum. Security and transport define **who may read**, **who may write**, and **what may cross the boundary**.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/self-evaluation_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/self-evaluation_agent.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Reflection**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 A **self-evaluation** (reflection) pattern compares **past outcomes** to intent-forecasts versus arrivals, routing
 versus reality-and proposes **bounded improvements** to prompts, policies, or weights under **human governance**. The
 agent reads telemetry and business results, compares them to what was supposed to happen, and outputs **reviewable

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/sense-decide-act_loop.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/sense-decide-act_loop.md
@@ -19,6 +19,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **ReAct**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 The **sense-decide-act loop** runs **observe → act → re-evaluate** in cycles so plans update when the world moves-ports
 stall, carriers roll bookings, quality signals shift-instead of treating the first guess as permanent truth.
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/session_context_buffer.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/session_context_buffer.md
@@ -21,6 +21,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Short-Term Memory**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 A **session context buffer** is a **temporary, shared scratchpad** for one negotiation or task-bids, floors, deadlines,
 last counters-without polluting long-term catalogs or treating ephemeral chatter as permanent truth. It answers: what is
 the **current** state of this deal for everyone who is allowed in the room?

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_agent_memory.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_agent_memory.md
@@ -24,6 +24,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY pattern introduced in [PR #711](https://github.com/agntcy/coffeeAgntcy/pull/711) and adapted from the **blackboard model**;
+see H. Penny Nii's [*The Blackboard Model of Problem Solving and the Evolution of Blackboard Architectures*](https://doi.org/10.1609/aimag.v7i2.537).
+
 **Shared agent memory** gives multiple agents a **common place to read and write facts** about the work in progress-
 task state, commitments, open questions, partial results-so they **build on each other's contributions** instead of
 re-asking the same questions or re-sending the same data in every message.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_knowledge_store.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_knowledge_store.md
@@ -18,6 +18,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** **Long-Term Memory**, as described in Antonio Gulli's
+[*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 A **shared knowledge store** **persists knowledge across tasks and time**-yield history, supplier reliability, settled
 prices-so agents query **curated records** instead of re-scraping the world on every run. Long-lived facts live in one
 governed place with keys, versions, and provenance.

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/supervisor.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/supervisor.md
@@ -23,6 +23,9 @@ graph TD
 
 ## Pattern
 
+**Origin:** CoffeeAGNTCY pattern abstraction introduced in [commit `4892cdc4`](https://github.com/agntcy/coffeeAgntcy/commit/4892cdc451ae1be3ae405bb31324cb1f61b94637) and conceptually based on
+**Supervisor / Manager** from Antonio Gulli's [*Agentic Design Patterns*](https://www.google.com/books/edition/Agentic_Design_Patterns/5Z6TEQAAQBAJ).
+
 > **TODO** - full pattern-level write-up. This is a minimal stub so the pattern reference library has reachable
 > reference material for the **Supervisor** pattern; a follow-up issue will replace this with the proper authored
 > doc.


### PR DESCRIPTION
# Description

Adds origin attribution to every agentic pattern reference document under:

`coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/`

This change:

* Maps the 21 canonical AGNTCY patterns to their corresponding origins from Antonio Gulli's *Agentic Design Patterns*.
* Documents the CoffeeAGNTCY provenance of project-specific workflows and pattern abstractions.
* References the blackboard model as the conceptual foundation for Shared Agent Memory.
* Uses a consistent `Origin` field across all 29 pattern documents.

## Testing

* Parsed and validated all 29 pattern documents through `load_parsed_workflow_documentation`.
* Verified that each document contains exactly one `Origin` attribution.
* Verified that all relative Markdown links resolve.
* Ran the agentic-workflows API unit tests:

```text
90 passed in 4.31s
```

* `git diff --check` passes.

## Issue Link

Resolves #724

## Type of Change

* [ ] Bugfix
* [ ] New Feature
* [ ] Breaking Change
* [ ] Refactor
* [x] Documentation
* [ ] Other

## Checklist

* [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md).
* [x] Existing issues have been referenced where applicable.
* [x] I have verified this change is not present in other open pull requests.
* [x] Functionality is documented.
* [x] All code style checks pass.
* [x] Relevant automated tests pass.
* [x] All documentation links added by this change were validated.
