### PR TITLE
fix(lungo-frontend): contrast fixes

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/eslint-rules/no-forbidden-dashes.mjs
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/eslint-rules/no-forbidden-dashes.mjs
@@ -1,0 +1,59 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Forbid en dash (U+2013) and em dash (U+2014) in source text.
+ * Aligns with repo CI: .github/workflows/source-lint.yaml (check-forbidden-strings).
+ * Use ASCII hyphen-minus (-) or rephrase (e.g. semicolon, comma).
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "disallow en dash (U+2013) and em dash (U+2014); use ASCII hyphen (-) instead",
+    },
+    messages: {
+      forbidden:
+        "Forbidden {{name}} ({{code}}). Use ASCII hyphen (-) or rephrase; see repo source-lint forbidden-strings check.",
+    },
+    schema: [],
+  },
+  create(context) {
+    const forbidden = [
+      ["\u2013", "en dash", "U+2013"],
+      ["\u2014", "em dash", "U+2014"],
+    ]
+
+    return {
+      Program(node) {
+        const sourceCode = context.sourceCode
+        // Full file text (includes comments); getText(node) omits comments.
+        const lines = sourceCode.text.split("\n")
+
+        for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+          const line = lines[lineIndex]
+
+          for (const [character, name, code] of forbidden) {
+            let column = line.indexOf(character)
+
+            while (column !== -1) {
+              context.report({
+                node,
+                loc: {
+                  start: { line: lineIndex + 1, column },
+                  end: { line: lineIndex + 1, column: column + 1 },
+                },
+                messageId: "forbidden",
+                data: { name, code },
+              })
+              column = line.indexOf(character, column + 1)
+            }
+          }
+        }
+      },
+    }
+  },
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/eslint.config.mjs
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/eslint.config.mjs
@@ -7,12 +7,19 @@ import tsparser from "@typescript-eslint/parser"
 import tsplugin from "@typescript-eslint/eslint-plugin"
 import prettier from "eslint-plugin-prettier"
 import prettierConfig from "eslint-config-prettier"
