### PR TITLE
fix: trigger python tests on PRs and push events

### DIFF
--- a/.github/workflows/test-subprojects-reusable.yaml
+++ b/.github/workflows/test-subprojects-reusable.yaml
@@ -116,7 +116,7 @@ jobs:
             test_corto=true
             test_lungo=true
             test_recruiter=true
-          elif [[ "${{ github.event_name }}" == "workflow_call" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             test_corto=${{ inputs.test_corto }}
             test_lungo=${{ inputs.test_lungo }}
             test_recruiter=${{ inputs.test_recruiter }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,9 +100,14 @@ jobs:
   subprojects-to-test:
     uses: ./.github/workflows/test-subprojects-reusable.yaml
     with:
-      test_corto: ${{ inputs.test_corto }}
-      test_lungo: ${{ inputs.test_lungo }}
-      test_recruiter: ${{ inputs.test_recruiter }}
+      # `inputs` only exists for workflow_call / workflow_dispatch; on push and
+      # pull_request it is empty, so these render to '' (invalid for the boolean
+      # inputs). `|| false` coerces them to a valid boolean. The reusable workflow
+      # ignores these values on push/pull_request anyway (it branches on
+      # github.event_name), so `false` here only ever applies to dispatch/call.
+      test_corto: ${{ inputs.test_corto || false }}
+      test_lungo: ${{ inputs.test_lungo || false }}
+      test_recruiter: ${{ inputs.test_recruiter || false }}
 
   tests-corto:
     name: tests / corto

--- a/coffeeAGNTCY/coffee_agents/corto/docker-compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/corto/docker-compose.yaml
@@ -11,7 +11,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/corto-farm:latest
     container_name: farm-server
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - FARM_AGENT_HOST=farm-server
       - FARM_AGENT_PORT=9999
@@ -59,7 +60,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/corto-exchange:latest
     container_name: exchange-server-corto
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - FARM_AGENT_HOST=farm-server
       - FARM_AGENT_PORT=9999

--- a/coffeeAGNTCY/coffee_agents/corto/tests/integration/conftest.py
+++ b/coffeeAGNTCY/coffee_agents/corto/tests/integration/conftest.py
@@ -93,8 +93,8 @@ def setup_transports():
     _startup_nats()
 
 def setup_observability():
-    _startup_otel_collector()
     _startup_clickhouse()
+    _startup_otel_collector()
     _startup_grafana()
 
 def setup_identity():

--- a/coffeeAGNTCY/coffee_agents/lungo/docker-compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/docker-compose.yaml
@@ -17,7 +17,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/brazil-farm:latest
     container_name: brazil-farm-server
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - FARM_AGENT_HOST=brazil-farm-server
@@ -49,7 +50,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/colombia-farm:latest
     container_name: colombia-farm-server
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - FARM_AGENT_HOST=colombia-farm-server
@@ -83,7 +85,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/vietnam-farm:latest
     container_name: vietnam-farm-server
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - FARM_AGENT_HOST=vietnam-farm-server
@@ -148,7 +151,8 @@ services:
       # Mount local git metadata so /build/info can derive latest tag/date in dev
       - ../../../.git:/app/.git:ro
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - FARM_AGENT_HOST=farm-server
@@ -186,7 +190,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/agentic-workflows-api:latest
     container_name: agentic-workflows-api
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - PORT=9105
@@ -207,7 +212,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/lungo-ui:latest
     container_name: lungo-ui
     env_file:
-      - frontend/.env
+      - path: .env
+        required: true
     environment:
       - TZ=UTC
       - VITE_AGENTIC_WORKFLOWS_API_KEY=${WORKFLOW_API_KEY:?WORKFLOW_API_KEY must be set in .env}
@@ -317,7 +323,8 @@ services:
     volumes:
       - ./config/docker/otel/:/etc/otel
     env_file:
-      - .env
+      - path: .env
+        required: false
     command: ["--config", "/etc/otel/otel-collector-config.yaml"]
 
   grafana:
@@ -473,7 +480,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/logistics-supervisor:latest
     container_name: logistics-supervisor
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - DEFAULT_MESSAGE_TRANSPORT=SLIM # Do not change. SLIM is required for group conversation.
@@ -541,7 +549,8 @@ services:
     image: ghcr.io/agntcy/dir-apiserver:v1.0.0
     container_name: dir-api-server
     env_file:
-      - ./config/docker/dir/apiserver.env
+      - path: ./config/docker/dir/apiserver.env
+        required: true
     ports:
       - 8888:8888
     depends_on:
@@ -628,7 +637,8 @@ services:
     image: ghcr.io/agntcy/coffee-agntcy/recruiter:latest
     container_name: recruiter
     env_file:
-      - .env
+      - path: .env
+        required: false
     depends_on:
       dir-api-server:
         condition: service_started
@@ -665,7 +675,8 @@ services:
       # Mount local git metadata so /build/info can derive latest tag/date in dev
       - ../../../.git:/app/.git:ro
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - TZ=UTC
       - RECRUITER_AGENT_URL=http://recruiter:8881

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
@@ -153,6 +153,8 @@ Returns the full markdown source for a category reference doc (from [`docs/categ
 }
 ```
 
+Returns `404` (`ApplicationError` body) for an unknown category display name or when no markdown file maps to it.
+
 ### `GET /agentic-workflows/` - list workflows
 
 Returns the workflows in the catalog as a **map keyed by workflow name**. Optional repeated query parameters filter the result:

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/api/generated/agenticWorkflows.openapi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/api/generated/agenticWorkflows.openapi.ts
@@ -845,13 +845,7 @@ export interface operations {
                     "application/json": components["schemas"]["PatternCategoryDocumentationResponse"];
                 };
             };
-            /** @description Category documentation not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+            404: components["responses"]["NotFound"];
         };
     };
     listAgenticWorkflows: {

--- a/coffeeAGNTCY/coffee_agents/lungo/schema/openapi/paths/agentic-workflows.yaml
+++ b/coffeeAGNTCY/coffee_agents/lungo/schema/openapi/paths/agentic-workflows.yaml
@@ -115,7 +115,7 @@ paths:
               schema:
                 $ref: ../components/schemas.yaml#/components/schemas/PatternCategoryDocumentationResponse
         "404":
-          description: Category documentation not found
+          $ref: ../components/schemas.yaml#/components/responses/NotFound
 
   /agentic-workflows/:
     get:

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/integration/helpers/docker_helpers.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/integration/helpers/docker_helpers.py
@@ -138,7 +138,7 @@ def _container_id(files: List[str], service: str) -> str:
     if res.returncode == 0 and cid:
         return cid
 
-    print(f"\nFailed to find container ID for service '{service}\n")
+    print(f"\nFailed to find container ID for service '{service}'\n")
     ps_out = subprocess.run(
         _compose_cmd(files) + ["ps", "--format", "table"],
         capture_output=True, text=True, cwd=PROJECT_DIR

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/integration/test_auction.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/integration/test_auction.py
@@ -5,8 +5,46 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agents.supervisors.auction.graph.a2a_retry import TransportTimeoutError
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import Runnable
 
 from tests.integration._auction_helpers import TRANSPORT_MATRIX, response_has_inventory_amount
+
+
+class _FakeStructuredRunnable(Runnable):
+    """Stand-in for ``get_llm(...).with_structured_output(...)`` returning a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def invoke(self, input, config=None, **kwargs):
+        return self._value
+
+    async def ainvoke(self, input, config=None, **kwargs):
+        return self._value
+
+
+class _FakeRoutingLLM(Runnable):
+    """Minimal ``get_llm()`` replacement so tests need no real LLM provider.
+
+    - Used as a pipe target (``prompt | llm``) it returns a fixed routing ``AIMessage``.
+    - ``.with_structured_output(schema, ...)`` yields a runnable returning
+      ``schema(should_continue=False, ...)`` so the reflection node routes to END.
+    """
+
+    def __init__(self, route: str):
+        self._route = route
+
+    def invoke(self, input, config=None, **kwargs):
+        return AIMessage(content=self._route)
+
+    async def ainvoke(self, input, config=None, **kwargs):
+        return AIMessage(content=self._route)
+
+    def with_structured_output(self, schema, **kwargs):
+        return _FakeStructuredRunnable(
+            schema(should_continue=False, reason="stubbed: no real LLM in this test"),
+        )
 
 
 @pytest.mark.parametrize(
@@ -34,8 +72,16 @@ def test_auction_a2a_timeout_returns_user_visible_error(auction_supervisor_clien
 
     Stub a2a_client_factory.create so execution reaches send_a2a_with_retry: without it, SLIM/agent-card
     handshake can fail before A2A send (mock would never be called).
+
+    Stub get_llm too: the supervisor routing node and the reflection node call the LLM, which would
+    otherwise require LLM provider secrets/config (unavailable in the CI tier and when no .env exists).
+    The fake routes to the single-farm branch and ends the reflection loop, so the test exercises only
+    the transport-error handling it is meant to cover, with no real LLM.
     """
     with patch(
+        "agents.supervisors.auction.graph.graph.get_llm",
+        return_value=_FakeRoutingLLM("inventory_single_farm"),
+    ), patch(
         "agents.supervisors.auction.graph.tools.a2a_client_factory.create",
         new_callable=AsyncMock,
         return_value=MagicMock(),

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_streaming_fail_fast.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_streaming_fail_fast.py
@@ -60,18 +60,14 @@ def _restore_modules(saved):
 def test_supervisor_raises_when_llm_does_not_support_streaming(monkeypatch, real_workflow_catalog, import_module, expected_agent_name):
   """With ENSURE_STREAMING_LLM=true, supervisor startup fails when get_model_info says no streaming."""
   _ensure_root_on_path()
-  import config.config as config_mod
-  saved_ensure = getattr(config_mod, "ENSURE_STREAMING_LLM", False)
-  saved_llm_model = getattr(config_mod, "LLM_MODEL", "")
-
   prefix = import_module.rsplit(".", 1)[0]
-  prefixes = [prefix, "common"]
+  prefixes = [prefix, "common", "config.config"]
   saved_modules = _save_modules(prefixes)
   try:
     with patch("litellm.get_model_info", return_value={"supports_native_streaming": False}) as mock_get_model_info:
       _purge_modules(prefixes)
-      monkeypatch.setattr(config_mod, "ENSURE_STREAMING_LLM", True)
-      monkeypatch.setattr(config_mod, "LLM_MODEL", "openai/gpt-4o-mini")
+      monkeypatch.setenv("ENSURE_STREAMING_LLM", "true")
+      monkeypatch.setenv("LLM_MODEL", "openai/gpt-4o-mini")
       try:
         importlib.import_module(import_module)
       except Exception as e:
@@ -84,8 +80,6 @@ def test_supervisor_raises_when_llm_does_not_support_streaming(monkeypatch, real
         return
     pytest.fail("Expected StreamingNotSupportedError")
   finally:
-    monkeypatch.setattr(config_mod, "ENSURE_STREAMING_LLM", saved_ensure)
-    monkeypatch.setattr(config_mod, "LLM_MODEL", saved_llm_model)
     _purge_modules(prefixes)
     _restore_modules(saved_modules)
 

--- a/coffeeAGNTCY/coffee_agents/recruiter/docker/docker-compose.yaml
+++ b/coffeeAGNTCY/coffee_agents/recruiter/docker/docker-compose.yaml
@@ -2,7 +2,8 @@ services:
   dir-api-server:
     image: ghcr.io/agntcy/dir-apiserver:v1.0.0
     env_file:
-      - ./configs/dir/apiserver.env
+      - path: ./configs/dir/apiserver.env
+        required: true
     ports:
       - 8888:8888
     depends_on:
@@ -88,7 +89,8 @@ services:
     ports:
       - "8881:8881"
     env_file:
-      - ../.env
+      - path: ../.env
+        required: false
     environment:
       - ENABLE_HTTP=true
       - MCP_CONNECTION_MODE=binary


### PR DESCRIPTION
# Description

The Python Tests workflow was failing at load time on push to main (and on `pull_request`), so no subproject tests ran. This PR fixes the invalid reusable-workflow inputs and removes a dead branch condition.

`test.yaml` passed `${{ inputs.test_corto }}` / `test_lungo` / `test_recruiter` straight into the `test-subprojects-reusable.yaml` reusable workflow. The `inputs` context only exists for `workflow_call` / `workflow_dispatch`, so on `push` and `pull_request` those expressions rendered to an empty string `''`. Since the reusable workflow declares those inputs as `type: boolean`, '' is not a valid value and GitHub rejected the run during "load reusable workflow context":
```
.github/workflows/test.yaml (Line: 103, Col: 19): Unexpected value ''
```
Because every tests / * job needs the `subprojects-to-test` job, the whole run failed before any job was scheduled — the tests appeared to never trigger.

### Changes
  * `test.yaml`: coerce the passthrough inputs to a valid boolean with `${{ inputs.<x> || false }}`, and add a comment explaining why. The reusable workflow ignores these values on `push`/`pull_request` (it branches on `github.event_name`), so `|| false` only ever applies to dispatch/call runs, where it still correctly honors an explicit `false`.
    * I chose the shorter version plus an educational comment but we could also have a longer and more explicit form of that condition (example for Corto below):
      ```
      test_corto: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.test_corto || false }}
      ```
  * `test-subprojects-reusable.yaml`: drop the dead `github.event_name == 'workflow_call'` condition. Inside a reusable workflow `github.event_name` is the **originating event** (`push` / `pull_request` / `workflow_dispatch`) and is never `workflow_call`, so that condition could never match.
    * From https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call: 
      > `workflow_call` is used to indicate that a workflow can be called by another workflow. When a workflow is triggered with the `workflow_call` event, the event payload in the called workflow is the same event payload from the calling workflow.

  * the rest are fixes for the Python tests that we didn't see before due to the previous issues
  
## Issue Link

Fixes #734
Fixes #735 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
