### PR TITLE
docs(lungo): add pattern-specific use cases

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
@@ -67,11 +67,10 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
-Sometimes the capability Coffee Agntcy needs next is not one it already runs: a new agent, service, or interface
-has to be found and vetted before it can carry supply-chain work. This workflow separates that selection moment
-from execution, with the **Agentic Recruiter** turning registered facts from the **AGNTCY Agent Directory** into a
-ranked, explainable shortlist before anything is delegated. What the business keeps is a defensible record of why
-a candidate earned trust.
+Coffee Agntcy cannot assume that every future operating need will be handled by a fixed roster of agents. **A2A HTTP**
+gives a selector a common way to inspect candidate services before entrusting any of them with work, while keeping
+selection separate from execution. New integrations therefore stay replaceable and governable rather than becoming
+hard-coded dependencies.
 
 ---
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/a2a_http.md
@@ -67,6 +67,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Sometimes the capability Coffee Agntcy needs next is not one it already runs: a new agent, service, or interface
+has to be found and vetted before it can carry supply-chain work. This workflow separates that selection moment
+from execution, with the **Agentic Recruiter** turning registered facts from the **AGNTCY Agent Directory** into a
+ranked, explainable shortlist before anything is delegated. What the business keeps is a defensible record of why
+a candidate earned trust.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/adversarial_review_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/adversarial_review_agents.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Coffee Agntcy takes market positions that outlive any single harvest, and a buying case assembled only by its
+advocates tends to flatter itself. **Adversarial review** builds a dissenting voice into the company: proposals
+face structured objections from a risk reviewer, with policy consulted and a human approver reachable when stakes
+outgrow the agents. Unlike an approval gate, the value is the argument itself, forcing evidence to improve while
+commitments are still reversible.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent-to-system_bridge.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent-to-system_bridge.md
@@ -46,6 +46,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Much of what Coffee Agntcy must know lives in systems it does not own: emissions services, finance backends, and
+similar records sit outside any agent's head. The **agent-to-system bridge** is the company's rule that arguments
+about routes and spend cite those systems directly, through adapters that normalize responses into shapes
+downstream agents can consume. It keeps the line between a recognized number and a confident guess visible
+wherever reasoning crosses into money or compliance.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent_workflow_chain.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/agent_workflow_chain.md
@@ -45,6 +45,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Procurement at Coffee Agntcy decomposes into ordered specialties, and each stage is only as defensible as the
+record the previous one leaves behind. The **agent workflow chain** makes that record explicit: every specialist
+reads the same evolving procurement state and records its contribution under a schema every later step can rely
+on. Accountability follows the chain, because who established each fact remains visible when a commitment is
+later questioned.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/approval_gate_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/approval_gate_agent.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Certain purchases commit Coffee Agntcy at a scale where the company wants a person, not a model, answerable for
+the outcome. The **approval gate** marks where automated buying ends: the proposal, the governing policy, and
+what changed since the last checkpoint arrive packaged for a human whose yes or no is recorded and attributable.
+Policy enforcement applies rules the firm has already written; the gate covers decisions that still deserve
+judgment.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/composable_agent_service.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/composable_agent_service.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Several parts of Coffee Agntcy need the same expertise from different angles: procurement, logistics, and
+reporting each ask emissions questions in their own context. A **composable agent service** answers all of them
+from one owned, versioned implementation registered in the catalog, with consumers declaring the interface ranges
+they depend on. The business gains a single accountable source for a shared capability, and when an answer is
+disputed, one version to trace instead of forks to reconcile.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/coordinator_+_worker_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/coordinator_+_worker_agents.md
@@ -43,6 +43,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+An order already sold commits Coffee Agntcy to work it can only partly perform itself: goods must leave a
+warehouse, clear a border, travel with a carrier, and settle financially. The **coordinator and worker** split
+gives that job one owner of progress, with the coordinator assigning bounded tasks and reconciling structured
+results while specialists execute their slice. The company keeps a definitive answer to where an order stands
+without any single worker owning the whole story.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/decentralized_consensus_agents.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/decentralized_consensus_agents.md
@@ -49,6 +49,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+No single desk at Coffee Agntcy sees demand whole; each region reads its own market, and a central override would
+only replace several partial views with another one. **Decentralized consensus** lets the regional agents
+exchange belief updates directly, with merge semantics and stopping rules supplying the discipline a permanent
+hub would otherwise impose. The business requirement is termination: the exchange must land on a workable plan
+rather than an open-ended debate.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/directory-based_dispatch.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/directory-based_dispatch.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Operational questions rarely arrive at Coffee Agntcy labeled with the discipline they belong to; the same signal
+can be a weather matter one day and a freight matter the next. **Directory-based dispatch** resolves that
+ambiguity at request time: a router reads registered skills and trust metadata and records why the chosen
+specialist was defensible. Where recruiter-style discovery shops for new capability, dispatch routes live
+questions across specialists the company already trusts.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/economic_constraint_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/economic_constraint_agent.md
@@ -43,6 +43,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Routing choices at Coffee Agntcy spend several currencies at once: money, delivery days, and carbon. The
+**economic constraint agent** holds those budgets in versioned models that planning consults before committing,
+so a plan that wins on one axis states plainly what it costs on the others. Governance patterns declare what the
+company refuses to do; this pattern quantifies what it is willing to trade, in units finance and operations
+already use.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/end-to-end_telemetry.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/end-to-end_telemetry.md
@@ -44,6 +44,11 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+A single lot passes through agents answering to different parts of Coffee Agntcy, and supply, buying, movement,
+and settlement each emit their own account of events. **End-to-end telemetry** correlates those accounts into one
+trace anchored to real business objects, so an incident or customer dispute is investigated across ownership
+boundaries instead of reassembled from partial logs.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/event_ledger_episodic_memory.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/event_ledger_episodic_memory.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+When automation makes a bad call at Coffee Agntcy, the expensive question is not whether something failed but
+which earlier decision made failure inevitable. The **event ledger** keeps an ordered, replayable account of what
+agents decided, checked, and invoked, tied to the lots and orders the business recognizes. Telemetry tells
+operators how the system ran; this episodic record lets a reviewer walk the reasoning itself, step by step, after
+the fact.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/feedback_loop.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/feedback_loop.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Supplier relationships at Coffee Agntcy are repeat business, which makes them exactly the place where measured
+history should matter. The **feedback loop** converts delivery outcomes and satisfaction signals into attributed
+performance data that adjusts selection weights in the directory, so each sourcing cycle starts from evidence
+rather than habit. Scoring patterns measure and evaluation patterns recommend; this is the pattern through which
+results actually reshape future selection.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
@@ -60,6 +60,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Fulfillment failures at Coffee Agntcy tend to start quietly, when supply, movement, and money keep separate views
+of an order until their assumptions conflict. **Group messaging** commits the company to a single shared
+conversation per order, where the farm, shipper, and accountant read and amend the same evolving facts. Unlike a
+coordinator that privately tasks workers, the shared channel keeps each function's decisions tied to one visible
+order state.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/group_messaging.md
@@ -60,11 +60,10 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
-Fulfillment failures at Coffee Agntcy tend to start quietly, when supply, movement, and money keep separate views
-of an order until their assumptions conflict. **Group messaging** commits the company to a single shared
-conversation per order, where the farm, shipper, and accountant read and amend the same evolving facts. Unlike a
-coordinator that privately tasks workers, the shared channel keeps each function's decisions tied to one visible
-order state.
+Coffee Agntcy's work regularly crosses functional boundaries where several participants must challenge, correct, and
+extend the same evolving picture rather than report separately to a hub. **Group messaging** gives them one shared
+conversational surface, so questions, clarifications, and hand-offs remain visible to the whole group while a moderator
+keeps the discussion moving. The value is collective context, not a central agent privately relaying each update.
 
 ---
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/mediated_semantic_alignment.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/mediated_semantic_alignment.md
@@ -47,6 +47,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce, contracts, risk, partners, and tools, rather than a single team
 inside one building holding every fact.
 