+import noForbiddenDashes from "./eslint-rules/no-forbidden-dashes.mjs"
+
+const localRulesPlugin = {
+  rules: {
+    "no-forbidden-dashes": noForbiddenDashes,
+  },
+}
 
 export default [
   { ignores: ["dist", "node_modules", "src/api/generated/**"] },
   ...tseslint.configs.recommended,
   {
-    files: ["**/*.{js,jsx,ts,tsx}"],
+    files: ["**/*.{js,jsx,ts,tsx,mjs}"],
     languageOptions: {
       ecmaVersion: "latest",
       globals: {
@@ -30,12 +37,14 @@ export default [
       "react-refresh": reactRefresh,
       "@typescript-eslint": tsplugin,
       prettier: prettier,
+      local: localRulesPlugin,
     },
     rules: {
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       ...prettierConfig.rules,
       "prettier/prettier": "error",
+      "local/no-forbidden-dashes": "error",
 
       "react-refresh/only-export-components": [
         "warn",
@@ -45,9 +54,7 @@ export default [
       "no-dupe-keys": "error",
       "no-console": ["warn", { allow: ["warn", "error"] }],
       "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-      ],
+      "@typescript-eslint/no-unused-vars": ["error"],
       "max-lines": ["warn", { max: 400 }],
     },
   },
@@ -79,7 +86,7 @@ export default [
     },
   },
   {
-    files: ["**/*.{js,jsx,ts,tsx}"],
+    files: ["**/*.{js,jsx,ts,tsx,mjs}"],
     ignores: ["**/logger.ts"],
     rules: {
       "no-restricted-syntax": [

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatArea.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatArea.tsx
@@ -6,6 +6,7 @@
 import React, { useRef, useState } from "react"
 
 import { useScrollPanelOnContentResize } from "@/utils/chatScroll"
+import { transparentScrollbarSx } from "@/utils/transparentScrollbarSx"
 
 import { useObservabilitySessionId, usePatternChatAPI } from "@/hooks/chat"
 import { Box, Stack } from "@open-ui-kit/core"
@@ -186,20 +187,22 @@ const ChatArea: React.FC<ChatAreaProps> = ({
         id={CHAT_MESSAGE_PANEL_ID}
         role="region"
         aria-label="Chat messages"
-        sx={{
+        sx={(theme) => ({
           flex: fillHeight ? "1 1 auto" : "0 0 auto",
           minHeight: fillHeight ? 0 : undefined,
           width: "100%",
           overflowY: "auto",
           overflowX: "hidden",
+          backgroundColor: theme.palette.action.selected,
           // Reserve the scrollbar gutter on both edges so the centered thread
           // doesn't shift left when a scrollbar appears (keeps it aligned with
           // the composer below).
           scrollbarGutter: "stable both-edges",
+          ...transparentScrollbarSx(theme),
           ...(currentUserMessage
             ? { borderTop: "1px solid", borderColor: "divider" }
             : { display: "none" }),
-        }}
+        })}
       >
         <Stack
           ref={threadContentRef}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatAreaComposer.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatAreaComposer.tsx
@@ -8,6 +8,7 @@ import SendIcon from "@mui/icons-material/Send"
 import { Box, Button, InputField, Stack } from "@open-ui-kit/core"
 
 import { iconGlyphFillSx } from "@/utils/iconGlyphFill"
+import { composerPrimaryButtonSx } from "@/utils/composerPrimaryButtonSx"
 
 import type { HttpRequestTarget } from "@/urls"
 
@@ -52,7 +53,10 @@ const ChatAreaComposer: React.FC<ChatAreaComposerProps> = ({
           <SuggestedPromptsDropdown
             promptsRequest={suggestedPromptsRequest}
             onSelect={onSuggestedPromptSelect}
-            sx={(theme) => theme.typography.body1}
+            sx={(theme) => ({
+              ...theme.typography.body1,
+              ...composerPrimaryButtonSx(theme),
+            })}
           />
         </Box>
       ) : null}
@@ -99,6 +103,7 @@ const ChatAreaComposer: React.FC<ChatAreaComposerProps> = ({
           flexShrink: 0,
           alignSelf: { xs: "stretch", sm: "flex-end" },
           ...theme.typography.body1,
+          ...composerPrimaryButtonSx(theme),
           "& .MuiButton-endIcon": iconGlyphFillSx(
             theme.palette.vars.baseTextInverse,
             { important: true },

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatAvatarCircle.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/ChatAvatarCircle.tsx
@@ -42,6 +42,10 @@ export const ChatAvatarCircle: React.FC<ChatAvatarCircleProps> = ({
 
 export const ChatAgentAvatar: React.FC = () => {
   const theme = useTheme()
+  const { isDarkMode } = useAppThemeMode()
+  const iconMaskColor = isDarkMode
+    ? theme.palette.grey[50]
+    : theme.palette.common.white
 
   return (
     <ChatAvatarCircle>
@@ -52,7 +56,7 @@ export const ChatAgentAvatar: React.FC = () => {
           width: 22,
           height: 22,
           flexShrink: 0,
-          bgcolor: theme.palette.grey[50],
+          bgcolor: iconMaskColor,
           maskImage: `url(${AgentIcon})`,
           maskSize: "contain",
           maskRepeat: "no-repeat",

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/feeds/AuctionStreamingFeed.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/feeds/AuctionStreamingFeed.tsx
@@ -13,6 +13,7 @@ import { NDJSON_STREAMING_STATUS } from "@/stores/ndjsonStreamingStatus"
 import type { GraphConfig } from "@/utils/graphConfigs"
 import { animationSequenceStepIds } from "../chatStreamGraphHighlight"
 import { FeedSpinnerRow } from "../FeedSpinnerRow"
+import { successIconColorSx } from "@/utils/successIconColor"
 import { FeedStatusLine } from "../FeedStatusLine"
 import { FeedErrorMessage } from "./FeedErrorMessage"
 import GrafanaSessionLink from "../GrafanaSessionLink"
@@ -168,7 +169,7 @@ const AuctionStreamingFeed: React.FC<AuctionStreamingFeedProps> = ({
                 >
                   <Box sx={{ mt: 0.5, display: "flex", alignItems: "center" }}>
                     <CheckCircleIcon
-                      sx={{ color: "success.main" }}
+                      sx={(theme) => successIconColorSx(theme)}
                       aria-hidden
                     />
                   </Box>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/feeds/GroupCommunicationFeed.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/feeds/GroupCommunicationFeed.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/stores/groupStreamingStore"
 import { NDJSON_STREAMING_STATUS } from "@/stores/ndjsonStreamingStatus"
 import { FeedSpinnerRow } from "../FeedSpinnerRow"
+import { successIconColorSx } from "@/utils/successIconColor"
 import { FeedStatusLine } from "../FeedStatusLine"
 import { FeedErrorMessage } from "./FeedErrorMessage"
 import { FeedCollapseButton } from "./FeedCollapseButton"
@@ -228,7 +229,7 @@ const GroupCommunicationFeed: React.FC<GroupCommunicationFeedProps> = ({
                 >
                   <Box sx={{ mt: 0.5, display: "flex", alignItems: "center" }}>
                     <CheckCircleIcon
-                      sx={{ color: "success.main" }}
+                      sx={(theme) => successIconColorSx(theme)}
                       aria-hidden
                     />
                   </Box>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/feeds/RecruiterStreamingFeed.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/feeds/RecruiterStreamingFeed.tsx
@@ -8,6 +8,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle"
 import { Box, Stack, Typography } from "@open-ui-kit/core"
 import { ChatAgentAvatar } from "../ChatAvatarCircle"
 import { FeedSpinnerRow } from "../FeedSpinnerRow"
+import { successIconColorSx } from "@/utils/successIconColor"
 import { FeedStatusLine } from "../FeedStatusLine"
 import { FeedErrorMessage } from "./FeedErrorMessage"
 import { FeedCollapseButton } from "./FeedCollapseButton"
@@ -182,7 +183,7 @@ const RecruiterStreamingFeed: React.FC<RecruiterStreamingFeedProps> = ({
                 >
                   <Box sx={{ mt: 0.5, display: "flex", alignItems: "center" }}>
                     <CheckCircleIcon
-                      sx={{ color: "success.main" }}
+                      sx={(theme) => successIconColorSx(theme)}
                       aria-hidden
                     />
                   </Box>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/prompts/SuggestedPromptsDropdown.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Chat/prompts/SuggestedPromptsDropdown.tsx
@@ -30,6 +30,7 @@ import {
 } from "./suggestedPromptsUtils"
 import { CustomDropdownListItemContent } from "./CustomDropdownListItemContent"
 import { useSuggestedPrompts } from "./useSuggestedPrompts"
+import { getDisabledRowOpacity } from "@/utils/a11ySx"
 
 interface PromptMenuItemProps {
   option: DropdownOption<string>
@@ -149,7 +150,12 @@ const SuggestedPromptsDropdown: React.FC<SuggestedPromptsDropdownProps> = ({
         ) as SystemStyleObject<Theme>
         return {
           ...resolvedCallerSx,
-          ...(isInactive ? { opacity: 0.5, pointerEvents: "none" } : {}),
+          ...(isInactive
+            ? {
+                opacity: getDisabledRowOpacity(theme),
+                pointerEvents: "none",
+              }
+            : {}),
         }
       }}
       endIcon={

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/CustomControls.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/CustomControls.tsx
@@ -32,7 +32,7 @@ const TooltipControlButton: React.FC<{
       component="span"
       sx={{
         display: "inline-flex",
-        ...(disabled ? { pointerEvents: "none", opacity: 0.5 } : {}),
+        ...(disabled ? { pointerEvents: "none" } : {}),
       }}
     >
       <IconButton

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/CustomNode.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/CustomNode.tsx
@@ -19,6 +19,7 @@ import agentDirectoryIconLight from "@/assets/Agent_Icon_light.png"
 import { useGithubIcon, useThemeIcon } from "@/hooks/ui"
 import { AssetPngIcon } from "@/components/AssetPngIcon"
 import { SecurityClass } from "@/utils/SecurityClass"
+import { getSuccessIconColor } from "@/utils/successIconColor"
 import {
   getGraphNodeHandleStyle,
   graphNodeRootSurfaceSx,
@@ -158,7 +159,7 @@ const CustomNode: React.FC<CustomNodeProps> = ({ id, data }) => {
                 flexShrink: 0,
                 flexGrow: 0,
                 order: 1,
-                color: "success.main",
+                color: getSuccessIconColor(theme),
               }}
             />
           )}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/TransportRail.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/TransportRail.tsx
@@ -105,8 +105,8 @@ const TransportRail: React.FC<{
                 <Typography
                   component="span"
                   sx={{
-                    fontSize: 10,
-                    lineHeight: "14px",
+                    fontSize: 11,
+                    lineHeight: "15px",
                     fontWeight: 700,
                     textTransform: "uppercase",
                   }}
@@ -116,10 +116,9 @@ const TransportRail: React.FC<{
                 <Typography
                   component="span"
                   sx={{
-                    fontSize: 9,
-                    lineHeight: "13px",
+                    fontSize: 11,
+                    lineHeight: "15px",
                     fontWeight: 500,
-                    opacity: isHighlighted ? 0.82 : 0.72,
                   }}
                 >
                   {meta.label}
@@ -131,10 +130,10 @@ const TransportRail: React.FC<{
                       px: 0.5,
                       py: 0.125,
                       borderRadius: 0.5,
-                      bgcolor: alpha(railColors.highlightedText, 0.22),
+                      bgcolor: alpha(theme.palette.common.black, 0.2),
                       color: railColors.highlightedText,
-                      fontSize: 8,
-                      lineHeight: "10px",
+                      fontSize: 10,
+                      lineHeight: "13px",
                       fontWeight: 700,
                       textTransform: "uppercase",
                     }}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/TransportRail.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/TransportRail.tsx
@@ -105,8 +105,7 @@ const TransportRail: React.FC<{
                 <Typography
                   component="span"
                   sx={{
-                    fontSize: 11,
-                    lineHeight: "15px",
+                    ...theme.typography.caption,
                     fontWeight: 700,
                     textTransform: "uppercase",
                   }}
@@ -116,8 +115,7 @@ const TransportRail: React.FC<{
                 <Typography
                   component="span"
                   sx={{
-                    fontSize: 11,
-                    lineHeight: "15px",
+                    ...theme.typography.caption,
                     fontWeight: 500,
                   }}
                 >
@@ -132,8 +130,7 @@ const TransportRail: React.FC<{
                       borderRadius: 0.5,
                       bgcolor: alpha(theme.palette.common.black, 0.2),
                       color: railColors.highlightedText,
-                      fontSize: 10,
-                      lineHeight: "13px",
+                      ...theme.typography.overline,
                       fontWeight: 700,
                       textTransform: "uppercase",
                     }}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/graphCanvasIconButtonSx.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/graphCanvasIconButtonSx.ts
@@ -10,7 +10,10 @@
 import type { Theme } from "@mui/material/styles"
 import type { SystemStyleObject } from "@mui/system"
 import { getAssetPngIconSize } from "@/utils/assetPngIcon"
-import { getControlIconColor } from "./graphNodeSurface"
+import {
+  getControlIconColor,
+  getControlIconDisabledColor,
+} from "./graphNodeSurface"
 
 /**
  * Recolor single-color SvgIcons via filter. Each chain starts with `brightness(0)` so
@@ -37,6 +40,9 @@ const GRAPH_CANVAS_ICON_FILTERS = {
   },
 } as const
 
+/** Glyph fade for disabled canvas icons (see `&.Mui-disabled` below). */
+const GRAPH_CANVAS_DISABLED_GLYPH_OPACITY = 0.6
+
 function getCanvasIconFilters(theme: Theme) {
   return theme.palette.mode === "dark"
     ? GRAPH_CANVAS_ICON_FILTERS.dark
@@ -54,6 +60,21 @@ function canvasIconRestingGlyphSx(theme: Theme): SystemStyleObject<Theme> {
     },
     "& .MuiSvgIcon-root path, & .MuiSvgIcon-root svg": {
       fill: restingIconColor,
+    },
+  }
+}
+
+function canvasIconDisabledGlyphSx(theme: Theme): SystemStyleObject<Theme> {
+  const disabledIconColor = getControlIconDisabledColor(theme)
+
+  return {
+    color: disabledIconColor,
+    "& .MuiSvgIcon-root": {
+      color: disabledIconColor,
+      fill: disabledIconColor,
+    },
+    "& .MuiSvgIcon-root path, & .MuiSvgIcon-root svg": {
+      fill: disabledIconColor,
     },
   }
 }
@@ -117,8 +138,13 @@ export function graphCanvasIconButtonSx(
     "&.Mui-disabled": {
       bgcolor: "transparent",
       backgroundColor: "transparent",
-      opacity: 0.45,
+      // Override MUI's default ~0.38 button fade; we mute via medium icon color + glyph opacity.
+      opacity: 1,
+      ...canvasIconDisabledGlyphSx(theme),
       ...canvasIconFilterSx("none"),
+      "& .MuiSvgIcon-root": {
+        opacity: GRAPH_CANVAS_DISABLED_GLYPH_OPACITY,
+      },
     },
   }
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/graphNodeSurface.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/MainArea/Graph/Elements/graphNodeSurface.ts
@@ -27,6 +27,11 @@ export function getControlIconColor(theme: Theme): string {
   return theme.palette.vars.controlIconDefault
 }
 
+/** Muted disabled glyph on graph canvas; paired with glyph opacity in graphCanvasIconButtonSx. */
+export function getControlIconDisabledColor(theme: Theme): string {
+  return theme.palette.vars.controlIconMedium
+}
+
 export interface GraphNodeRootSurfaceOptions {
   /** Defaults to theme.shape.borderRadius (typically 4px). */
   borderRadius?: string | number

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Navigation/Navigation.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Navigation/Navigation.tsx
@@ -34,7 +34,7 @@ const Navigation: React.FC = () => {
     <>
       <Header
         position="static"
-        sx={navigationHeaderSx()}
+        sx={(theme) => navigationHeaderSx(theme)}
         logo={
           <Box
             component="img"
@@ -53,7 +53,7 @@ const Navigation: React.FC = () => {
               <IconButton
                 aria-label={themeToggleLabel}
                 onClick={toggleTheme}
-                sx={navigationHeaderIconButtonSx()}
+                sx={(theme) => navigationHeaderIconButtonSx(theme)}
               >
                 <ThemeToggleIcon />
               </IconButton>
@@ -62,7 +62,7 @@ const Navigation: React.FC = () => {
               <IconButton
                 aria-label="Help"
                 onClick={handleHelpClick}
-                sx={navigationHeaderIconButtonSx()}
+                sx={(theme) => navigationHeaderIconButtonSx(theme)}
               >
                 <HelpOutline />
               </IconButton>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Navigation/navigationHeaderSx.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Navigation/navigationHeaderSx.ts
@@ -5,19 +5,26 @@
  * Top title bar uses light-theme chrome in both app color modes (see corto exchange nav).
  */
 
-import type { Theme } from "@mui/material/styles"
+import { alpha, type Theme } from "@mui/material/styles"
 import type { SystemStyleObject } from "@mui/system"
+import { lightVars } from "@open-ui-kit/core"
+
 import { iconGlyphFillSx } from "@/utils/iconGlyphFill"
 
-/** Fixed light nav surface - not tied to active MUI color mode. */
-export const LUNGO_NAV_HEADER_COLORS = {
-  background: "#eff3fc",
-  border: "#dbe0e5",
-  icon: "#1d69cc",
-} as const
+/**
+ * Fixed light nav surface - not tied to active MUI color mode.
+ * Uses OUK light semantic tokens (same values as theme.palette.vars in light mode).
+ */
+export function getLungoNavHeaderColors(theme: Theme) {
+  return {
+    background: lightVars.baseBackgroundStrong,
+    border: theme.palette.grey[300],
+    icon: lightVars.brandIconPrimaryDefault,
+  } as const
+}
 
-export function navigationHeaderSx(): SystemStyleObject<Theme> {
-  const { background, border } = LUNGO_NAV_HEADER_COLORS
+export function navigationHeaderSx(theme: Theme): SystemStyleObject<Theme> {
+  const { background, border } = getLungoNavHeaderColors(theme)
 
   return {
     bgcolor: `${background} !important`,
@@ -26,12 +33,17 @@ export function navigationHeaderSx(): SystemStyleObject<Theme> {
   }
 }
 
-export function navigationHeaderIconButtonSx(): SystemStyleObject<Theme> {
+export function navigationHeaderIconButtonSx(
+  theme: Theme,
+): SystemStyleObject<Theme> {
+  const { icon } = getLungoNavHeaderColors(theme)
+  const iconHoverFill = alpha(icon, 0.08)
+
   return {
-    ...iconGlyphFillSx(LUNGO_NAV_HEADER_COLORS.icon, { important: true }),
+    ...iconGlyphFillSx(icon, { important: true }),
     "&:hover": {
-      bgcolor: "rgba(29, 105, 204, 0.08)",
-      backgroundColor: "rgba(29, 105, 204, 0.08)",
+      bgcolor: iconHoverFill,
+      backgroundColor: iconHoverFill,
     },
   }
 }

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
 } from "@open-ui-kit/core"
 import type { WorkflowSummary } from "@/utils/agenticWorkflowsApi"
 import { getAppShellBackgroundColor } from "../MainArea/mainAreaBackground"
+import { transparentScrollbarSx } from "@/utils/transparentScrollbarSx"
 import CatalogTree from "./CatalogTree"
 import {
   buildCatalogSidebarLayout,
@@ -100,7 +101,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       }}
     >
       <List
-        sx={{
+        sx={(theme) => ({
           display: "flex",
           flexDirection: "column",
           gap: 3,
@@ -111,19 +112,21 @@ const Sidebar: React.FC<SidebarProps> = ({
           width: "100%",
           minHeight: 0,
           flex: 1,
-        }}
+          ...transparentScrollbarSx(theme),
+        })}
       >
         <Box
           component="nav"
           aria-label="Agentic patterns catalog"
-          sx={{
+          sx={(theme) => ({
             width: "100%",
             minWidth: 0,
             alignSelf: "stretch",
             flex: 1,
             minHeight: 0,
             overflow: "auto",
-          }}
+            ...transparentScrollbarSx(theme),
+          })}
         >
           <Stack direction="column" sx={{ width: "100%" }}>
             <Typography variant="h6">Agentic Patterns</Typography>

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -11,6 +11,7 @@ import {
   sidebarItemMarginTop,
   sidebarListItemSx,
 } from "./sidebarSx"
+import { getDisabledRowOpacity } from "@/utils/a11ySx"
 
 interface SidebarItemProps {
   title: string
@@ -51,7 +52,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
           justifyContent: "flex-start",
           borderRadius: sidebarBorderRadius(theme),
           textWrap: "auto",
-          ...(disabled && { opacity: 0.5 }),
+          ...(disabled && { opacity: getDisabledRowOpacity(theme) }),
           ...(isRowDisabled && { pointerEvents: "none" }),
         })}
       >

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/layout/ResizablePanelSeparator.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/components/layout/ResizablePanelSeparator.tsx
@@ -28,8 +28,9 @@ const StyledSeparator = styled(Separator, {
   resizeEnabled?: boolean
 }>(({ theme, orientation, resizeEnabled = true }) => {
   const isLight = theme.palette.mode === "light"
-  const restingOpacity = isLight ? 0.18 : 0.22
-  const hoverOpacity = isLight ? 0.32 : 0.38
+  // B7: raise from 0.18/0.22 so the handle meets ≥3:1 UI contrast on paper.
+  const restingOpacity = isLight ? 0.35 : 0.4
+  const hoverOpacity = isLight ? 0.48 : 0.52
   const isHorizontalGroup = orientation === "horizontal"
 
   return {

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/contexts/compactThemeOptions.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/contexts/compactThemeOptions.ts
@@ -5,7 +5,7 @@
  * Compact density layer merged onto the OUK theme (see CompactTheme).
  * Body scale shifts one OUK tier down (body1: 16px → 14px); spacing unit: 6px.
  *
- * Minimum tiers (B2 / #618): caption & button ≥12px, overline ≥10px — sub-12px
+ * Minimum tiers (B2 / #618): caption & button ≥12px, overline ≥10px; sub-12px
  * body copy fails contrast more often on marginal OUK tokens.
  */
 

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/contexts/compactThemeOptions.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/contexts/compactThemeOptions.ts
@@ -4,6 +4,9 @@
  *
  * Compact density layer merged onto the OUK theme (see CompactTheme).
  * Body scale shifts one OUK tier down (body1: 16px → 14px); spacing unit: 6px.
+ *
+ * Minimum tiers (B2 / #618): caption & button ≥12px, overline ≥10px — sub-12px
+ * body copy fails contrast more often on marginal OUK tokens.
  */
 
 import type { ThemeOptions } from "@mui/material/styles"
@@ -42,9 +45,9 @@ export const compactThemeOptions: ThemeOptions = {
     subtitle2: { fontSize: "12px", lineHeight: "16px" },
     headingSubSection: { fontSize: "14px", lineHeight: "20px" },
 
-    caption: { fontSize: "11px", lineHeight: "15px" },
-    captionMedium: { fontSize: "11px", lineHeight: "15px" },
-    captionSemibold: { fontSize: "11px", lineHeight: "15px" },
+    caption: { fontSize: "12px", lineHeight: "16px" },
+    captionMedium: { fontSize: "12px", lineHeight: "16px" },
+    captionSemibold: { fontSize: "12px", lineHeight: "16px" },
 
     h6: { fontSize: "18px", lineHeight: "25px" },
     h5: { fontSize: "21px", lineHeight: "28px" },
@@ -53,8 +56,8 @@ export const compactThemeOptions: ThemeOptions = {
     h2: { fontSize: "42px", lineHeight: "46px" },
     h1: { fontSize: "52px", lineHeight: "56px" },
 
-    button: { fontSize: "11px", lineHeight: "15px" },
-    overline: { fontSize: "9px", lineHeight: "14px" },
+    button: { fontSize: "12px", lineHeight: "16px" },
+    overline: { fontSize: "10px", lineHeight: "14px" },
   },
 
   components: {

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
@@ -341,7 +341,7 @@ const RootPage: React.FC = () => {
                           minWidth: 0,
                           minHeight: 0,
                           flexDirection: "column",
-                          overflow: "hidden",
+                          overflow: "auto",
                         }}
                       >
                         <ChatArea {...chatAreaProps} />

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/pages/RootPage.tsx
@@ -330,6 +330,7 @@ const RootPage: React.FC = () => {
                       panelRef={chatPanelRef}
                       minSize={hasChatMessages ? CHAT_MIN_SIZE : undefined}
                       maxSize={CHAT_MAX_SIZE}
+                      style={{ overflow: "hidden" }}
                     >
                       <Box
                         component="section"
@@ -341,7 +342,7 @@ const RootPage: React.FC = () => {
                           minWidth: 0,
                           minHeight: 0,
                           flexDirection: "column",
-                          overflow: "auto",
+                          overflow: "hidden",
                         }}
                       >
                         <ChatArea {...chatAreaProps} />

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/a11ySx.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/a11ySx.ts
@@ -7,6 +7,11 @@
 
 import type { SxProps, Theme } from "@mui/material/styles"
 
+/** Inactive/disabled row fade; 0.6 in light mode meets UI contrast (B9). */
+export function getDisabledRowOpacity(theme: Theme): number {
+  return theme.palette.mode === "light" ? 0.6 : 0.5
+}
+
 /** Hide visually; keep available to screen readers and associated controls. */
 export const visuallyHiddenSx: SxProps<Theme> = {
   position: "absolute",

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/composerPrimaryButtonSx.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/composerPrimaryButtonSx.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import type { Theme } from "@mui/material/styles"
+import type { SystemStyleObject } from "@mui/system"
+
+/**
+ * Neutralize OUK primary `:active` layout shift (border + padding shrink).
+ * Resting size stays on OUK defaults; only press state is overridden.
+ */
+export function composerPrimaryButtonSx(
+  theme: Theme,
+): SystemStyleObject<Theme> {
+  const activeBorderColor = theme.palette.vars.interactivePrimaryDefaultDefault
+
+  return {
+    "&.MuiButton-sizeMedium.MuiButton-primary": {
+      "&:active": {
+        border: "none",
+        outline: `1px solid ${activeBorderColor}`,
+        outlineOffset: "-1px",
+        paddingLeft: "16px",
+        paddingRight: "16px",
+      },
+    },
+  }
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/successIconColor.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/successIconColor.ts
@@ -12,9 +12,7 @@ import type { SystemStyleObject } from "@mui/system"
 
 /** ≥3:1 on white (UI component AA). Dark mode keeps success.main (~5.9:1 on paper). */
 export function getSuccessIconColor(theme: Theme): string {
-  return theme.palette.mode === "light"
-    ? green800
-    : theme.palette.success.main
+  return theme.palette.mode === "light" ? green800 : theme.palette.success.main
 }
 
 export function successIconColorSx(theme: Theme): SystemStyleObject<Theme> {

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/successIconColor.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/successIconColor.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Success icon fill on paper surfaces. OUK success.main (green500) is ~2.52:1 on
+ * white; use green800 in light mode until upstream A2 is fixed (see contrast-audit.md).
+ */
+
+import { green800 } from "@open-ui-kit/core"
+import type { Theme } from "@mui/material/styles"
+import type { SystemStyleObject } from "@mui/system"
+
+/** ≥3:1 on white (UI component AA). Dark mode keeps success.main (~5.9:1 on paper). */
+export function getSuccessIconColor(theme: Theme): string {
+  return theme.palette.mode === "light"
+    ? green800
+    : theme.palette.success.main
+}
+
+export function successIconColorSx(theme: Theme): SystemStyleObject<Theme> {
+  return { color: getSuccessIconColor(theme) }
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/successIconColor.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/successIconColor.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Success icon fill on paper surfaces. OUK success.main (green500) is ~2.52:1 on
- * white; use green800 in light mode until upstream A2 is fixed (see contrast-audit.md).
+ * white; use green800 in light mode until OUK upstream is fixed.
  */
 
 import { green800 } from "@open-ui-kit/core"

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/transparentScrollbarSx.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/transparentScrollbarSx.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Scrollbar track matches the host surface (transparent track + themed thumb).
+ */
+
+import type { Theme } from "@mui/material/styles"
+import { alpha } from "@mui/material/styles"
+import type { SystemStyleObject } from "@mui/system"
+
+export function transparentScrollbarSx(theme: Theme): SystemStyleObject<Theme> {
+  const thumb = alpha(theme.palette.text.primary, 0.28)
+
+  return {
+    scrollbarWidth: "thin",
+    scrollbarColor: `${thumb} transparent`,
+    "&::-webkit-scrollbar": {
+      width: 8,
+    },
+    "&::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
+    "&::-webkit-scrollbar-thumb": {
+      backgroundColor: thumb,
+      borderRadius: 4,
+    },
+  }
+}


### PR DESCRIPTION
# Description

Improves color contrast, typography minimums, scrollbar presentation, and a few interaction/layout fixes in lungo-ui (`coffee_agents/lungo/frontend`) for [issue #618](https://github.com/agntcy/coffeeAgntcy/issues/618): *Check the contrast and colors of the new OUK components*.

All changes are **lungo-local**; no OUK or corto upstream patches.

### Contrast and readability

| Area | Change |
|------|--------|
| Transport rail | Removed stacked opacity on labels; rail text uses `theme.typography.caption` and badges use `overline`; darker badge pill |
| Compact typography | Raised minimum font sizes in `compactThemeOptions`: caption and button to 12px/16px line-height, overline to 10px/14px; font weights still come from OUK via theme merge |
| Graph canvas controls | Disabled icon buttons use `controlIconMedium` and glyph opacity instead of fading the whole control |
| Graph nodes | Disabled node surface tokens aligned with canvas icon treatment |
| Navigation header | Light chrome uses OUK semantic tokens; stronger border for separation |
| Chat avatar | White icon mask in light mode on the brand circle |
| Success icons | `green800` in light mode for check-circle icons on white/paper (feeds, graph nodes) |
| Panel resize separator | Higher handle opacity for visibility |
| Disabled rows | Shared `getDisabledRowOpacity()` for sidebar items and suggested-prompts trigger |
| Scrollbars | Transparent tracks in sidebar and chat message panel via `transparentScrollbarSx` |

### Layout and interaction

| Area | Change |
|------|--------|
| Chat scroll | Scroll confined to `#chat-message-panel`; chat panel and section wrappers use `overflow: hidden` so outer panel chrome does not become a second scroll container |
| Composer buttons | `:active` press ring via `outline` (no layout shift); blocks OUK primary `:active` border and horizontal padding shrink on Send and Suggested Prompts |

### Tooling

- Local ESLint rule `local/no-forbidden-dashes` flags en dash (U+2013) and em dash (U+2014) in source files, matching CI text checks

## Issue Link

Fixes #618

## Type of Change

- Bugfix

## Checklist

Targets [WCAG 2.2 contrast](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html) (4.5:1 normal text, 3:1 large text and UI components) and lungo compact typography minimums in `compactThemeOptions.ts` (caption/button ≥12px, overline ≥10px).

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Test plan

1. Run `npm run lint` in `coffee_agents/lungo/frontend`.
2. Open lungo-ui in **light mode** and load a workflow with graph, chat, and sidebar visible.
3. Scan the **sidebar** and **nav header**; confirm text and borders are readable and not washed out.
4. On the **graph**, check transport rail labels/badges, zoom/fit controls (enabled and disabled), node success icons, and the panel resize handle between graph and chat.
5. In **chat**, check the agent avatar, streaming feed success icons, and scrollbars on the sidebar (white) vs message panel (grey-blue); tracks should be transparent, thumbs visible.
6. Send several messages so the thread overflows; scroll and confirm only **`#chat-message-panel`** scrolls while the chat header and composer stay fixed.
7. Press and hold **Send** and **Suggested Prompts**; confirm size does not jump and the pressed outline is visible.
8. Set browser zoom to **200%**; re-check caption-sized labels (graph edges, spinners, small UI copy) for legibility at the raised minimum sizes.
9. Trigger **disabled** states (inactive sidebar rows, suggested prompts while loading/empty); confirm they read as disabled but remain legible.
