### PR TITLE
fix(ui): increase chat header touch target

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatHeader.test.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatHeader.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import { ThemeProvider } from "@open-ui-kit/core"
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ComponentProps } from "react"
+import { describe, expect, it, vi } from "vitest"
+import ChatHeader from "./ChatHeader"
+
+const renderHeader = (props: ComponentProps<typeof ChatHeader> = {}) =>
+  render(
+    <ThemeProvider>
+      <ChatHeader {...props} />
+    </ThemeProvider>,
+  )
+
+describe("ChatHeader", () => {
+  it("renders no button when onClearConversation is not provided", () => {
+    renderHeader()
+
+    expect(
+      screen.queryByRole("button", { name: "Clear conversation" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("invokes onClearConversation when the clear button is clicked", () => {
+    const onClearConversation = vi.fn()
+
+    renderHeader({ onClearConversation })
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear conversation" }))
+    expect(onClearConversation).toHaveBeenCalledOnce()
+  })
+
+  it("gives the clear conversation button a >=44x44 touch target", () => {
+    renderHeader({ onClearConversation: vi.fn() })
+
+    const button = screen.getByRole("button", { name: "Clear conversation" })
+    const { width, height } = getComputedStyle(button)
+
+    expect(parseFloat(width)).toBeGreaterThanOrEqual(44)
+    expect(parseFloat(height)).toBeGreaterThanOrEqual(44)
+  })
+})

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatHeader.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatHeader.tsx
@@ -12,9 +12,11 @@ import { iconGlyphFillSx } from "@/utils/iconGlyphFill"
 
 function chatHeaderIconButtonSx(theme: Theme) {
   return {
-    width: 32,
-    height: 32,
-    minWidth: 32,
+    // Use the issue's recommended 44x44 touch target while keeping the icon
+    // at its existing visual size.
+    width: 44,
+    height: 44,
+    minWidth: 44,
     padding: "6px",
     borderRadius: theme.shape.borderRadius,
     background: "none",


### PR DESCRIPTION
# Description

Increase the Lungo chat header clear-conversation button's clickable area from 32×32px to 44×44px while preserving the existing icon size and visual styling.

This addresses the remaining actionable part of issue #423. The issue's separate `ChatArea` cleanup is no longer applicable because the redundant `w-auto w-full` classes were removed during the later Open UI Kit migration.

A focused `ChatHeader` test now verifies:

- no clear button is rendered without a handler
- clicking the clear button invokes the callback
- the rendered touch target is at least 44×44px

## Issue Link

Fixes #423

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Verification

From `coffeeAGNTCY/coffee_agents/lungo/frontend`:

```bash
npx vitest run src/components/Chat/ChatHeader.test.tsx
```

Result: 3 tests passed.

```bash
npm run check
```

Result:

- lint passed
- formatting check passed
- TypeScript check passed
- 273 tests passed across 31 test files

Also verified:

```bash
git diff --check
```

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