+Commercial terms at Coffee Agntcy bind independent parties whose vocabulary carries unstated assumptions, and a
+deal signed over ambiguous words is a dispute deferred. **Mediated semantic alignment** supplies a neutral
+mechanism for settling meaning first: the engine structures issues and options while each participant weighs
+offers against private economics and reveals only its chosen position. Consensus patterns converge on a number;
+this pattern first establishes what any agreed number is actually about.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/orchestrator_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/orchestrator_agent.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Regional flows at Coffee Agntcy run in parallel against inventory and commitments that are ultimately shared, so
+each local decision can be sensible while the sum is impossible. The **orchestrator agent** sits at that seam: it
+watches several workflows at once, arbitrates competing claims under global policy, and escalates when precedence
+rules run out. A supervisor owns a single workflow's story; the orchestrator owns the space between workflows,
+where conflicts live.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/performance_scoring_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/performance_scoring_agent.md
@@ -43,6 +43,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Automated sourcing at Coffee Agntcy has to justify itself in the units leadership already budgets: cost, time,
+carbon, and quality. The **performance scoring agent** joins run telemetry with recorded business outcomes and
+publishes KPI scores under transparent formulas, giving the company a comparable record of how its agentic runs
+perform across cycles. Telemetry explains how a run unfolded and business outcomes show what it achieved; scoring
+turns those inputs into comparable numbers the firm can defend.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/policy-enforced_execution.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/policy-enforced_execution.md
@@ -43,6 +43,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Published sourcing standards only mean something at Coffee Agntcy if its automation cannot route around them.
+**Policy-enforced execution** wires those non-negotiables into the contracting path itself: enforcement checks
+identity-attributed supplier facts and returns explainable allow or deny decisions before any agreement forms. An
+approval gate asks a human to weigh a hard case; this pattern uniformly settles the cases the company has already
+decided, with denials that cite the rule instead of failing silently.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
@@ -65,11 +65,11 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
-Green coffee buying rewards the desk that hears the whole market before committing, and Coffee Agntcy's origins
-answer on their own terms and timetables. This workflow keeps buying authority with one supervisor while
-**publish-subscribe** transport turns a single inquiry into simultaneous deliveries to every subscribed farm
-agent. The business result is breadth with comparability: offers return through one observable channel as answers
-to the same question, and one accountable agent decides what happens next.
+Coffee Agntcy often needs one business question or update to reach several independent parties at the same time without
+creating a private connection to each one. **Publish-subscribe** provides that shared delivery mechanism: a publisher
+addresses a topic, every interested agent receives the same event, and orchestration remains responsible for
+interpreting the replies. The participant set can grow or change without rewriting the business step that initiated the
+exchange.
 
 ---
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe.md
@@ -65,6 +65,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Green coffee buying rewards the desk that hears the whole market before committing, and Coffee Agntcy's origins
+answer on their own terms and timetables. This workflow keeps buying authority with one supervisor while
+**publish-subscribe** transport turns a single inquiry into simultaneous deliveries to every subscribed farm
+agent. The business result is breadth with comparability: offers return through one observable channel as answers
+to the same question, and one accountable agent decides what happens next.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe_streaming.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/publish_subscribe_streaming.md
@@ -72,6 +72,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Time-pressed purchasing at Coffee Agntcy cares not only what each origin answers but when and in what shape the
+answer arrives. The **streaming** variant lets farm replies and specialist counsel reach the desk incrementally
+while the auction agent still gates what becomes official, so hesitation or bad news is visible before the desk
+commits. The classic workflow delivers a market of finished answers; this one delivers the market while it is
+still moving.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/resilience_&_re-routing.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/resilience_&_re-routing.md
@@ -45,6 +45,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Delivery promises at Coffee Agntcy are made to customers, not to carriers, so a partner failure must not become
+the customer's problem by default. **Resilience and re-routing** treats recovery as designed behavior: a monitor
+classifies the fault, the certified logistics directory yields a qualified replacement, and the coordinator
+updates the promise honestly instead of quietly absorbing the slip. Dispatch patterns choose the first
+specialist; this pattern keeps the flow coherent when the chosen one fails.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/secure_group_collaboration.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/secure_group_collaboration.md
@@ -46,6 +46,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Pricing and allocation conversations at Coffee Agntcy cross company boundaries: growers, intermediaries, and
+finance each see a different slice of a deal, and not every party may see every number. **Secure group
+collaboration** makes the trust boundary the design object, with authenticated membership, scoped visibility, and
+speech that remains attributable if terms are later disputed. Group messaging supplies the shared conversation;
+this pattern determines who belongs inside it and what their words commit them to.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/self-evaluation_agent.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/self-evaluation_agent.md
@@ -43,6 +43,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Sourcing at Coffee Agntcy runs on assumptions about harvests and suppliers that deserve to be confronted with
+recorded results. The **self-evaluation agent** institutionalizes that reckoning: it compares intent against
+outcomes and drafts bounded, reviewable changes to prompts and policies that a person can approve, reject, or
+defer. Where the feedback loop tunes selection weights inside preset gates, this pattern questions the settings
+themselves, and nothing changes until someone accountable signs off.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/sense-decide-act_loop.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/sense-decide-act_loop.md
@@ -44,6 +44,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Coffee moves through conditions that change faster than plans survive: carrier schedules slip, ports stall, and
+quality signals change. The **sense-decide-act loop** makes revision Coffee Agntcy's normal operating
+mode, with fresh signals continuously normalized into one situation picture and each cycle committing only the
+next small action under policy. Re-routing recovers after a declared failure; this loop treats every plan as
+provisional before anything has failed at all.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/session_context_buffer.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/session_context_buffer.md
@@ -47,6 +47,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Deals in motion generate state Coffee Agntcy needs every participant to share but nobody wants preserved: floors,
+counters, and constraints that hold only until the next message. The **session context buffer** scopes that
+volatile state to a single negotiation, with ownership and time-to-live keeping it authoritative while the deal
+lives and disposable once it closes. Longer-lived memory patterns hold what the company knows; this buffer holds
+only where one deal currently stands.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_agent_memory.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_agent_memory.md
@@ -80,11 +80,10 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
-An order crossing Coffee Agntcy's fulfillment chain accumulates facts that every later leg depends on, yet no
-message should have to carry all of them forever. **Shared agent memory** separates the two jobs the conversation
-was doing: transport keeps carrying dialogue between the logistics peers, while settled facts are retained once
-and recalled by whichever agent needs them, including one that restarted or joined late. The current truth about
-an order stops living only in the transcript.
+Coffee Agntcy's multi-agent work creates operational facts that remain relevant beyond the message that introduced them.
+**Shared agent memory** gives participants a common working state while transport continues to carry dialogue, so
+coordination depends on what the group now knows rather than on who still holds a particular transcript. The memory
+stays scoped to the current activity, distinct from the company's long-lived knowledge records.
 
 ---
 

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_agent_memory.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_agent_memory.md
@@ -80,6 +80,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+An order crossing Coffee Agntcy's fulfillment chain accumulates facts that every later leg depends on, yet no
+message should have to carry all of them forever. **Shared agent memory** separates the two jobs the conversation
+was doing: transport keeps carrying dialogue between the logistics peers, while settled facts are retained once
+and recalled by whichever agent needs them, including one that restarted or joined late. The current truth about
+an order stops living only in the transcript.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_knowledge_store.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/api/agentic_workflows/docs/workflows/shared_knowledge_store.md
@@ -43,6 +43,12 @@ promises** through operations, logistics, and finance it does not always own end
 those worlds: much of the drama is ordinary commerce-contracts, risk, partners, and tools-rather than a single team
 inside one building holding every fact.
 
+Contracting at Coffee Agntcy is a bet that history informs the next season, and history only helps if the company
+actually keeps it. The **shared knowledge store** turns accumulated experience with origins and partners into
+governed records, with keys, versions, and provenance any agent can cite. Unlike working memory scoped to a live
+task or deal, this store is the institutional layer: what the firm has learned across seasons, curated and
+auditable rather than merely remembered.
+
 ---
 
 ## Scenario

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_documentation.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/agentic_workflows/api/test_workflow_documentation.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import re
 from urllib.parse import quote
 
 import pytest
 from api.agentic_workflows.router import create_agentic_workflows_router
 from api.agentic_workflows.workflow_documentation import (
     load_parsed_workflow_documentation,
+    workflow_documentation_dir,
     workflow_name_to_documentation_slug,
 )
 from api.agentic_workflows.workflows import set_starting_workflows
@@ -39,6 +41,62 @@ def test_load_parsed_real_file_has_pattern_section() -> None:
     assert parsed is not None
     headings = [h for _, h, _ in parsed.sections]
     assert "Pattern" in headings
+
+
+def test_use_case_has_common_context_plus_unique_pattern_paragraph() -> None:
+    seen: dict[str, str] = {}
+
+    for path in sorted(workflow_documentation_dir().glob("*.md")):
+        parsed = load_parsed_workflow_documentation(path.stem)
+        assert parsed is not None, path.name
+
+        pattern_body = next(
+            (body for _, heading, body in parsed.sections if heading == "Pattern"),
+            "",
+        )
+        is_stub = "> **TODO** - full pattern-level write-up." in pattern_body
+
+        use_case_bodies = [
+            body
+            for _, heading, body in parsed.sections
+            if heading == "Use case"
+        ]
+
+        if is_stub:
+            assert not use_case_bodies, (
+                f"{path.name}: explicit stub unexpectedly has a Use case section"
+            )
+            continue
+
+        assert len(use_case_bodies) == 1, (
+            f"{path.name}: expected exactly one Use case section"
+        )
+
+        body = re.sub(r"\n+---\s*$", "", use_case_bodies[0].strip())
+        paragraphs = [
+            paragraph.strip()
+            for paragraph in re.split(r"\n\s*\n", body)
+            if paragraph.strip()
+        ]
+
+        assert len(paragraphs) == 2, (
+            f"{path.name}: expected common context plus one "
+            "pattern-specific paragraph"
+        )
+
+        common, specific = paragraphs
+        assert common.startswith(
+            "**Coffee Agntcy** is a coffee company"
+        ), path.name
+
+        specific = " ".join(specific.split())
+        assert specific, f"{path.name}: empty pattern-specific paragraph"
+        assert specific not in seen, (
+            f"{path.name} duplicates {seen[specific]}"
+        )
+        seen[specific] = path.name
+
+    assert seen
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

Adds pattern-specific Coffee Agntcy use-case context to each completed agentic workflow pattern document.

Each updated `## Use case` section now:

* preserves the existing common Coffee Agntcy company and supply-chain context;
* adds one concise paragraph explaining how the individual pattern applies within that company;
* connects the abstract `## Pattern` description to the concrete `## Scenario`;
* avoids duplicating or rewriting existing Scenario and Workflow content.

The three explicit minimal stubs, `peer_group.md`, `recruiter.md`, and `supervisor.md`, remain unchanged because they intentionally do not yet contain `## Use case` sections and identify their full pattern-level write-ups as follow-up work.

A parser-backed regression test dynamically discovers all workflow documentation and verifies that:

* explicit stubs do not unexpectedly contain a Use case section;
* every completed document contains exactly one Use case section;
* each completed Use case contains the common Coffee Agntcy context followed by exactly one nonempty pattern-specific paragraph;
* all pattern-specific paragraphs are unique.

## Issue Link

Fixes #725

## Type of Change

* [ ] Bugfix
* [ ] New Feature
* [ ] Breaking Change
* [ ] Refactor
* [x] Documentation
* [ ] Other (please describe)

## Testing

From `coffeeAGNTCY/coffee_agents/lungo`:

```text
uv run pytest tests/unit/agentic_workflows/api/test_workflow_documentation.py -q
10 passed

uv run pytest tests/unit -q
494 passed
```

Additional verification:

```text
git show --check HEAD
```

The final change updates 27 workflow documents and one regression-test file, with 216 insertions and no deletions.

## Checklist

* [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
* [x] Existing issues have been referenced (where applicable)
* [x] I have verified this change is not present in other open pull requests
* [x] Functionality is documented
* [x] All code style checks pass
* [x] New code contribution is covered by automated tests
* [x] All new and existing tests pass

