### PR TITLE
Eliminate dummy nodes from mcp calls

### DIFF
--- a/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/farms/colombia/agent.py
@@ -28,6 +28,7 @@ from agents.farms.colombia.card import AGENT_CARD, AGENT_ID
 from agents.mcp_servers.utils import invoke_payment_mcp_tool
 from common.llm import get_llm
 from common.mcp_client import call_mcp_tool
+from common.stable_agent_id import stable_agent_id_for_name
 
 logger = logging.getLogger("lungo.colombia_farm_agent.agent")
 
@@ -123,6 +124,8 @@ class FarmAgent:
             forecast = await call_mcp_tool(
                 topic="lungo_weather_service",
                 tool_name="get_forecast",
+                # OASF name in weather-mcp-server.json (not the transport topic).
+                target_stable_agent_id=stable_agent_id_for_name("Weather MCP Server"),
                 arguments={"location": "colombia"},
                 agent_id=AGENT_CARD.name,
                 source=AGENT_ID,

--- a/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/utils.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/agents/mcp_servers/utils.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from agents.exceptions import AuthError
 from common.mcp_client import call_mcp_tool
+from common.stable_agent_id import stable_agent_id_for_name
 
 
 async def invoke_payment_mcp_tool(
@@ -24,6 +25,8 @@ async def invoke_payment_mcp_tool(
     return await call_mcp_tool(
       topic="lungo_payment_service",
       tool_name=tool_name,
+      # OASF name in payment-mcp-server.json (not the transport topic).
+      target_stable_agent_id=stable_agent_id_for_name("Payment MCP Server"),
       agent_id=agent_id,
       source=source,
       workflow_name=workflow_name,

--- a/coffeeAGNTCY/coffee_agents/lungo/common/mcp_client/client.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/mcp_client/client.py
@@ -80,6 +80,7 @@ async def call_mcp_tool(
 	*,
 	topic: str,
 	tool_name: str,
+	target_stable_agent_id: str,
 	arguments: dict[str, Any] | None = None,
 	agent_id: str,
 	source: str,
@@ -102,6 +103,8 @@ async def call_mcp_tool(
 			(e.g. ``"lungo_weather_service"``). Also used as the ``mcp_server``
 			label for workflow topology events.
 		tool_name: Name of the tool to invoke.
+		target_stable_agent_id: Stable ``agent://`` id of the catalog MCP
+			server node (derived from the OASF record ``name`` field).
 		arguments: Tool arguments; defaults to ``{}``.
 		agent_id: Human-readable agent name for event emission.
 		source: Stable source id for event emission / correlation.
@@ -146,6 +149,7 @@ async def call_mcp_tool(
 		client,
 		agent_id=agent_id,
 		mcp_server=topic,
+		target_stable_agent_id=target_stable_agent_id,
 		source=source,
 		workflow_name=workflow_name,
 		instance_id=instance_id,

--- a/coffeeAGNTCY/coffee_agents/lungo/common/mcp_event_middleware/wrapper.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/mcp_event_middleware/wrapper.py
@@ -3,11 +3,10 @@
 
 """Client-side MCP middleware for emitting workflow topology events.
 
-Wraps an MCP client so each ``call_tool`` invocation emits a transient
-topology node: CREATE when the call starts and DELETE when it ends (success
-or error, including streamed responses). Pure event builders live in
-``common.workflow_utils.mcp``; this module owns the orchestration (identity
-resolution, timing, sink lifecycle).
+Wraps an MCP client so each ``call_tool`` invocation emits UPDATE events on
+the catalog edge between the invoking agent and the target MCP server node.
+Pure event builders live in ``common.workflow_utils.mcp``; this module owns
+the orchestration (identity resolution, timing, sink lifecycle).
 
 Workflow identity for the farm-to-MCP hop is resolved once, at wrap time,
 in this order:
@@ -23,22 +22,19 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from time import monotonic
 from typing import Any, AsyncIterator
-from uuid import uuid4
 
 from pydantic import ValidationError
 
 from common.workflow_utils.event_sink import WorkflowAPIEventSink
 from common.workflow_utils.inflight import (
-	RuntimeIdAllocator,
 	read_trace_context,
 	resolve_correlation_id,
 )
-from common.workflow_utils.mcp import emit_mcp_tool_call_event
+from common.workflow_utils.mcp import emit_mcp_edge_event
 from common.workflow_utils.workflow_catalog import lookup_workflow
 from config.config import EMIT_WORKFLOW_EVENTS
-from schema.types import InstanceId, Operation
+from schema.types import InstanceId
 
 logger = logging.getLogger("lungo.common.event_middleware")
 
@@ -149,9 +145,9 @@ class EventEmittingMCPClient:
 		*,
 		agent_id: str,
 		mcp_server: str,
+		target_stable_agent_id: str,
 		source: str,
 		identity: _ResolvedIdentity,
-		layer_index: int = 0,
 	) -> None:
 		# ``_cm`` is the async context manager handed to us; ``_session`` is the
 		# object that exposes call_tool/list_tools. They are the same until
@@ -162,13 +158,9 @@ class EventEmittingMCPClient:
 		self._session = client
 		self._agent_id = agent_id
 		self._mcp_server = mcp_server
+		self._target_stable_agent_id = target_stable_agent_id
 		self._source = source
 		self._identity = identity
-		self._layer_index = layer_index
-		self._allocator = RuntimeIdAllocator()
-		# Active call_tool count: the invoking-agent node is created on the
-		# first in-flight call and deleted when the last one ends.
-		self._inflight = 0
 		self._event_sink = WorkflowAPIEventSink()
 
 	async def __aenter__(self) -> "EventEmittingMCPClient":
@@ -203,92 +195,56 @@ class EventEmittingMCPClient:
 	async def _emit(
 		self,
 		*,
-		operation: Operation,
 		tool_name: str,
-		call_key: str,
+		mcp_in_flight: bool,
 		correlation_id: str,
-		duration_ms: float | None = None,
-		error: str | None = None,
-		delete_agent_node: bool = False,
 	) -> None:
 		"""Best-effort emission; never propagates failures to the tool call."""
 		try:
-			await emit_mcp_tool_call_event(
+			await emit_mcp_edge_event(
 				sink=self._event_sink,
 				source=self._source,
 				agent_id=self._agent_id,
 				tool_name=tool_name,
 				mcp_server=self._mcp_server,
-				operation=operation,
-				allocator=self._allocator,
-				call_key=call_key,
+				target_stable_agent_id=self._target_stable_agent_id,
+				mcp_in_flight=mcp_in_flight,
 				correlation_id=correlation_id,
 				workflow_name=self._identity.workflow_name,
 				instance_id=self._identity.instance_id,
 				trace_id=self._identity.trace_id,
 				span_id=self._identity.span_id,
-				layer_index=self._layer_index,
-				duration_ms=duration_ms,
-				error=error,
-				delete_agent_node=delete_agent_node,
 			)
 		except Exception as exc:
 			logger.warning(
-				"EventEmittingMCPClient [%s]: failed to emit %s event for tool "
-				"%s: %s",
+				"EventEmittingMCPClient [%s]: failed to emit mcp_in_flight=%s "
+				"event for tool %s: %s",
 				self._source,
-				operation,
+				mcp_in_flight,
 				tool_name,
 				exc,
 			)
 
-	async def _emit_end(
-		self,
-		*,
-		tool_name: str,
-		call_key: str,
-		correlation_id: str,
-		start: float,
-		error: str | None = None,
-	) -> None:
-		"""Emit the DELETE event, removing the agent node on the last call."""
-		self._inflight -= 1
-		await self._emit(
-			operation=Operation.DELETE,
-			tool_name=tool_name,
-			call_key=call_key,
-			correlation_id=correlation_id,
-			duration_ms=(monotonic() - start) * 1000.0,
-			error=error,
-			delete_agent_node=self._inflight <= 0,
-		)
-
 	async def call_tool(self, *args: Any, **kwargs: Any) -> Any:
-		"""Invoke the underlying tool, emitting CREATE/DELETE topology events."""
+		"""Invoke the underlying tool, emitting start/end edge UPDATE events."""
 		tool_name = self._extract_tool_name(args, kwargs)
 		correlation_id = resolve_correlation_id(
 			ctx_state={}, trace_id=self._identity.trace_id,
 		)
-		call_key = f"mcp-tool-{self._agent_id}-{tool_name}-{uuid4()}"
 
-		self._inflight += 1
 		await self._emit(
-			operation=Operation.CREATE,
 			tool_name=tool_name,
-			call_key=call_key,
+			mcp_in_flight=True,
 			correlation_id=correlation_id,
 		)
 
-		start = monotonic()
 		try:
 			result = await self._session.call_tool(*args, **kwargs)
-		except Exception as exc:
-			await self._emit_end(
+		except Exception:
+			await self._emit(
 				tool_name=tool_name,
-				call_key=call_key,
+				mcp_in_flight=False,
 				correlation_id=correlation_id,
-				start=start,
-				error=str(exc),
 			)
 			raise
 
@@ -296,16 +252,13 @@ class EventEmittingMCPClient:
 			return self._instrument_stream(
 				result,
 				tool_name=tool_name,
-				call_key=call_key,
 				correlation_id=correlation_id,
-				start=start,
 			)
 
-		await self._emit_end(
+		await self._emit(
 			tool_name=tool_name,
-			call_key=call_key,
+			mcp_in_flight=False,
 			correlation_id=correlation_id,
-			start=start,
 		)
 		return result
 
@@ -314,25 +267,17 @@ class EventEmittingMCPClient:
 		source_iter: AsyncIterator[Any],
 		*,
 		tool_name: str,
-		call_key: str,
 		correlation_id: str,
-		start: float,
 	) -> AsyncIterator[Any]:
-		"""Forward streamed chunks, emitting DELETE on completion or error."""
-		error: str | None = None
+		"""Forward streamed chunks, emitting end on completion or error."""
 		try:
 			async for chunk in source_iter:
 				yield chunk
-		except Exception as exc:
-			error = str(exc)
-			raise
 		finally:
-			await self._emit_end(
+			await self._emit(
 				tool_name=tool_name,
-				call_key=call_key,
+				mcp_in_flight=False,
 				correlation_id=correlation_id,
-				start=start,
-				error=error,
 			)
 
 
@@ -341,10 +286,10 @@ def wrap_mcp_client(
 	*,
 	agent_id: str,
 	mcp_server: str,
+	target_stable_agent_id: str,
 	source: str,
 	workflow_name: str | None = None,
 	instance_id: str | None = None,
-	layer_index: int = 0,
 ) -> Any:
 	"""Wrap an MCP client for event emission, or return it unwrapped.
 
@@ -373,7 +318,7 @@ def wrap_mcp_client(
 		client,
 		agent_id=agent_id,
 		mcp_server=mcp_server,
+		target_stable_agent_id=target_stable_agent_id,
 		source=source,
 		identity=identity,
-		layer_index=layer_index,
 	)

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/__init__.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/__init__.py
@@ -13,6 +13,7 @@ from common.workflow_instance_store.discovery_layout import enrich_discovery_nod
 from common.workflow_instance_store.merge import (
     merge_event_data,
     merge_topology_delta,
+    reconcile_event_mcp_edges,
     reconcile_event_node_identities,
 )
 from common.workflow_instance_store.notifier import NoOpNotifier, NotifierProtocol
@@ -30,5 +31,6 @@ __all__ = [
     "enrich_discovery_node_layout",
     "merge_event_data",
     "merge_topology_delta",
+    "reconcile_event_mcp_edges",
     "reconcile_event_node_identities",
 ]

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/merge.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/merge.py
@@ -39,9 +39,12 @@ already deep-copied.
 from __future__ import annotations
 
 import copy
+import logging
 from typing import Any
 
-from schema.types import Data, Event, NodeId, Operation, Workflow
+from schema.types import Data, EdgeId, Event, NodeId, Operation, Workflow
+
+logger = logging.getLogger(__name__)
 
 
 def _topology_lists_insertion_order(by_id: dict[str, dict]) -> list[dict]:
@@ -268,6 +271,132 @@ def _existing_stable_agent_id_index(
         if sid is not None:
             index.setdefault(sid, node.id.root)
     return index
+
+
+def _topology_nodes_for_instance(
+    state_wf: Workflow | None,
+    instance_id: str,
+) -> list:
+    """Return nodes for one instance, falling back to ``starting_topology``."""
+    if state_wf is None:
+        return []
+    inst = state_wf.instances.get(instance_id)
+    if inst is not None and inst.topology is not None and inst.topology.nodes:
+        return inst.topology.nodes
+    if (
+        state_wf.starting_topology is not None and state_wf.starting_topology.nodes
+    ):
+        return state_wf.starting_topology.nodes
+    return []
+
+
+def _topology_edges_for_instance(
+    state_wf: Workflow | None,
+    instance_id: str,
+) -> list:
+    """Return edges for one instance, falling back to ``starting_topology``."""
+    if state_wf is None:
+        return []
+    inst = state_wf.instances.get(instance_id)
+    if inst is not None and inst.topology is not None and inst.topology.edges:
+        return inst.topology.edges
+    if (
+        state_wf.starting_topology is not None and state_wf.starting_topology.edges
+    ):
+        return state_wf.starting_topology.edges
+    return []
+
+
+def _edge_stable_agent_id_pair(edge: Any) -> tuple[str, str] | None:
+    """Read ``(source_stable_agent_id, target_stable_agent_id)`` from an edge."""
+    src = getattr(edge, "source_stable_agent_id", None)
+    tgt = getattr(edge, "target_stable_agent_id", None)
+    if isinstance(src, str) and isinstance(tgt, str) and src and tgt:
+        return src, tgt
+    return None
+
+
+def _existing_stable_edge_index(
+    state_wf: Workflow | None,
+    instance_id: str,
+) -> dict[tuple[str, str], str]:
+    """Map ``(source_sid, target_sid)`` -> existing edge id for one instance."""
+    nodes = _topology_nodes_for_instance(state_wf, instance_id)
+    edges = _topology_edges_for_instance(state_wf, instance_id)
+    id_to_sid: dict[str, str] = {}
+    for node in nodes:
+        sid = _node_stable_agent_id(node)
+        if sid is not None:
+            id_to_sid[node.id.root] = sid
+    index: dict[tuple[str, str], str] = {}
+    for edge in edges:
+        if edge.source is None or edge.target is None:
+            continue
+        src_sid = id_to_sid.get(edge.source.root)
+        tgt_sid = id_to_sid.get(edge.target.root)
+        if src_sid is not None and tgt_sid is not None:
+            index.setdefault((src_sid, tgt_sid), edge.id.root)
+    return index
+
+
+def reconcile_event_mcp_edges(state: Data, event: Event) -> Event:
+    """Resolve MCP edge identity server-side before merging.
+
+    Incoming edges carrying ``source_stable_agent_id`` and
+    ``target_stable_agent_id`` are rewritten to the live catalog edge id
+    and endpoint node ids. Unresolvable edges are dropped.
+
+    Returns a new :class:`Event`; the input is never mutated.
+    """
+    result = event.model_copy(deep=True)
+    for wf_name, wf in result.data.workflows.items():
+        state_wf = state.workflows.get(wf_name)
+        for instance_id, inst in wf.instances.items():
+            topology = inst.topology
+            if topology is None or not topology.edges:
+                continue
+            node_index = _existing_stable_agent_id_index(state_wf, instance_id)
+            edge_index = _existing_stable_edge_index(state_wf, instance_id)
+            if not edge_index:
+                continue
+            kept_edges: list = []
+            for edge in topology.edges:
+                sid_pair = _edge_stable_agent_id_pair(edge)
+                if sid_pair is None:
+                    kept_edges.append(edge)
+                    continue
+                existing_edge_id = edge_index.get(sid_pair)
+                if existing_edge_id is None:
+                    logger.warning(
+                        "reconcile_event_mcp_edges: no catalog edge for "
+                        "stable pair %s -> %s in workflow %r instance %r; "
+                        "dropping edge item",
+                        sid_pair[0],
+                        sid_pair[1],
+                        wf_name,
+                        instance_id,
+                    )
+                    continue
+                src_nid = node_index.get(sid_pair[0])
+                tgt_nid = node_index.get(sid_pair[1])
+                if src_nid is None or tgt_nid is None:
+                    logger.warning(
+                        "reconcile_event_mcp_edges: missing node ids for "
+                        "stable pair %s -> %s in workflow %r instance %r; "
+                        "dropping edge item",
+                        sid_pair[0],
+                        sid_pair[1],
+                        wf_name,
+                        instance_id,
+                    )
+                    continue
+                edge.id = EdgeId(root=existing_edge_id)
+                edge.source = NodeId(root=src_nid)
+                edge.target = NodeId(root=tgt_nid)
+                edge.operation = Operation.UPDATE
+                kept_edges.append(edge)
+            topology.edges = kept_edges
+    return result
 
 
 def reconcile_event_node_identities(state: Data, event: Event) -> Event:

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/store.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_instance_store/store.py
@@ -46,6 +46,7 @@ from common.workflow_instance_store.discovery_layout import (
 )
 from common.workflow_instance_store.merge import (
     merge_event_data,
+    reconcile_event_mcp_edges,
     reconcile_event_node_identities,
 )
 from common.workflow_instance_store.notifier import NoOpNotifier, NotifierProtocol
@@ -145,6 +146,7 @@ class _MergeCoordinator:
                 touched = _touched_instance_ids(item)
                 with self._state_lock:
                     normalized = reconcile_event_node_identities(self._state, item)
+                    normalized = reconcile_event_mcp_edges(self._state, normalized)
                     normalized = enrich_discovery_node_layout(self._state, normalized)
                     self._state = merge_event_data(self._state, normalized)
                 if touched:

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_utils/__init__.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_utils/__init__.py
@@ -12,9 +12,8 @@ from common.workflow_utils.builders import (
 )
 from common.workflow_utils.event_sink import EventSink, WorkflowAPIEventSink
 from common.workflow_utils.mcp import (
-	MCP_TOOL_NODE_TYPE,
-	build_mcp_tool_topology,
-	emit_mcp_tool_call_event,
+	build_mcp_edge_topology,
+	emit_mcp_edge_event,
 )
 from common.workflow_utils.inflight import (
 	InterceptionState,
@@ -51,9 +50,8 @@ __all__ = [
 	"build_metadata",
 	"build_event",
 	"init_starting_topology",
-	"MCP_TOOL_NODE_TYPE",
-	"build_mcp_tool_topology",
-	"emit_mcp_tool_call_event",
+	"build_mcp_edge_topology",
+	"emit_mcp_edge_event",
 	"read_trace_context",
 	"resolve_correlation_id",
 	"resolve_consumer_state",

--- a/coffeeAGNTCY/coffee_agents/lungo/common/workflow_utils/mcp.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/common/workflow_utils/mcp.py
@@ -1,165 +1,89 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Transport-agnostic builders for MCP tool-call topology events.
+"""Transport-agnostic builders for MCP tool-call edge topology events.
 
-An MCP tool call is modeled as a transient topology node: a CREATE event when
-the tool call starts and a DELETE event when it ends (success or error). The
-invoking agent node carries a stable_agent_id so it merges with the same agent
-node the A2A middleware emits.
+An MCP tool call is modeled as an UPDATE on an existing catalog edge between
+the invoking agent and the MCP server node. Emitters carry ``stable_agent_id``
+endpoint pairs; the merge layer resolves live ``edge://`` ids server-side.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from uuid import uuid4
 
 from schema.types import (
+	EdgeId,
 	Event,
 	EventType,
 	Operation,
+	PartialEdge,
 	PartialTopology,
-	TopologyEdgeItem,
-	TopologyNodeItem,
 )
 
 from common.stable_agent_id import stable_agent_id_for_name
-from common.workflow_utils.builders import build_event, make_edge, make_node
+from common.workflow_utils.builders import build_event
 from common.workflow_utils.event_sink import EventSink
-from common.workflow_utils.inflight import RuntimeIdAllocator
-
-MCP_TOOL_NODE_TYPE = "mcp_tool_call"
-_AGENT_NODE_TYPE = "customNode"
 
 
-async def build_mcp_tool_topology(
+def build_mcp_edge_topology(
 	agent_id: str,
 	tool_name: str,
 	mcp_server: str,
+	target_stable_agent_id: str,
 	*,
-	operation: Operation,
-	allocator: RuntimeIdAllocator,
-	call_key: str,
-	layer_index: int = 0,
-	duration_ms: float | None = None,
-	error: str | None = None,
-	delete_agent_node: bool = False,
+	mcp_in_flight: bool,
 ) -> PartialTopology:
-	"""Build a topology fragment for one MCP tool-call lifecycle event.
+	"""Build a topology fragment for one MCP tool-call edge event.
 
-	CREATE emits the invoking-agent node, the transient tool-call node
-	(carrying tool_name + mcp_server), and the connecting edge. DELETE removes
-	the tool-call node and its edge, attaching duration_ms/error when present;
-	when ``delete_agent_node`` is set (last in-flight call for this agent) the
-	invoking-agent node is removed too so it does not linger in the snapshot.
+	Emits a single edge UPDATE keyed by ``source_stable_agent_id`` and
+	``target_stable_agent_id`` extras. The workflow API reconcile step
+	replaces the placeholder edge id with the live catalog edge id.
 	"""
-	agent_node = await allocator.node_id(f"agent-{agent_id}")
-	tool_node = await allocator.node_id(call_key)
-
-	if operation == Operation.CREATE:
-		nodes: list[TopologyNodeItem] = [
-			make_node(
-				agent_node,
-				operation=Operation.CREATE,
-				node_type=_AGENT_NODE_TYPE,
-				label=agent_id,
-				layer_index=layer_index,
-				stable_agent_id=stable_agent_id_for_name(agent_id),
+	source_stable_agent_id = stable_agent_id_for_name(agent_id)
+	return PartialTopology(
+		nodes=[],
+		edges=[
+			PartialEdge(
+				id=EdgeId(f"edge://{uuid4()}"),
+				operation=Operation.UPDATE,
+				source_stable_agent_id=source_stable_agent_id,
+				target_stable_agent_id=target_stable_agent_id,
+				tool_name=tool_name,
+				mcp_server=mcp_server,
+				mcp_in_flight=mcp_in_flight,
 			),
-			make_node(
-				tool_node,
-				operation=Operation.CREATE,
-				node_type=MCP_TOOL_NODE_TYPE,
-				label=tool_name,
-				layer_index=layer_index + 1,
-				extras={"tool_name": tool_name, "mcp_server": mcp_server},
-			),
-		]
-		edges: list[TopologyEdgeItem] = [
-			await make_edge(
-				agent_node,
-				tool_node,
-				operation=Operation.CREATE,
-				allocator=allocator,
-			),
-		]
-		return PartialTopology(nodes=nodes, edges=edges)
-
-	tool_extras: dict[str, Any] = {}
-	if duration_ms is not None:
-		tool_extras["duration_ms"] = duration_ms
-	if error is not None:
-		tool_extras["error"] = error
-
-	nodes = [
-		make_node(
-			tool_node,
-			operation=Operation.DELETE,
-			node_type=MCP_TOOL_NODE_TYPE,
-			label=tool_name,
-			layer_index=layer_index + 1,
-			include_size=False,
-			extras=tool_extras,
-		),
-	]
-	if delete_agent_node:
-		nodes.append(
-			make_node(
-				agent_node,
-				operation=Operation.DELETE,
-				node_type=_AGENT_NODE_TYPE,
-				label=agent_id,
-				layer_index=layer_index,
-				include_size=False,
-			)
-		)
-	edges = [
-		await make_edge(
-			agent_node,
-			tool_node,
-			operation=Operation.DELETE,
-			allocator=allocator,
-		),
-	]
-	return PartialTopology(nodes=nodes, edges=edges)
+		],
+	)
 
 
-def _correlation_message(operation: Operation, tool_name: str, mcp_server: str) -> str:
-	verb = "start" if operation == Operation.CREATE else "end"
+def _correlation_message(mcp_in_flight: bool, tool_name: str, mcp_server: str) -> str:
+	verb = "start" if mcp_in_flight else "end"
 	return f"mcp tool {verb}: {tool_name} on {mcp_server}"
 
 
-async def emit_mcp_tool_call_event(
+async def emit_mcp_edge_event(
 	*,
 	sink: EventSink,
 	source: str,
 	agent_id: str,
 	tool_name: str,
 	mcp_server: str,
-	operation: Operation,
-	allocator: RuntimeIdAllocator,
-	call_key: str,
+	target_stable_agent_id: str,
+	mcp_in_flight: bool,
 	correlation_id: str,
 	workflow_name: str,
 	instance_id: str,
 	trace_id: int | None = None,
 	span_id: int | None = None,
-	layer_index: int = 0,
-	duration_ms: float | None = None,
-	error: str | None = None,
-	delete_agent_node: bool = False,
 ) -> Event:
-	"""Build and emit one MCP tool-call topology event via the sink."""
-	topology = await build_mcp_tool_topology(
+	"""Build and emit one MCP edge topology event via the sink."""
+	topology = build_mcp_edge_topology(
 		agent_id,
 		tool_name,
 		mcp_server,
-		operation=operation,
-		allocator=allocator,
-		call_key=call_key,
-		layer_index=layer_index,
-		duration_ms=duration_ms,
-		error=error,
-		delete_agent_node=delete_agent_node,
+		target_stable_agent_id,
+		mcp_in_flight=mcp_in_flight,
 	)
 	event = build_event(
 		source=source,
@@ -168,7 +92,7 @@ async def emit_mcp_tool_call_event(
 		topology=topology,
 		correlation_id=correlation_id,
 		event_type=EventType.STATE_PROGRESS_UPDATE,
-		correlation_message=_correlation_message(operation, tool_name, mcp_server),
+		correlation_message=_correlation_message(mcp_in_flight, tool_name, mcp_server),
 		trace_id=trace_id,
 		span_id=span_id,
 	)

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/a2a_event_schema_middleware.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/a2a_event_schema_middleware.md
@@ -8,7 +8,7 @@ and MCP tool calls.
 Shared, transport-agnostic pieces live in `common/workflow_utils/`:
 
 - `common/workflow_utils/builders.py` - `event_v1` metadata, nodes, edges, and full `Event` assembly.
-- `common/workflow_utils/mcp.py` - transient MCP tool-call topology builders + `emit_mcp_tool_call_event`.
+- `common/workflow_utils/mcp.py` - MCP edge topology builders + `emit_mcp_edge_event`.
 - `common/workflow_utils/event_sink.py` - `EventSink` and `WorkflowAPIEventSink` (HTTP POST to workflow API).
 - `common/workflow_utils/inflight.py` - trace-scoped in-flight state, runtime ID allocator, span-end cleanup.
 - `common/workflow_utils/workflow_catalog.py` - workflow name → pattern/use-case metadata (`lookup_workflow`).
@@ -96,23 +96,36 @@ Both events are correlated by OTel `trace_id` and a shared in-flight state map.
 
 ## MCP Tool-Call Events
 
-MCP tool calls are modeled as **transient** topology nodes rather than the
-persistent caller/transport/remote nodes used for A2A.
+MCP tool calls are modeled as **edge UPDATE** events on existing catalog edges
+between the invoking agent and the target MCP server node (no transient nodes).
 
 - **`EventEmittingMCPClient` / `wrap_mcp_client(...)`**
-  - `wrap_mcp_client(...)` resolves identity once (see below) and returns either an `EventEmittingMCPClient` or, when no identity resolves (or `EMIT_WORKFLOW_EVENTS` is false), the **original client unwrapped** so the tool call behaves exactly as before.
-  - The wrapper keeps the original async context manager (`_cm`) and the object it yields (`_session`) separate: `__aexit__` always closes `_cm` so the SDK client's teardown (cancelling its anyio task group, closing streams) runs, while `call_tool`/`list_tools` and other attributes delegate to `_session`. Exiting the yielded session instead leaks those streams and hangs the event loop.
-  - Intercepts `call_tool` (positional `name` or `name=` keyword), emitting one event when the call starts and one when it ends.
+  - `wrap_mcp_client(...)` requires `target_stable_agent_id` (derived from the
+    target MCP server OASF record `name`) in addition to the transport `topic`.
+  - Resolves workflow identity once (see below) and returns either an
+    `EventEmittingMCPClient` or, when no identity resolves (or
+    `EMIT_WORKFLOW_EVENTS` is false), the **original client unwrapped**.
+  - The wrapper keeps the original async context manager (`_cm`) and the object
+    it yields (`_session`) separate: `__aexit__` always closes `_cm` so the SDK
+    client's teardown runs, while `call_tool`/`list_tools` delegate to
+    `_session`.
+  - Intercepts `call_tool`, emitting one edge event when the call starts and
+    one when it ends.
   - Best-effort: emission failures are logged, never raised to the tool caller.
 
 ### Lifecycle
 
-1. **Start** → `Operation.CREATE`: emits the invoking-agent node (carrying `stable_agent_id` so it merges with the A2A agent node), a transient `mcp_tool_call` node (extras `tool_name`, `mcp_server`), and the connecting edge.
-2. **End** → `Operation.DELETE`: removes the `mcp_tool_call` node and edge, attaching `duration_ms` and (on failure) `error`. The wrapper refcounts in-flight calls and, when the last one ends, the DELETE also removes the invoking-agent node so it does not linger in the instance snapshot (the frontend still renders the agent via the A2A node, which shares the same `stable_agent_id`).
-   - For non-streaming results, DELETE is emitted as soon as `call_tool` returns.
-   - For streamed (async-iterable) results, the wrapper returns a proxy iterator and emits DELETE only when iteration completes or raises.
+1. **Start** → `Operation.UPDATE` on a placeholder edge carrying
+   `source_stable_agent_id`, `target_stable_agent_id`, and `mcp_in_flight=true`.
+2. **End** → same edge with `mcp_in_flight=false`.
+   - For non-streaming results, end is emitted when `call_tool` returns.
+   - For streamed (async-iterable) results, end is emitted when iteration
+     completes or raises.
 
-The CREATE and DELETE of one call share a `node://`/`edge://` id (same per-instance `RuntimeIdAllocator` + per-call `call_key`), so the frontend can add and later remove the same transient node.
+The workflow API runs `reconcile_event_mcp_edges` before merge: it looks up the
+live catalog `edge://` id and endpoint `node://` ids from the instance (or
+`starting_topology`) using the stable-id pair, then applies the UPDATE on that
+edge. The frontend animates the existing branching edge via SSE highlight.
 
 ### Workflow Identity Propagation (supervisor → farm)
 
@@ -127,6 +140,10 @@ supervisor's workflow instance:
    3. otherwise **None** - the client is returned unwrapped and no events are emitted (the tool call still runs).
    In all cases the candidate must validate (workflow_name in the catalog, `instance_id` matching `instance://<uuid>`); an invalid candidate falls through to the next source.
 4. `register_cleanup_span_processor()` is registered on the farm (`farm_server.py`) for parity with the supervisor.
+
+Call sites pass `target_stable_agent_id=stable_agent_id_for_name("<OASF name>")` —
+for example `"Weather MCP Server"` or `"Payment MCP Server"` — not the transport
+topic string.
 
 ## Design Notes
 

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/a2a_event_schema_middleware.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/a2a_event_schema_middleware.md
@@ -141,8 +141,8 @@ supervisor's workflow instance:
    In all cases the candidate must validate (workflow_name in the catalog, `instance_id` matching `instance://<uuid>`); an invalid candidate falls through to the next source.
 4. `register_cleanup_span_processor()` is registered on the farm (`farm_server.py`) for parity with the supervisor.
 
-Call sites pass `target_stable_agent_id=stable_agent_id_for_name("<OASF name>")` —
-for example `"Weather MCP Server"` or `"Payment MCP Server"` — not the transport
+Call sites pass `target_stable_agent_id=stable_agent_id_for_name("<OASF name>")`,
+for example `"Weather MCP Server"` or `"Payment MCP Server"`, not the transport
 topic string.
 
 ## Design Notes

--- a/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
+++ b/coffeeAGNTCY/coffee_agents/lungo/docs/workflow-instance_api.md
@@ -326,6 +326,8 @@ Returns `404` when `workflow_name` is not in the catalog.
 
 > **Note on node ids.** At startup the catalog loader assigns fresh runtime `node://`/`edge://` ids and derives `stable_agent_id` (a UUID5 of the agent record `name`) for agent nodes. Treat ids returned by the API as the live values; do not assume they match the static JSON file verbatim.
 
+> **MCP edge events.** MCP middleware emits edge-only partials keyed by `(source_stable_agent_id, target_stable_agent_id)`. Before merge, `reconcile_event_mcp_edges` resolves them to the live catalog edge id and endpoint node ids from the instance topology (or `starting_topology` when the instance graph is still empty).
+
 ---
 
 ## Workflow-instance lifecycle & state

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/workflowGraph/useWorkflowGraphFromAgenticApi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/workflowGraph/useWorkflowGraphFromAgenticApi.ts
@@ -141,7 +141,10 @@ export function useWorkflowGraphFromAgenticApi({
         instanceId,
       )
       const ids = messagingHighlightIdsFromTopology(partial)
-      const hasAny = ids.nodeIds.size > 0 || ids.edgeIds.size > 0
+      const hasAny =
+        ids.nodeIds.size > 0 ||
+        ids.edgeIds.size > 0 ||
+        ids.edgePairs.size > 0
       if (hasAny) {
         lastMessagingHighlightRef.current = {
           nodeIds: new Set(ids.nodeIds),

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/workflowGraph/useWorkflowGraphFromAgenticApi.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/hooks/workflowGraph/useWorkflowGraphFromAgenticApi.ts
@@ -142,9 +142,7 @@ export function useWorkflowGraphFromAgenticApi({
       )
       const ids = messagingHighlightIdsFromTopology(partial)
       const hasAny =
-        ids.nodeIds.size > 0 ||
-        ids.edgeIds.size > 0 ||
-        ids.edgePairs.size > 0
+        ids.nodeIds.size > 0 || ids.edgeIds.size > 0 || ids.edgePairs.size > 0
       if (hasAny) {
         lastMessagingHighlightRef.current = {
           nodeIds: new Set(ids.nodeIds),

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.test.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright AGNTCY Contributors (https://github.com/agntcy)
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+import { describe, expect, it } from "vitest"
+import {
+  messagingHighlightIdsFromTopology,
+  patchGraphActiveHighlight,
+} from "@/utils/workflowEventMessagingHighlight"
+
+describe("workflowEventMessagingHighlight", () => {
+  it("highlights edge-only partial with resolved catalog edge id", () => {
+    const catalogEdgeId = "edge://1a000001-0001-4000-a001-e00000000005"
+    const sourceSid = "agent://colombia-farm-stable"
+    const targetSid = "agent://weather-mcp-stable"
+    const partial = {
+      nodes: [],
+      edges: [
+        {
+          id: catalogEdgeId,
+          source: "node://colombia-wire",
+          target: "node://weather-wire",
+        },
+      ],
+    }
+
+    const ids = messagingHighlightIdsFromTopology(partial)
+    expect(ids.nodeIds.size).toBe(0)
+    expect(ids.edgeIds.has(catalogEdgeId)).toBe(true)
+    expect(
+      ids.edgePairs.has(`${sourceSid}->${targetSid}`) ||
+        ids.edgePairs.has("node://colombia-wire->node://weather-wire"),
+    ).toBe(true)
+
+    const edges = [
+      {
+        id: catalogEdgeId,
+        source: sourceSid,
+        target: targetSid,
+        animated: false,
+        data: {},
+      },
+    ]
+    const { edges: highlighted } = patchGraphActiveHighlight([], edges, ids)
+    expect(highlighted[0]?.animated).toBe(true)
+  })
+
+  it("indexes stable agent id pairs from edge wire fields", () => {
+    const sourceSid = "agent://colombia-farm-stable"
+    const targetSid = "agent://weather-mcp-stable"
+    const ids = messagingHighlightIdsFromTopology({
+      nodes: [],
+      edges: [
+        {
+          id: "edge://catalog-mcp",
+          source: "node://colombia-wire",
+          target: "node://weather-wire",
+          source_stable_agent_id: sourceSid,
+          target_stable_agent_id: targetSid,
+        },
+      ],
+    })
+
+    expect(ids.edgePairs.has(`${sourceSid}->${targetSid}`)).toBe(true)
+  })
+})

--- a/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.ts
+++ b/coffeeAGNTCY/coffee_agents/lungo/frontend/src/utils/workflowEventMessagingHighlight.ts
@@ -76,6 +76,15 @@ function collectMessagingHighlightIds(
 
   for (const edge of topology.edges ?? []) {
     if (hasText(edge.id)) edgeIds.add(edge.id)
+
+    const sourceStable = (edge as { source_stable_agent_id?: string })
+      .source_stable_agent_id
+    const targetStable = (edge as { target_stable_agent_id?: string })
+      .target_stable_agent_id
+    if (hasText(sourceStable) && hasText(targetStable)) {
+      edgePairs.add(edgePairId(sourceStable, targetStable))
+    }
+
     if (!hasText(edge.source) || !hasText(edge.target)) continue
 
     const source = wireIdToRenderedId.get(edge.source) ?? edge.source

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_client.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_client.py
@@ -86,6 +86,7 @@ async def _run(captured, session, **overrides):
     kwargs = dict(
         topic="lungo_weather_service",
         tool_name="get_forecast",
+        target_stable_agent_id="agent://00000000-0000-4000-8000-000000000099",
         arguments={"location": "colombia"},
         agent_id="Colombia Coffee Farm",
         source="colombia_coffee_farm",

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_event_middleware.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_event_middleware.py
@@ -12,8 +12,8 @@ from common.mcp_event_middleware import wrap_mcp_client
 from common.mcp_event_middleware import wrapper as wrapper_mod
 from common.stable_agent_id import stable_agent_id_for_name
 from common.workflow_context_prop import (
-	attach_workflow_context,
-	detach_workflow_context,
+    attach_workflow_context,
+    detach_workflow_context,
 )
 
 _AGENT_ID = "Colombia Coffee Farm"
@@ -25,313 +25,313 @@ _INSTANCE_ID = "instance://00000000-0000-4000-8000-000000000001"
 
 
 class _CapturingSink:
-	"""Sink stub that records emitted events on the instance."""
+    """Sink stub that records emitted events on the instance."""
 
-	def __init__(self, *args, **kwargs) -> None:
-		self.events: list = []
+    def __init__(self, *args, **kwargs) -> None:
+        self.events: list = []
 
-	async def emit(self, event) -> None:
-		self.events.append(event)
+    async def emit(self, event) -> None:
+        self.events.append(event)
 
-	async def aclose(self) -> None:
-		return None
+    async def aclose(self) -> None:
+        return None
 
 
 async def _aiter(items):
-	for item in items:
-		yield item
+    for item in items:
+        yield item
 
 
 async def _aiter_then_raise(items, exc):
-	for item in items:
-		yield item
-	raise exc
+    for item in items:
+        yield item
+    raise exc
 
 
 class _FakeMCPClient:
-	"""Duck-typed MCP client used to drive the wrapper."""
+    """Duck-typed MCP client used to drive the wrapper."""
 
-	def __init__(self, *, result="ok", stream=None, stream_error=None, error=None) -> None:
-		self.result = result
-		self.stream = stream
-		self.stream_error = stream_error
-		self.error = error
-		self.calls: list = []
-		self.entered = False
-		self.exited = False
-		self.list_tools_calls = 0
+    def __init__(self, *, result="ok", stream=None, stream_error=None, error=None) -> None:
+        self.result = result
+        self.stream = stream
+        self.stream_error = stream_error
+        self.error = error
+        self.calls: list = []
+        self.entered = False
+        self.exited = False
+        self.list_tools_calls = 0
 
-	async def __aenter__(self):
-		self.entered = True
-		return self
+    async def __aenter__(self):
+        self.entered = True
+        return self
 
-	async def __aexit__(self, *exc_info):
-		self.exited = True
-		return False
+    async def __aexit__(self, *exc_info):
+        self.exited = True
+        return False
 
-	async def call_tool(self, *args, **kwargs):
-		self.calls.append((args, kwargs))
-		if self.error is not None:
-			raise self.error
-		if self.stream is not None:
-			if self.stream_error is not None:
-				return _aiter_then_raise(self.stream, self.stream_error)
-			return _aiter(self.stream)
-		return self.result
+    async def call_tool(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self.error is not None:
+            raise self.error
+        if self.stream is not None:
+            if self.stream_error is not None:
+                return _aiter_then_raise(self.stream, self.stream_error)
+            return _aiter(self.stream)
+        return self.result
 
-	async def list_tools(self):
-		self.list_tools_calls += 1
-		return ["t1", "t2"]
+    async def list_tools(self):
+        self.list_tools_calls += 1
+        return ["t1", "t2"]
 
 
 class _DistinctSession:
-	"""Session object yielded by a context manager (exposes call_tool)."""
+    """Session object yielded by a context manager (exposes call_tool)."""
 
-	def __init__(self, result="ok") -> None:
-		self.result = result
-		self.calls: list = []
-		self.session_exited = False
+    def __init__(self, result="ok") -> None:
+        self.result = result
+        self.calls: list = []
+        self.session_exited = False
 
-	async def call_tool(self, *args, **kwargs):
-		self.calls.append((args, kwargs))
-		return self.result
+    async def call_tool(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.result
 
-	async def __aexit__(self, *exc_info):
-		self.session_exited = True
-		return False
+    async def __aexit__(self, *exc_info):
+        self.session_exited = True
+        return False
 
 
 class _DistinctSessionClient:
-	"""Context manager whose __aenter__ yields a distinct session object."""
+    """Context manager whose __aenter__ yields a distinct session object."""
 
-	def __init__(self, session: _DistinctSession) -> None:
-		self._session = session
-		self.entered = False
-		self.cm_exited = False
+    def __init__(self, session: _DistinctSession) -> None:
+        self._session = session
+        self.entered = False
+        self.cm_exited = False
 
-	async def __aenter__(self):
-		self.entered = True
-		return self._session
+    async def __aenter__(self):
+        self.entered = True
+        return self._session
 
-	async def __aexit__(self, *exc_info):
-		self.cm_exited = True
-		return False
+    async def __aexit__(self, *exc_info):
+        self.cm_exited = True
+        return False
 
 
 @pytest.fixture
 def emit_enabled(monkeypatch):
-	"""Enable emission and route the sink to an in-memory capturer."""
-	monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", True, raising=False)
-	monkeypatch.setattr(wrapper_mod, "WorkflowAPIEventSink", _CapturingSink, raising=True)
+    """Enable emission and route the sink to an in-memory capturer."""
+    monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", True, raising=False)
+    monkeypatch.setattr(wrapper_mod, "WorkflowAPIEventSink", _CapturingSink, raising=True)
 
 
 def _instance(event):
-	workflow = next(iter(event.data.workflows.values()))
-	return next(iter(workflow.instances.values()))
+    workflow = next(iter(event.data.workflows.values()))
+    return next(iter(workflow.instances.values()))
 
 
 def _edge(event):
-	topology = _instance(event).topology
-	assert topology.edges
-	return topology.edges[0]
+    topology = _instance(event).topology
+    assert topology.edges
+    return topology.edges[0]
 
 
 def _wrap(client):
-	return wrap_mcp_client(
-		client,
-		agent_id=_AGENT_ID,
-		mcp_server=_SERVER,
-		target_stable_agent_id=_TARGET_SID,
-		source=_SOURCE,
-	)
+    return wrap_mcp_client(
+        client,
+        agent_id=_AGENT_ID,
+        mcp_server=_SERVER,
+        target_stable_agent_id=_TARGET_SID,
+        source=_SOURCE,
+    )
 
 
 @pytest.mark.parametrize(
-	"case,args,kwargs",
-	[
-		("positional", ("get_forecast",), {}),
-		("name_kwarg", (), {"name": "get_forecast"}),
-	],
+    "case,args,kwargs",
+    [
+        ("positional", ("get_forecast",), {}),
+        ("name_kwarg", (), {"name": "get_forecast"}),
+    ],
 )
 async def test_call_tool_emits_start_then_end(case, args, kwargs, emit_enabled):
-	"""Both call styles emit edge UPDATE start then end events."""
-	fake = _FakeMCPClient(result="forecast")
-	wrapped = _wrap(fake)
+    """Both call styles emit edge UPDATE start then end events."""
+    fake = _FakeMCPClient(result="forecast")
+    wrapped = _wrap(fake)
 
-	result = await wrapped.call_tool(*args, **kwargs)
+    result = await wrapped.call_tool(*args, **kwargs)
 
-	assert result == "forecast"
-	assert fake.calls == [(args, kwargs)]
+    assert result == "forecast"
+    assert fake.calls == [(args, kwargs)]
 
-	events = wrapped._event_sink.events
-	assert len(events) == 2
+    events = wrapped._event_sink.events
+    assert len(events) == 2
 
-	start_edge = _edge(events[0])
-	assert start_edge.operation == Operation.UPDATE
-	assert start_edge.mcp_in_flight is True
-	assert start_edge.tool_name == "get_forecast"
-	assert start_edge.mcp_server == _SERVER
-	assert start_edge.source_stable_agent_id == stable_agent_id_for_name(_AGENT_ID)
-	assert start_edge.target_stable_agent_id == _TARGET_SID
+    start_edge = _edge(events[0])
+    assert start_edge.operation == Operation.UPDATE
+    assert start_edge.mcp_in_flight is True
+    assert start_edge.tool_name == "get_forecast"
+    assert start_edge.mcp_server == _SERVER
+    assert start_edge.source_stable_agent_id == stable_agent_id_for_name(_AGENT_ID)
+    assert start_edge.target_stable_agent_id == _TARGET_SID
 
-	end_edge = _edge(events[1])
-	assert end_edge.operation == Operation.UPDATE
-	assert end_edge.mcp_in_flight is False
-	assert _instance(events[0]).topology.nodes == []
-	assert _instance(events[1]).topology.nodes == []
+    end_edge = _edge(events[1])
+    assert end_edge.operation == Operation.UPDATE
+    assert end_edge.mcp_in_flight is False
+    assert _instance(events[0]).topology.nodes == []
+    assert _instance(events[1]).topology.nodes == []
 
 
 async def test_call_tool_error_emits_end_and_reraises(emit_enabled):
-	"""A failing tool call still emits end and re-raises."""
-	fake = _FakeMCPClient(error=RuntimeError("boom"))
-	wrapped = _wrap(fake)
+    """A failing tool call still emits end and re-raises."""
+    fake = _FakeMCPClient(error=RuntimeError("boom"))
+    wrapped = _wrap(fake)
 
-	with pytest.raises(RuntimeError, match="boom"):
-		await wrapped.call_tool("create_payment", {})
+    with pytest.raises(RuntimeError, match="boom"):
+        await wrapped.call_tool("create_payment", {})
 
-	events = wrapped._event_sink.events
-	assert len(events) == 2
-	assert _edge(events[1]).mcp_in_flight is False
+    events = wrapped._event_sink.events
+    assert len(events) == 2
+    assert _edge(events[1]).mcp_in_flight is False
 
 
 async def test_call_tool_streaming_end_after_iteration(emit_enabled):
-	"""Streamed results emit start up front and end only after iteration."""
-	fake = _FakeMCPClient(stream=["a", "b", "c"])
-	wrapped = _wrap(fake)
+    """Streamed results emit start up front and end only after iteration."""
+    fake = _FakeMCPClient(stream=["a", "b", "c"])
+    wrapped = _wrap(fake)
 
-	stream = await wrapped.call_tool(name="get_forecast")
-	events = wrapped._event_sink.events
-	assert len(events) == 1
-	assert _edge(events[0]).mcp_in_flight is True
+    stream = await wrapped.call_tool(name="get_forecast")
+    events = wrapped._event_sink.events
+    assert len(events) == 1
+    assert _edge(events[0]).mcp_in_flight is True
 
-	chunks = [chunk async for chunk in stream]
-	assert chunks == ["a", "b", "c"]
-	assert len(events) == 2
-	assert _edge(events[1]).mcp_in_flight is False
+    chunks = [chunk async for chunk in stream]
+    assert chunks == ["a", "b", "c"]
+    assert len(events) == 2
+    assert _edge(events[1]).mcp_in_flight is False
 
 
 async def test_call_tool_streaming_error_emits_end(emit_enabled):
-	"""Errors raised during streaming still emit end."""
-	fake = _FakeMCPClient(stream=["a"], stream_error=RuntimeError("midstream"))
-	wrapped = _wrap(fake)
+    """Errors raised during streaming still emit end."""
+    fake = _FakeMCPClient(stream=["a"], stream_error=RuntimeError("midstream"))
+    wrapped = _wrap(fake)
 
-	stream = await wrapped.call_tool(name="get_forecast")
+    stream = await wrapped.call_tool(name="get_forecast")
 
-	with pytest.raises(RuntimeError, match="midstream"):
-		async for _chunk in stream:
-			pass
+    with pytest.raises(RuntimeError, match="midstream"):
+        async for _chunk in stream:
+            pass
 
-	events = wrapped._event_sink.events
-	assert len(events) == 2
-	assert _edge(events[1]).mcp_in_flight is False
+    events = wrapped._event_sink.events
+    assert len(events) == 2
+    assert _edge(events[1]).mcp_in_flight is False
 
 
 async def test_list_tools_passthrough(emit_enabled):
-	"""Non-call_tool methods delegate to the underlying client, no events."""
-	fake = _FakeMCPClient()
-	wrapped = _wrap(fake)
+    """Non-call_tool methods delegate to the underlying client, no events."""
+    fake = _FakeMCPClient()
+    wrapped = _wrap(fake)
 
-	tools = await wrapped.list_tools()
+    tools = await wrapped.list_tools()
 
-	assert tools == ["t1", "t2"]
-	assert fake.list_tools_calls == 1
-	assert wrapped._event_sink.events == []
+    assert tools == ["t1", "t2"]
+    assert fake.list_tools_calls == 1
+    assert wrapped._event_sink.events == []
 
 
 async def test_async_context_manager_delegation(emit_enabled):
-	"""The wrapper delegates __aenter__/__aexit__ to the wrapped client."""
-	fake = _FakeMCPClient(result="ok")
+    """The wrapper delegates __aenter__/__aexit__ to the wrapped client."""
+    fake = _FakeMCPClient(result="ok")
 
-	async with _wrap(fake) as client:
-		result = await client.call_tool("get_forecast")
+    async with _wrap(fake) as client:
+        result = await client.call_tool("get_forecast")
 
-	assert fake.entered is True
-	assert fake.exited is True
-	assert result == "ok"
-	assert len(client._event_sink.events) == 2
+    assert fake.entered is True
+    assert fake.exited is True
+    assert result == "ok"
+    assert len(client._event_sink.events) == 2
 
 
 async def test_aexit_targets_context_manager_not_session(emit_enabled):
-	"""Regression: __aexit__ must close the context manager, not the session."""
-	session = _DistinctSession(result="forecast")
-	cm = _DistinctSessionClient(session)
+    """Regression: __aexit__ must close the context manager, not the session."""
+    session = _DistinctSession(result="forecast")
+    cm = _DistinctSessionClient(session)
 
-	async with _wrap(cm) as client:
-		result = await client.call_tool("get_forecast")
+    async with _wrap(cm) as client:
+        result = await client.call_tool("get_forecast")
 
-	assert result == "forecast"
-	assert session.calls == [(("get_forecast",), {})]
-	assert cm.entered is True
-	assert cm.cm_exited is True
-	assert session.session_exited is False
-	assert len(client._event_sink.events) == 2
+    assert result == "forecast"
+    assert session.calls == [(("get_forecast",), {})]
+    assert cm.entered is True
+    assert cm.cm_exited is True
+    assert session.session_exited is False
+    assert len(client._event_sink.events) == 2
 
 
 async def test_emit_disabled_returns_unwrapped(monkeypatch):
-	"""With emission disabled the original client is returned unwrapped."""
-	monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", False, raising=False)
-	fake = _FakeMCPClient(result="ok")
-	wrapped = _wrap(fake)
+    """With emission disabled the original client is returned unwrapped."""
+    monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", False, raising=False)
+    fake = _FakeMCPClient(result="ok")
+    wrapped = _wrap(fake)
 
-	assert wrapped is fake
-	result = await wrapped.call_tool("get_forecast")
+    assert wrapped is fake
+    result = await wrapped.call_tool("get_forecast")
 
-	assert result == "ok"
-	assert fake.calls == [(("get_forecast",), {})]
+    assert result == "ok"
+    assert fake.calls == [(("get_forecast",), {})]
 
 
 async def test_missing_workflow_context_returns_unwrapped(emit_enabled, no_default_baggage):
-	"""Absent workflow identity returns the unwrapped client (no events)."""
-	fake = _FakeMCPClient(result="ok")
-	wrapped = _wrap(fake)
+    """Absent workflow identity returns the unwrapped client (no events)."""
+    fake = _FakeMCPClient(result="ok")
+    wrapped = _wrap(fake)
 
-	assert wrapped is fake
-	result = await wrapped.call_tool("get_forecast")
+    assert wrapped is fake
+    result = await wrapped.call_tool("get_forecast")
 
-	assert result == "ok"
-	assert fake.calls == [(("get_forecast",), {})]
+    assert result == "ok"
+    assert fake.calls == [(("get_forecast",), {})]
 
 
 async def test_explicit_identity_used_when_baggage_absent(emit_enabled, no_default_baggage):
-	"""With no baggage, explicit workflow_name/instance_id resolve identity."""
-	fake = _FakeMCPClient(result="forecast")
-	wrapped = wrap_mcp_client(
-		fake,
-		agent_id=_AGENT_ID,
-		mcp_server=_SERVER,
-		target_stable_agent_id=_TARGET_SID,
-		source=_SOURCE,
-		workflow_name=_WORKFLOW_NAME,
-		instance_id=_INSTANCE_ID,
-	)
+    """With no baggage, explicit workflow_name/instance_id resolve identity."""
+    fake = _FakeMCPClient(result="forecast")
+    wrapped = wrap_mcp_client(
+        fake,
+        agent_id=_AGENT_ID,
+        mcp_server=_SERVER,
+        target_stable_agent_id=_TARGET_SID,
+        source=_SOURCE,
+        workflow_name=_WORKFLOW_NAME,
+        instance_id=_INSTANCE_ID,
+    )
 
-	assert wrapped is not fake
-	result = await wrapped.call_tool("get_forecast")
+    assert wrapped is not fake
+    result = await wrapped.call_tool("get_forecast")
 
-	assert result == "forecast"
-	assert len(wrapped._event_sink.events) == 2
+    assert result == "forecast"
+    assert len(wrapped._event_sink.events) == 2
 
 
 async def test_explicit_fallback_when_baggage_unknown(emit_enabled, no_default_baggage):
-	"""Baggage present but unknown to the catalog falls through to explicit."""
-	token = attach_workflow_context(
-		workflow_name="Unknown Workflow",
-		workflow_instance_id="instance://00000000-0000-4000-8000-000000000099",
-	)
-	try:
-		fake = _FakeMCPClient(result="ok")
-		wrapped = wrap_mcp_client(
-			fake,
-			agent_id=_AGENT_ID,
-			mcp_server=_SERVER,
-			target_stable_agent_id=_TARGET_SID,
-			source=_SOURCE,
-			workflow_name=_WORKFLOW_NAME,
-			instance_id=_INSTANCE_ID,
-		)
+    """Baggage present but unknown to the catalog falls through to explicit."""
+    token = attach_workflow_context(
+        workflow_name="Unknown Workflow",
+        workflow_instance_id="instance://00000000-0000-4000-8000-000000000099",
+    )
+    try:
+        fake = _FakeMCPClient(result="ok")
+        wrapped = wrap_mcp_client(
+            fake,
+            agent_id=_AGENT_ID,
+            mcp_server=_SERVER,
+            target_stable_agent_id=_TARGET_SID,
+            source=_SOURCE,
+            workflow_name=_WORKFLOW_NAME,
+            instance_id=_INSTANCE_ID,
+        )
 
-		assert wrapped is not fake
-		await wrapped.call_tool("get_forecast")
-		assert len(wrapped._event_sink.events) == 2
-	finally:
-		detach_workflow_context(token)
+        assert wrapped is not fake
+        await wrapped.call_tool("get_forecast")
+        assert len(wrapped._event_sink.events) == 2
+    finally:
+        detach_workflow_context(token)

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_event_middleware.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_mcp_event_middleware.py
@@ -10,13 +10,14 @@ from schema.types import Operation
 
 from common.mcp_event_middleware import wrap_mcp_client
 from common.mcp_event_middleware import wrapper as wrapper_mod
+from common.stable_agent_id import stable_agent_id_for_name
 from common.workflow_context_prop import (
-    attach_workflow_context,
-    detach_workflow_context,
+	attach_workflow_context,
+	detach_workflow_context,
 )
-from common.workflow_utils.mcp import MCP_TOOL_NODE_TYPE
 
 _AGENT_ID = "Colombia Coffee Farm"
+_TARGET_SID = stable_agent_id_for_name("Weather MCP Server")
 _SERVER = "lungo_weather_service"
 _SOURCE = "colombia_coffee_farm"
 _WORKFLOW_NAME = "Test Workflow Alpha"
@@ -24,393 +25,313 @@ _INSTANCE_ID = "instance://00000000-0000-4000-8000-000000000001"
 
 
 class _CapturingSink:
-    """Sink stub that records emitted events on the instance."""
+	"""Sink stub that records emitted events on the instance."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        self.events: list = []
+	def __init__(self, *args, **kwargs) -> None:
+		self.events: list = []
 
-    async def emit(self, event) -> None:
-        self.events.append(event)
+	async def emit(self, event) -> None:
+		self.events.append(event)
 
-    async def aclose(self) -> None:
-        return None
+	async def aclose(self) -> None:
+		return None
 
 
 async def _aiter(items):
-    for item in items:
-        yield item
+	for item in items:
+		yield item
 
 
 async def _aiter_then_raise(items, exc):
-    for item in items:
-        yield item
-    raise exc
+	for item in items:
+		yield item
+	raise exc
 
 
 class _FakeMCPClient:
-    """Duck-typed MCP client used to drive the wrapper."""
+	"""Duck-typed MCP client used to drive the wrapper."""
 
-    def __init__(self, *, result="ok", stream=None, stream_error=None, error=None) -> None:
-        self.result = result
-        self.stream = stream
-        self.stream_error = stream_error
-        self.error = error
-        self.calls: list = []
-        self.entered = False
-        self.exited = False
-        self.list_tools_calls = 0
+	def __init__(self, *, result="ok", stream=None, stream_error=None, error=None) -> None:
+		self.result = result
+		self.stream = stream
+		self.stream_error = stream_error
+		self.error = error
+		self.calls: list = []
+		self.entered = False
+		self.exited = False
+		self.list_tools_calls = 0
 
-    async def __aenter__(self):
-        self.entered = True
-        return self
+	async def __aenter__(self):
+		self.entered = True
+		return self
 
-    async def __aexit__(self, *exc_info):
-        self.exited = True
-        return False
+	async def __aexit__(self, *exc_info):
+		self.exited = True
+		return False
 
-    async def call_tool(self, *args, **kwargs):
-        self.calls.append((args, kwargs))
-        if self.error is not None:
-            raise self.error
-        if self.stream is not None:
-            if self.stream_error is not None:
-                return _aiter_then_raise(self.stream, self.stream_error)
-            return _aiter(self.stream)
-        return self.result
+	async def call_tool(self, *args, **kwargs):
+		self.calls.append((args, kwargs))
+		if self.error is not None:
+			raise self.error
+		if self.stream is not None:
+			if self.stream_error is not None:
+				return _aiter_then_raise(self.stream, self.stream_error)
+			return _aiter(self.stream)
+		return self.result
 
-    async def list_tools(self):
-        self.list_tools_calls += 1
-        return ["t1", "t2"]
-
-
-class _StreamThenValueClient:
-    """Returns a stream on the first call, a plain value on later calls.
-
-    Lets a streamed call stay in flight (DELETE deferred until iteration)
-    while a second call completes, to exercise the agent-node refcount.
-    """
-
-    def __init__(self, stream, value) -> None:
-        self.stream = stream
-        self.value = value
-        self.calls = 0
-
-    async def call_tool(self, *args, **kwargs):
-        self.calls += 1
-        if self.calls == 1:
-            return _aiter(self.stream)
-        return self.value
+	async def list_tools(self):
+		self.list_tools_calls += 1
+		return ["t1", "t2"]
 
 
 class _DistinctSession:
-    """Session object yielded by a context manager (exposes call_tool)."""
+	"""Session object yielded by a context manager (exposes call_tool)."""
 
-    def __init__(self, result="ok") -> None:
-        self.result = result
-        self.calls: list = []
-        self.session_exited = False
+	def __init__(self, result="ok") -> None:
+		self.result = result
+		self.calls: list = []
+		self.session_exited = False
 
-    async def call_tool(self, *args, **kwargs):
-        self.calls.append((args, kwargs))
-        return self.result
+	async def call_tool(self, *args, **kwargs):
+		self.calls.append((args, kwargs))
+		return self.result
 
-    async def __aexit__(self, *exc_info):
-        # If the wrapper wrongly exits the session instead of the context
-        # manager, this flips True and the CM teardown never runs (the bug
-        # that left SDK streams open and hung CI).
-        self.session_exited = True
-        return False
+	async def __aexit__(self, *exc_info):
+		self.session_exited = True
+		return False
 
 
 class _DistinctSessionClient:
-    """Context manager whose __aenter__ yields a *distinct* session object.
+	"""Context manager whose __aenter__ yields a distinct session object."""
 
-    Mirrors the agntcy SDK MCP client: the object exposing call_tool differs
-    from the context manager, and only the context manager's __aexit__ runs
-    the teardown.
-    """
+	def __init__(self, session: _DistinctSession) -> None:
+		self._session = session
+		self.entered = False
+		self.cm_exited = False
 
-    def __init__(self, session: _DistinctSession) -> None:
-        self._session = session
-        self.entered = False
-        self.cm_exited = False
+	async def __aenter__(self):
+		self.entered = True
+		return self._session
 
-    async def __aenter__(self):
-        self.entered = True
-        return self._session
-
-    async def __aexit__(self, *exc_info):
-        self.cm_exited = True
-        return False
+	async def __aexit__(self, *exc_info):
+		self.cm_exited = True
+		return False
 
 
 @pytest.fixture
 def emit_enabled(monkeypatch):
-    """Enable emission and route the sink to an in-memory capturer."""
-    monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", True, raising=False)
-    monkeypatch.setattr(wrapper_mod, "WorkflowAPIEventSink", _CapturingSink, raising=True)
+	"""Enable emission and route the sink to an in-memory capturer."""
+	monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", True, raising=False)
+	monkeypatch.setattr(wrapper_mod, "WorkflowAPIEventSink", _CapturingSink, raising=True)
 
 
 def _instance(event):
-    workflow = next(iter(event.data.workflows.values()))
-    return next(iter(workflow.instances.values()))
+	workflow = next(iter(event.data.workflows.values()))
+	return next(iter(workflow.instances.values()))
 
 
-def _node_operations(event):
-    return [node.operation for node in _instance(event).topology.nodes]
-
-
-def _mcp_node(event):
-    for node in _instance(event).topology.nodes:
-        if getattr(node, "type", None) == MCP_TOOL_NODE_TYPE:
-            return node
-    return None
-
-
-def _deleted_agent_node(event):
-    for node in _instance(event).topology.nodes:
-        is_agent = getattr(node, "type", None) != MCP_TOOL_NODE_TYPE
-        if is_agent and node.operation == Operation.DELETE:
-            return node
-    return None
+def _edge(event):
+	topology = _instance(event).topology
+	assert topology.edges
+	return topology.edges[0]
 
 
 def _wrap(client):
-    return wrap_mcp_client(
-        client,
-        agent_id=_AGENT_ID,
-        mcp_server=_SERVER,
-        source=_SOURCE,
-    )
+	return wrap_mcp_client(
+		client,
+		agent_id=_AGENT_ID,
+		mcp_server=_SERVER,
+		target_stable_agent_id=_TARGET_SID,
+		source=_SOURCE,
+	)
 
 
 @pytest.mark.parametrize(
-    "case,args,kwargs",
-    [
-        ("positional", ("get_forecast",), {}),
-        ("name_kwarg", (), {"name": "get_forecast"}),
-    ],
+	"case,args,kwargs",
+	[
+		("positional", ("get_forecast",), {}),
+		("name_kwarg", (), {"name": "get_forecast"}),
+	],
 )
-async def test_call_tool_emits_create_then_delete(case, args, kwargs, emit_enabled):
-    """Both call styles forward unchanged and emit CREATE then DELETE."""
-    fake = _FakeMCPClient(result="forecast")
-    wrapped = _wrap(fake)
+async def test_call_tool_emits_start_then_end(case, args, kwargs, emit_enabled):
+	"""Both call styles emit edge UPDATE start then end events."""
+	fake = _FakeMCPClient(result="forecast")
+	wrapped = _wrap(fake)
 
-    result = await wrapped.call_tool(*args, **kwargs)
+	result = await wrapped.call_tool(*args, **kwargs)
 
-    assert result == "forecast"
-    assert fake.calls == [(args, kwargs)]
+	assert result == "forecast"
+	assert fake.calls == [(args, kwargs)]
 
-    events = wrapped._event_sink.events
-    assert len(events) == 2
-    assert Operation.CREATE in _node_operations(events[0])
+	events = wrapped._event_sink.events
+	assert len(events) == 2
 
-    create_node = _mcp_node(events[0])
-    assert create_node.tool_name == "get_forecast"
-    assert create_node.mcp_server == _SERVER
+	start_edge = _edge(events[0])
+	assert start_edge.operation == Operation.UPDATE
+	assert start_edge.mcp_in_flight is True
+	assert start_edge.tool_name == "get_forecast"
+	assert start_edge.mcp_server == _SERVER
+	assert start_edge.source_stable_agent_id == stable_agent_id_for_name(_AGENT_ID)
+	assert start_edge.target_stable_agent_id == _TARGET_SID
 
-    delete_node = _mcp_node(events[1])
-    assert delete_node.operation == Operation.DELETE
-    assert getattr(delete_node, "duration_ms", None) is not None
-    assert getattr(delete_node, "error", None) is None
-
-
-async def test_call_tool_error_emits_delete_and_reraises(emit_enabled):
-    """A failing tool call still emits DELETE (with error) and re-raises."""
-    fake = _FakeMCPClient(error=RuntimeError("boom"))
-    wrapped = _wrap(fake)
-
-    with pytest.raises(RuntimeError, match="boom"):
-        await wrapped.call_tool("create_payment", {})
-
-    events = wrapped._event_sink.events
-    assert len(events) == 2
-    delete_node = _mcp_node(events[1])
-    assert delete_node.operation == Operation.DELETE
-    assert delete_node.error == "boom"
-    assert getattr(delete_node, "duration_ms", None) is not None
+	end_edge = _edge(events[1])
+	assert end_edge.operation == Operation.UPDATE
+	assert end_edge.mcp_in_flight is False
+	assert _instance(events[0]).topology.nodes == []
+	assert _instance(events[1]).topology.nodes == []
 
 
-async def test_call_tool_streaming_delete_after_iteration(emit_enabled):
-    """Streamed results emit CREATE up front and DELETE only after iteration."""
-    fake = _FakeMCPClient(stream=["a", "b", "c"])
-    wrapped = _wrap(fake)
+async def test_call_tool_error_emits_end_and_reraises(emit_enabled):
+	"""A failing tool call still emits end and re-raises."""
+	fake = _FakeMCPClient(error=RuntimeError("boom"))
+	wrapped = _wrap(fake)
 
-    stream = await wrapped.call_tool(name="get_forecast")
-    events = wrapped._event_sink.events
-    assert len(events) == 1
-    assert Operation.CREATE in _node_operations(events[0])
+	with pytest.raises(RuntimeError, match="boom"):
+		await wrapped.call_tool("create_payment", {})
 
-    chunks = [chunk async for chunk in stream]
-    assert chunks == ["a", "b", "c"]
-    assert len(events) == 2
-
-    delete_node = _mcp_node(events[1])
-    assert delete_node.operation == Operation.DELETE
-    assert getattr(delete_node, "error", None) is None
+	events = wrapped._event_sink.events
+	assert len(events) == 2
+	assert _edge(events[1]).mcp_in_flight is False
 
 
-async def test_call_tool_streaming_error_emits_delete_with_error(emit_enabled):
-    """Errors raised during streaming surface a DELETE carrying the error."""
-    fake = _FakeMCPClient(stream=["a"], stream_error=RuntimeError("midstream"))
-    wrapped = _wrap(fake)
+async def test_call_tool_streaming_end_after_iteration(emit_enabled):
+	"""Streamed results emit start up front and end only after iteration."""
+	fake = _FakeMCPClient(stream=["a", "b", "c"])
+	wrapped = _wrap(fake)
 
-    stream = await wrapped.call_tool(name="get_forecast")
+	stream = await wrapped.call_tool(name="get_forecast")
+	events = wrapped._event_sink.events
+	assert len(events) == 1
+	assert _edge(events[0]).mcp_in_flight is True
 
-    with pytest.raises(RuntimeError, match="midstream"):
-        async for _chunk in stream:
-            pass
-
-    events = wrapped._event_sink.events
-    assert len(events) == 2
-    delete_node = _mcp_node(events[1])
-    assert delete_node.operation == Operation.DELETE
-    assert delete_node.error == "midstream"
+	chunks = [chunk async for chunk in stream]
+	assert chunks == ["a", "b", "c"]
+	assert len(events) == 2
+	assert _edge(events[1]).mcp_in_flight is False
 
 
-async def test_single_call_delete_removes_agent_node(emit_enabled):
-    """A lone call drops the in-flight count to zero, so DELETE removes the agent node."""
-    fake = _FakeMCPClient(result="forecast")
-    wrapped = _wrap(fake)
+async def test_call_tool_streaming_error_emits_end(emit_enabled):
+	"""Errors raised during streaming still emit end."""
+	fake = _FakeMCPClient(stream=["a"], stream_error=RuntimeError("midstream"))
+	wrapped = _wrap(fake)
 
-    await wrapped.call_tool("get_forecast")
+	stream = await wrapped.call_tool(name="get_forecast")
 
-    delete_event = wrapped._event_sink.events[1]
-    assert _deleted_agent_node(delete_event) is not None
+	with pytest.raises(RuntimeError, match="midstream"):
+		async for _chunk in stream:
+			pass
 
-
-async def test_agent_node_deleted_only_after_last_inflight_call(emit_enabled):
-    """With overlapping calls the agent node is removed only when the last ends."""
-    fake = _StreamThenValueClient(["x", "y"], "done")
-    wrapped = _wrap(fake)
-
-    stream = await wrapped.call_tool("streamer")
-    plain = await wrapped.call_tool("quick")
-    assert plain == "done"
-
-    # The quick call ends while the stream is still open: no agent-node delete.
-    quick_delete = wrapped._event_sink.events[-1]
-    assert _mcp_node(quick_delete).operation == Operation.DELETE
-    assert _deleted_agent_node(quick_delete) is None
-
-    chunks = [chunk async for chunk in stream]
-    assert chunks == ["x", "y"]
-
-    # Stream completion is the last in-flight call: agent node is now removed.
-    final_delete = wrapped._event_sink.events[-1]
-    assert _deleted_agent_node(final_delete) is not None
+	events = wrapped._event_sink.events
+	assert len(events) == 2
+	assert _edge(events[1]).mcp_in_flight is False
 
 
 async def test_list_tools_passthrough(emit_enabled):
-    """Non-call_tool methods delegate to the underlying client, no events."""
-    fake = _FakeMCPClient()
-    wrapped = _wrap(fake)
+	"""Non-call_tool methods delegate to the underlying client, no events."""
+	fake = _FakeMCPClient()
+	wrapped = _wrap(fake)
 
-    tools = await wrapped.list_tools()
+	tools = await wrapped.list_tools()
 
-    assert tools == ["t1", "t2"]
-    assert fake.list_tools_calls == 1
-    assert wrapped._event_sink.events == []
+	assert tools == ["t1", "t2"]
+	assert fake.list_tools_calls == 1
+	assert wrapped._event_sink.events == []
 
 
 async def test_async_context_manager_delegation(emit_enabled):
-    """The wrapper delegates __aenter__/__aexit__ to the wrapped client."""
-    fake = _FakeMCPClient(result="ok")
+	"""The wrapper delegates __aenter__/__aexit__ to the wrapped client."""
+	fake = _FakeMCPClient(result="ok")
 
-    async with _wrap(fake) as client:
-        result = await client.call_tool("get_forecast")
+	async with _wrap(fake) as client:
+		result = await client.call_tool("get_forecast")
 
-    assert fake.entered is True
-    assert fake.exited is True
-    assert result == "ok"
-    assert len(client._event_sink.events) == 2
+	assert fake.entered is True
+	assert fake.exited is True
+	assert result == "ok"
+	assert len(client._event_sink.events) == 2
 
 
 async def test_aexit_targets_context_manager_not_session(emit_enabled):
-    """Regression: __aexit__ must close the context manager, not the session.
+	"""Regression: __aexit__ must close the context manager, not the session."""
+	session = _DistinctSession(result="forecast")
+	cm = _DistinctSessionClient(session)
 
-    When __aenter__ yields a distinct session (as the real SDK client does),
-    the wrapper must still exit the original context manager so its teardown
-    runs. Exiting the yielded session instead skips that teardown and leaks
-    the SDK's background streams - the bug that hung CI.
-    """
-    session = _DistinctSession(result="forecast")
-    cm = _DistinctSessionClient(session)
+	async with _wrap(cm) as client:
+		result = await client.call_tool("get_forecast")
 
-    async with _wrap(cm) as client:
-        result = await client.call_tool("get_forecast")
-
-    assert result == "forecast"
-    assert session.calls == [(("get_forecast",), {})]
-    assert cm.entered is True
-    assert cm.cm_exited is True
-    assert session.session_exited is False
-    assert len(client._event_sink.events) == 2
+	assert result == "forecast"
+	assert session.calls == [(("get_forecast",), {})]
+	assert cm.entered is True
+	assert cm.cm_exited is True
+	assert session.session_exited is False
+	assert len(client._event_sink.events) == 2
 
 
 async def test_emit_disabled_returns_unwrapped(monkeypatch):
-    """With emission disabled the original client is returned unwrapped."""
-    monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", False, raising=False)
-    fake = _FakeMCPClient(result="ok")
-    wrapped = _wrap(fake)
+	"""With emission disabled the original client is returned unwrapped."""
+	monkeypatch.setattr(wrapper_mod, "EMIT_WORKFLOW_EVENTS", False, raising=False)
+	fake = _FakeMCPClient(result="ok")
+	wrapped = _wrap(fake)
 
-    assert wrapped is fake
-    result = await wrapped.call_tool("get_forecast")
+	assert wrapped is fake
+	result = await wrapped.call_tool("get_forecast")
 
-    assert result == "ok"
-    assert fake.calls == [(("get_forecast",), {})]
+	assert result == "ok"
+	assert fake.calls == [(("get_forecast",), {})]
 
 
 async def test_missing_workflow_context_returns_unwrapped(emit_enabled, no_default_baggage):
-    """Absent workflow identity returns the unwrapped client (no events)."""
-    fake = _FakeMCPClient(result="ok")
-    wrapped = _wrap(fake)
+	"""Absent workflow identity returns the unwrapped client (no events)."""
+	fake = _FakeMCPClient(result="ok")
+	wrapped = _wrap(fake)
 
-    assert wrapped is fake
-    result = await wrapped.call_tool("get_forecast")
+	assert wrapped is fake
+	result = await wrapped.call_tool("get_forecast")
 
-    assert result == "ok"
-    assert fake.calls == [(("get_forecast",), {})]
+	assert result == "ok"
+	assert fake.calls == [(("get_forecast",), {})]
 
 
 async def test_explicit_identity_used_when_baggage_absent(emit_enabled, no_default_baggage):
-    """With no baggage, explicit workflow_name/instance_id resolve identity."""
-    fake = _FakeMCPClient(result="forecast")
-    wrapped = wrap_mcp_client(
-        fake,
-        agent_id=_AGENT_ID,
-        mcp_server=_SERVER,
-        source=_SOURCE,
-        workflow_name=_WORKFLOW_NAME,
-        instance_id=_INSTANCE_ID,
-    )
+	"""With no baggage, explicit workflow_name/instance_id resolve identity."""
+	fake = _FakeMCPClient(result="forecast")
+	wrapped = wrap_mcp_client(
+		fake,
+		agent_id=_AGENT_ID,
+		mcp_server=_SERVER,
+		target_stable_agent_id=_TARGET_SID,
+		source=_SOURCE,
+		workflow_name=_WORKFLOW_NAME,
+		instance_id=_INSTANCE_ID,
+	)
 
-    assert wrapped is not fake
-    result = await wrapped.call_tool("get_forecast")
+	assert wrapped is not fake
+	result = await wrapped.call_tool("get_forecast")
 
-    assert result == "forecast"
-    assert len(wrapped._event_sink.events) == 2
+	assert result == "forecast"
+	assert len(wrapped._event_sink.events) == 2
 
 
 async def test_explicit_fallback_when_baggage_unknown(emit_enabled, no_default_baggage):
-    """Baggage present but unknown to the catalog falls through to explicit."""
-    token = attach_workflow_context(
-        workflow_name="Unknown Workflow",
-        workflow_instance_id="instance://00000000-0000-4000-8000-000000000099",
-    )
-    try:
-        fake = _FakeMCPClient(result="ok")
-        wrapped = wrap_mcp_client(
-            fake,
-            agent_id=_AGENT_ID,
-            mcp_server=_SERVER,
-            source=_SOURCE,
-            workflow_name=_WORKFLOW_NAME,
-            instance_id=_INSTANCE_ID,
-        )
+	"""Baggage present but unknown to the catalog falls through to explicit."""
+	token = attach_workflow_context(
+		workflow_name="Unknown Workflow",
+		workflow_instance_id="instance://00000000-0000-4000-8000-000000000099",
+	)
+	try:
+		fake = _FakeMCPClient(result="ok")
+		wrapped = wrap_mcp_client(
+			fake,
+			agent_id=_AGENT_ID,
+			mcp_server=_SERVER,
+			target_stable_agent_id=_TARGET_SID,
+			source=_SOURCE,
+			workflow_name=_WORKFLOW_NAME,
+			instance_id=_INSTANCE_ID,
+		)
 
-        assert wrapped is not fake
-        await wrapped.call_tool("get_forecast")
-        assert len(wrapped._event_sink.events) == 2
-    finally:
-        detach_workflow_context(token)
+		assert wrapped is not fake
+		await wrapped.call_tool("get_forecast")
+		assert len(wrapped._event_sink.events) == 2
+	finally:
+		detach_workflow_context(token)

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_workflow_utils_mcp.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_workflow_utils_mcp.py
@@ -10,8 +10,8 @@ from schema.types import Operation
 
 from common.stable_agent_id import stable_agent_id_for_name
 from common.workflow_utils.mcp import (
-	build_mcp_edge_topology,
-	emit_mcp_edge_event,
+    build_mcp_edge_topology,
+    emit_mcp_edge_event,
 )
 
 _AGENT_ID = "Colombia Coffee Farm"
@@ -21,69 +21,69 @@ _SERVER = "lungo_weather_service"
 
 
 class _CapturingSink:
-	"""In-memory EventSink for asserting emitted events."""
+    """In-memory EventSink for asserting emitted events."""
 
-	def __init__(self) -> None:
-		self.events: list = []
+    def __init__(self) -> None:
+        self.events: list = []
 
-	async def emit(self, event) -> None:
-		self.events.append(event)
+    async def emit(self, event) -> None:
+        self.events.append(event)
 
-	async def aclose(self) -> None:
-		return None
+    async def aclose(self) -> None:
+        return None
 
 
 @pytest.mark.parametrize(
-	"case,mcp_in_flight",
-	[
-		("start", True),
-		("end", False),
-	],
+    "case,mcp_in_flight",
+    [
+        ("start", True),
+        ("end", False),
+    ],
 )
 def test_build_mcp_edge_topology(case, mcp_in_flight):
-	"""Edge-only topology carries stable ids and mcp_in_flight flag."""
-	topology = build_mcp_edge_topology(
-		_AGENT_ID,
-		_TOOL,
-		_SERVER,
-		_TARGET_SID,
-		mcp_in_flight=mcp_in_flight,
-	)
+    """Edge-only topology carries stable ids and mcp_in_flight flag."""
+    topology = build_mcp_edge_topology(
+        _AGENT_ID,
+        _TOOL,
+        _SERVER,
+        _TARGET_SID,
+        mcp_in_flight=mcp_in_flight,
+    )
 
-	assert topology.nodes == []
-	assert len(topology.edges) == 1
+    assert topology.nodes == []
+    assert len(topology.edges) == 1
 
-	edge = topology.edges[0]
-	assert edge.operation == Operation.UPDATE
-	assert edge.source_stable_agent_id == stable_agent_id_for_name(_AGENT_ID)
-	assert edge.target_stable_agent_id == _TARGET_SID
-	assert edge.tool_name == _TOOL
-	assert edge.mcp_server == _SERVER
-	assert edge.mcp_in_flight is mcp_in_flight
-	assert edge.id.root.startswith("edge://")
+    edge = topology.edges[0]
+    assert edge.operation == Operation.UPDATE
+    assert edge.source_stable_agent_id == stable_agent_id_for_name(_AGENT_ID)
+    assert edge.target_stable_agent_id == _TARGET_SID
+    assert edge.tool_name == _TOOL
+    assert edge.mcp_server == _SERVER
+    assert edge.mcp_in_flight is mcp_in_flight
+    assert edge.id.root.startswith("edge://")
 
 
 async def test_emit_mcp_edge_event_posts_to_sink():
-	"""emit_mcp_edge_event builds an event and delivers it to the sink."""
-	sink = _CapturingSink()
+    """emit_mcp_edge_event builds an event and delivers it to the sink."""
+    sink = _CapturingSink()
 
-	event = await emit_mcp_edge_event(
-		sink=sink,
-		source="colombia_coffee_farm",
-		agent_id=_AGENT_ID,
-		tool_name=_TOOL,
-		mcp_server=_SERVER,
-		target_stable_agent_id=_TARGET_SID,
-		mcp_in_flight=True,
-		correlation_id="correlation://00000000-0000-4000-8000-000000000004",
-		workflow_name="Test Workflow Alpha",
-		instance_id="instance://00000000-0000-4000-8000-000000000003",
-	)
+    event = await emit_mcp_edge_event(
+        sink=sink,
+        source="colombia_coffee_farm",
+        agent_id=_AGENT_ID,
+        tool_name=_TOOL,
+        mcp_server=_SERVER,
+        target_stable_agent_id=_TARGET_SID,
+        mcp_in_flight=True,
+        correlation_id="correlation://00000000-0000-4000-8000-000000000004",
+        workflow_name="Test Workflow Alpha",
+        instance_id="instance://00000000-0000-4000-8000-000000000003",
+    )
 
-	assert len(sink.events) == 1
-	assert sink.events[0] is event
-	assert "Test Workflow Alpha" in event.data.workflows
-	assert _TOOL in event.metadata.correlation.message
-	assert event.data.workflows["Test Workflow Alpha"].instances[
-		"instance://00000000-0000-4000-8000-000000000003"
-	].topology.edges[0].mcp_in_flight is True
+    assert len(sink.events) == 1
+    assert sink.events[0] is event
+    assert "Test Workflow Alpha" in event.data.workflows
+    assert _TOOL in event.metadata.correlation.message
+    assert event.data.workflows["Test Workflow Alpha"].instances[
+        "instance://00000000-0000-4000-8000-000000000003"
+    ].topology.edges[0].mcp_in_flight is True

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_workflow_utils_mcp.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/test_workflow_utils_mcp.py
@@ -1,174 +1,89 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for ``common.workflow_utils.mcp`` (MCP tool-call builders)."""
+"""Unit tests for ``common.workflow_utils.mcp`` (MCP edge builders)."""
 
 from __future__ import annotations
 
 import pytest
 from schema.types import Operation
 
-from common.workflow_utils.inflight import RuntimeIdAllocator
+from common.stable_agent_id import stable_agent_id_for_name
 from common.workflow_utils.mcp import (
-    MCP_TOOL_NODE_TYPE,
-    build_mcp_tool_topology,
-    emit_mcp_tool_call_event,
+	build_mcp_edge_topology,
+	emit_mcp_edge_event,
 )
 
 _AGENT_ID = "Colombia Coffee Farm"
+_TARGET_SID = stable_agent_id_for_name("Weather MCP Server")
 _TOOL = "get_forecast"
 _SERVER = "lungo_weather_service"
 
 
 class _CapturingSink:
-    """In-memory EventSink for asserting emitted events."""
+	"""In-memory EventSink for asserting emitted events."""
 
-    def __init__(self) -> None:
-        self.events: list = []
+	def __init__(self) -> None:
+		self.events: list = []
 
-    async def emit(self, event) -> None:
-        self.events.append(event)
+	async def emit(self, event) -> None:
+		self.events.append(event)
 
-    async def aclose(self) -> None:
-        return None
-
-
-def _agent_node(topology):
-    for node in topology.nodes:
-        if getattr(node, "type", None) != MCP_TOOL_NODE_TYPE:
-            return node
-    return None
-
-
-def _tool_node(topology):
-    for node in topology.nodes:
-        if getattr(node, "type", None) == MCP_TOOL_NODE_TYPE:
-            return node
-    return None
-
-
-async def test_build_mcp_tool_topology_create():
-    """CREATE builds an agent node, a tool node, and a connecting edge."""
-    allocator = RuntimeIdAllocator()
-    topology = await build_mcp_tool_topology(
-        _AGENT_ID,
-        _TOOL,
-        _SERVER,
-        operation=Operation.CREATE,
-        allocator=allocator,
-        call_key="call-1",
-        layer_index=0,
-    )
-
-    assert len(topology.nodes) == 2
-    assert len(topology.edges) == 1
-
-    agent_node = _agent_node(topology)
-    tool_node = _tool_node(topology)
-    assert agent_node.label == _AGENT_ID
-    assert getattr(agent_node, "stable_agent_id", None) is not None
-    assert tool_node.operation == Operation.CREATE
-    assert tool_node.label == _TOOL
-    assert tool_node.tool_name == _TOOL
-    assert tool_node.mcp_server == _SERVER
-
-    edge = topology.edges[0]
-    assert edge.operation == Operation.CREATE
-    assert edge.source.root == agent_node.id.root
-    assert edge.target.root == tool_node.id.root
+	async def aclose(self) -> None:
+		return None
 
 
 @pytest.mark.parametrize(
-    "case,duration_ms,error,expect_extras",
-    [
-        ("with_metrics", 12.5, "boom", True),
-        ("without_metrics", None, None, False),
-    ],
+	"case,mcp_in_flight",
+	[
+		("start", True),
+		("end", False),
+	],
 )
-async def test_build_mcp_tool_topology_delete(case, duration_ms, error, expect_extras):
-    """DELETE removes the tool node/edge, attaching metrics only when present."""
-    allocator = RuntimeIdAllocator()
-    topology = await build_mcp_tool_topology(
-        _AGENT_ID,
-        _TOOL,
-        _SERVER,
-        operation=Operation.DELETE,
-        allocator=allocator,
-        call_key="call-1",
-        duration_ms=duration_ms,
-        error=error,
-    )
+def test_build_mcp_edge_topology(case, mcp_in_flight):
+	"""Edge-only topology carries stable ids and mcp_in_flight flag."""
+	topology = build_mcp_edge_topology(
+		_AGENT_ID,
+		_TOOL,
+		_SERVER,
+		_TARGET_SID,
+		mcp_in_flight=mcp_in_flight,
+	)
 
-    assert len(topology.nodes) == 1
-    assert len(topology.edges) == 1
+	assert topology.nodes == []
+	assert len(topology.edges) == 1
 
-    tool_node = _tool_node(topology)
-    assert tool_node.operation == Operation.DELETE
-    assert topology.edges[0].operation == Operation.DELETE
-
-    if expect_extras:
-        assert tool_node.duration_ms == duration_ms
-        assert tool_node.error == error
-    else:
-        assert getattr(tool_node, "duration_ms", None) is None
-        assert getattr(tool_node, "error", None) is None
+	edge = topology.edges[0]
+	assert edge.operation == Operation.UPDATE
+	assert edge.source_stable_agent_id == stable_agent_id_for_name(_AGENT_ID)
+	assert edge.target_stable_agent_id == _TARGET_SID
+	assert edge.tool_name == _TOOL
+	assert edge.mcp_server == _SERVER
+	assert edge.mcp_in_flight is mcp_in_flight
+	assert edge.id.root.startswith("edge://")
 
 
-async def test_build_mcp_tool_topology_delete_removes_agent_node():
-    """delete_agent_node also tears down the invoking-agent node on the last call."""
-    allocator = RuntimeIdAllocator()
-    topology = await build_mcp_tool_topology(
-        _AGENT_ID,
-        _TOOL,
-        _SERVER,
-        operation=Operation.DELETE,
-        allocator=allocator,
-        call_key="call-1",
-        delete_agent_node=True,
-    )
+async def test_emit_mcp_edge_event_posts_to_sink():
+	"""emit_mcp_edge_event builds an event and delivers it to the sink."""
+	sink = _CapturingSink()
 
-    assert len(topology.nodes) == 2
-    agent_node = _agent_node(topology)
-    assert agent_node is not None
-    assert agent_node.operation == Operation.DELETE
-    assert agent_node.label == _AGENT_ID
-    assert _tool_node(topology).operation == Operation.DELETE
+	event = await emit_mcp_edge_event(
+		sink=sink,
+		source="colombia_coffee_farm",
+		agent_id=_AGENT_ID,
+		tool_name=_TOOL,
+		mcp_server=_SERVER,
+		target_stable_agent_id=_TARGET_SID,
+		mcp_in_flight=True,
+		correlation_id="correlation://00000000-0000-4000-8000-000000000004",
+		workflow_name="Test Workflow Alpha",
+		instance_id="instance://00000000-0000-4000-8000-000000000003",
+	)
 
-
-async def test_create_and_delete_share_tool_node_id():
-    """A shared allocator + call_key yields a stable tool node id across events."""
-    allocator = RuntimeIdAllocator()
-    create = await build_mcp_tool_topology(
-        _AGENT_ID, _TOOL, _SERVER,
-        operation=Operation.CREATE, allocator=allocator, call_key="call-1",
-    )
-    delete = await build_mcp_tool_topology(
-        _AGENT_ID, _TOOL, _SERVER,
-        operation=Operation.DELETE, allocator=allocator, call_key="call-1",
-    )
-    assert _tool_node(create).id.root == _tool_node(delete).id.root
-
-
-async def test_emit_mcp_tool_call_event_posts_to_sink():
-    """emit_mcp_tool_call_event builds an event and delivers it to the sink."""
-    sink = _CapturingSink()
-    allocator = RuntimeIdAllocator()
-
-    event = await emit_mcp_tool_call_event(
-        sink=sink,
-        source="colombia_coffee_farm",
-        agent_id=_AGENT_ID,
-        tool_name=_TOOL,
-        mcp_server=_SERVER,
-        operation=Operation.CREATE,
-        allocator=allocator,
-        call_key="call-1",
-        correlation_id="correlation://00000000-0000-4000-8000-000000000004",
-        workflow_name="Test Workflow Alpha",
-        instance_id="instance://00000000-0000-4000-8000-000000000003",
-    )
-
-    assert len(sink.events) == 1
-    assert sink.events[0] is event
-    assert "Test Workflow Alpha" in event.data.workflows
-    assert _TOOL in event.metadata.correlation.message
+	assert len(sink.events) == 1
+	assert sink.events[0] is event
+	assert "Test Workflow Alpha" in event.data.workflows
+	assert _TOOL in event.metadata.correlation.message
+	assert event.data.workflows["Test Workflow Alpha"].instances[
+		"instance://00000000-0000-4000-8000-000000000003"
+	].topology.edges[0].mcp_in_flight is True

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_merge.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_merge.py
@@ -909,122 +909,122 @@ WEATHER_SID = stable_agent_id_for_name("Weather MCP Server")
 
 
 def _publish_subscribe_starting_topology() -> dict:
-	return {
-		"nodes": [
-			{
-				"id": COLOMBIA_NODE,
-				"operation": "read",
-				"type": "customNode",
-				"label": "Colombia Coffee Farm Agent",
-				"size": {"width": 1, "height": 1},
-				"layer_index": 2,
-				"stable_agent_id": COLOMBIA_SID,
-				"agent_record_uri": "agent-card://colombia",
-			},
-			{
-				"id": WEATHER_NODE,
-				"operation": "read",
-				"type": "customNode",
-				"label": "Weather MCP Server",
-				"size": {"width": 1, "height": 1},
-				"layer_index": 3,
-				"stable_agent_id": WEATHER_SID,
-				"agent_record_uri": "agent-card://weather",
-			},
-		],
-		"edges": [
-			{
-				"id": CATALOG_EDGE,
-				"operation": "read",
-				"type": "branching",
-				"source": COLOMBIA_NODE,
-				"target": WEATHER_NODE,
-				"bidirectional": False,
-				"weight": 1.0,
-			},
-		],
-	}
+    return {
+        "nodes": [
+            {
+                "id": COLOMBIA_NODE,
+                "operation": "read",
+                "type": "customNode",
+                "label": "Colombia Coffee Farm Agent",
+                "size": {"width": 1, "height": 1},
+                "layer_index": 2,
+                "stable_agent_id": COLOMBIA_SID,
+                "agent_record_uri": "agent-card://colombia",
+            },
+            {
+                "id": WEATHER_NODE,
+                "operation": "read",
+                "type": "customNode",
+                "label": "Weather MCP Server",
+                "size": {"width": 1, "height": 1},
+                "layer_index": 3,
+                "stable_agent_id": WEATHER_SID,
+                "agent_record_uri": "agent-card://weather",
+            },
+        ],
+        "edges": [
+            {
+                "id": CATALOG_EDGE,
+                "operation": "read",
+                "type": "branching",
+                "source": COLOMBIA_NODE,
+                "target": WEATHER_NODE,
+                "bidirectional": False,
+                "weight": 1.0,
+            },
+        ],
+    }
 
 
 def _state_publish_subscribe_seed() -> Data:
-	return Data.model_validate(
-		{
-			"workflows": {
-				"w": {
-					"name": "n",
-					"pattern": "p",
-					"use_case": "u",
-					"scenario": "s",
-					"starting_topology": _publish_subscribe_starting_topology(),
-					"instances": {
-						INST: {
-							"id": INST,
-							"topology": {"nodes": [], "edges": []},
-						}
-					},
-				}
-			}
-		}
-	)
+    return Data.model_validate(
+        {
+            "workflows": {
+                "w": {
+                    "name": "n",
+                    "pattern": "p",
+                    "use_case": "u",
+                    "scenario": "s",
+                    "starting_topology": _publish_subscribe_starting_topology(),
+                    "instances": {
+                        INST: {
+                            "id": INST,
+                            "topology": {"nodes": [], "edges": []},
+                        }
+                    },
+                }
+            }
+        }
+    )
 
 
 def _mcp_edge_event(*, mcp_in_flight: bool) -> Event:
-	return _evt(
-		{
-			"workflows": {
-				"w": {
-					"name": "n",
-					"pattern": "p",
-					"use_case": "u",
-					"scenario": "s",
-					"starting_topology": {"nodes": [], "edges": []},
-					"instances": {
-						INST: {
-							"id": INST,
-							"topology": {
-								"nodes": [],
-								"edges": [
-									{
-										"id": PLACEHOLDER_EDGE,
-										"operation": "update",
-										"source_stable_agent_id": COLOMBIA_SID,
-										"target_stable_agent_id": WEATHER_SID,
-										"mcp_in_flight": mcp_in_flight,
-										"tool_name": "get_forecast",
-										"mcp_server": "lungo_weather_service",
-									}
-								],
-							},
-						}
-					},
-				}
-			}
-		}
-	)
+    return _evt(
+        {
+            "workflows": {
+                "w": {
+                    "name": "n",
+                    "pattern": "p",
+                    "use_case": "u",
+                    "scenario": "s",
+                    "starting_topology": {"nodes": [], "edges": []},
+                    "instances": {
+                        INST: {
+                            "id": INST,
+                            "topology": {
+                                "nodes": [],
+                                "edges": [
+                                    {
+                                        "id": PLACEHOLDER_EDGE,
+                                        "operation": "update",
+                                        "source_stable_agent_id": COLOMBIA_SID,
+                                        "target_stable_agent_id": WEATHER_SID,
+                                        "mcp_in_flight": mcp_in_flight,
+                                        "tool_name": "get_forecast",
+                                        "mcp_server": "lungo_weather_service",
+                                    }
+                                ],
+                            },
+                        }
+                    },
+                }
+            }
+        }
+    )
 
 
 def test_reconcile_mcp_edge_resolves_catalog_edge_id():
-	state = _state_publish_subscribe_seed()
-	normalized = reconcile_event_mcp_edges(state, _mcp_edge_event(mcp_in_flight=True))
-	edge = normalized.data.workflows["w"].instances[INST].topology.edges[0]
-	assert edge.id.root == CATALOG_EDGE
-	assert edge.source.root == COLOMBIA_NODE
-	assert edge.target.root == WEATHER_NODE
-	assert edge.operation.value == "update"
-	assert edge.mcp_in_flight is True
+    state = _state_publish_subscribe_seed()
+    normalized = reconcile_event_mcp_edges(state, _mcp_edge_event(mcp_in_flight=True))
+    edge = normalized.data.workflows["w"].instances[INST].topology.edges[0]
+    assert edge.id.root == CATALOG_EDGE
+    assert edge.source.root == COLOMBIA_NODE
+    assert edge.target.root == WEATHER_NODE
+    assert edge.operation.value == "update"
+    assert edge.mcp_in_flight is True
 
 
 def test_reconcile_then_merge_mcp_edge_keeps_single_catalog_edge():
-	state = _state_publish_subscribe_seed()
-	start = reconcile_event_mcp_edges(state, _mcp_edge_event(mcp_in_flight=True))
-	out = merge_event_data(state, start)
-	end = reconcile_event_mcp_edges(out, _mcp_edge_event(mcp_in_flight=False))
-	out = merge_event_data(out, end)
-	topo = _dump(out)["workflows"]["w"]["instances"][INST]["topology"]
-	assert len(topo["edges"]) == 1
-	assert topo["edges"][0]["id"] == CATALOG_EDGE
-	assert topo["edges"][0]["source"] == COLOMBIA_NODE
-	assert topo["edges"][0]["target"] == WEATHER_NODE
-	assert topo["edges"][0]["mcp_in_flight"] is False
-	assert topo["edges"][0]["tool_name"] == "get_forecast"
-	assert len(topo["nodes"]) == 2
+    state = _state_publish_subscribe_seed()
+    start = reconcile_event_mcp_edges(state, _mcp_edge_event(mcp_in_flight=True))
+    out = merge_event_data(state, start)
+    end = reconcile_event_mcp_edges(out, _mcp_edge_event(mcp_in_flight=False))
+    out = merge_event_data(out, end)
+    topo = _dump(out)["workflows"]["w"]["instances"][INST]["topology"]
+    assert len(topo["edges"]) == 1
+    assert topo["edges"][0]["id"] == CATALOG_EDGE
+    assert topo["edges"][0]["source"] == COLOMBIA_NODE
+    assert topo["edges"][0]["target"] == WEATHER_NODE
+    assert topo["edges"][0]["mcp_in_flight"] is False
+    assert topo["edges"][0]["tool_name"] == "get_forecast"
+    assert len(topo["nodes"]) == 2

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_merge.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/common/workflow_instance_store/test_merge.py
@@ -11,9 +11,11 @@ import pytest
 
 from schema.types import Data, Event
 
+from common.stable_agent_id import stable_agent_id_for_name
 from common.workflow_instance_store.merge import (
     merge_event_data,
     merge_topology_delta,
+    reconcile_event_mcp_edges,
     reconcile_event_node_identities,
 )
 
@@ -892,3 +894,137 @@ def test_merge_empty_workflows_preserves_existing_workflows_and_merges_extra():
     assert "w" in d["workflows"]
     assert d["workflows"]["w"]["pattern"] == "p"
     assert d["app_state"] == {"level": 2}
+
+
+# ---------------------------------------------------------------------------
+# reconcile_event_mcp_edges (catalog edge resolution by stable_agent_id)
+# ---------------------------------------------------------------------------
+
+COLOMBIA_NODE = "node://1a000001-0001-4000-a001-000000000004"
+WEATHER_NODE = "node://1a000001-0001-4000-a001-000000000006"
+CATALOG_EDGE = "edge://1a000001-0001-4000-a001-e00000000005"
+PLACEHOLDER_EDGE = "edge://550e8400-e29b-41d4-a716-446655440399"
+COLOMBIA_SID = stable_agent_id_for_name("Colombia Coffee Farm")
+WEATHER_SID = stable_agent_id_for_name("Weather MCP Server")
+
+
+def _publish_subscribe_starting_topology() -> dict:
+	return {
+		"nodes": [
+			{
+				"id": COLOMBIA_NODE,
+				"operation": "read",
+				"type": "customNode",
+				"label": "Colombia Coffee Farm Agent",
+				"size": {"width": 1, "height": 1},
+				"layer_index": 2,
+				"stable_agent_id": COLOMBIA_SID,
+				"agent_record_uri": "agent-card://colombia",
+			},
+			{
+				"id": WEATHER_NODE,
+				"operation": "read",
+				"type": "customNode",
+				"label": "Weather MCP Server",
+				"size": {"width": 1, "height": 1},
+				"layer_index": 3,
+				"stable_agent_id": WEATHER_SID,
+				"agent_record_uri": "agent-card://weather",
+			},
+		],
+		"edges": [
+			{
+				"id": CATALOG_EDGE,
+				"operation": "read",
+				"type": "branching",
+				"source": COLOMBIA_NODE,
+				"target": WEATHER_NODE,
+				"bidirectional": False,
+				"weight": 1.0,
+			},
+		],
+	}
+
+
+def _state_publish_subscribe_seed() -> Data:
+	return Data.model_validate(
+		{
+			"workflows": {
+				"w": {
+					"name": "n",
+					"pattern": "p",
+					"use_case": "u",
+					"scenario": "s",
+					"starting_topology": _publish_subscribe_starting_topology(),
+					"instances": {
+						INST: {
+							"id": INST,
+							"topology": {"nodes": [], "edges": []},
+						}
+					},
+				}
+			}
+		}
+	)
+
+
+def _mcp_edge_event(*, mcp_in_flight: bool) -> Event:
+	return _evt(
+		{
+			"workflows": {
+				"w": {
+					"name": "n",
+					"pattern": "p",
+					"use_case": "u",
+					"scenario": "s",
+					"starting_topology": {"nodes": [], "edges": []},
+					"instances": {
+						INST: {
+							"id": INST,
+							"topology": {
+								"nodes": [],
+								"edges": [
+									{
+										"id": PLACEHOLDER_EDGE,
+										"operation": "update",
+										"source_stable_agent_id": COLOMBIA_SID,
+										"target_stable_agent_id": WEATHER_SID,
+										"mcp_in_flight": mcp_in_flight,
+										"tool_name": "get_forecast",
+										"mcp_server": "lungo_weather_service",
+									}
+								],
+							},
+						}
+					},
+				}
+			}
+		}
+	)
+
+
+def test_reconcile_mcp_edge_resolves_catalog_edge_id():
+	state = _state_publish_subscribe_seed()
+	normalized = reconcile_event_mcp_edges(state, _mcp_edge_event(mcp_in_flight=True))
+	edge = normalized.data.workflows["w"].instances[INST].topology.edges[0]
+	assert edge.id.root == CATALOG_EDGE
+	assert edge.source.root == COLOMBIA_NODE
+	assert edge.target.root == WEATHER_NODE
+	assert edge.operation.value == "update"
+	assert edge.mcp_in_flight is True
+
+
+def test_reconcile_then_merge_mcp_edge_keeps_single_catalog_edge():
+	state = _state_publish_subscribe_seed()
+	start = reconcile_event_mcp_edges(state, _mcp_edge_event(mcp_in_flight=True))
+	out = merge_event_data(state, start)
+	end = reconcile_event_mcp_edges(out, _mcp_edge_event(mcp_in_flight=False))
+	out = merge_event_data(out, end)
+	topo = _dump(out)["workflows"]["w"]["instances"][INST]["topology"]
+	assert len(topo["edges"]) == 1
+	assert topo["edges"][0]["id"] == CATALOG_EDGE
+	assert topo["edges"][0]["source"] == COLOMBIA_NODE
+	assert topo["edges"][0]["target"] == WEATHER_NODE
+	assert topo["edges"][0]["mcp_in_flight"] is False
+	assert topo["edges"][0]["tool_name"] == "get_forecast"
+	assert len(topo["nodes"]) == 2

--- a/coffeeAGNTCY/coffee_agents/lungo/tests/unit/mcp_servers/test_payment_client.py
+++ b/coffeeAGNTCY/coffee_agents/lungo/tests/unit/mcp_servers/test_payment_client.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 from agents.exceptions import AuthError
 from agents.mcp_servers import utils
+from common.stable_agent_id import stable_agent_id_for_name
 
 _AGENT_ID = "Colombia Coffee Farm"
 _SOURCE = "colombia_coffee_farm"
@@ -61,6 +62,9 @@ async def test_delegates_to_call_mcp_tool_with_payment_args(identity_auth_on):
     assert result == expected
     assert captured["topic"] == "lungo_payment_service"
     assert captured["tool_name"] == "create_payment"
+    assert captured["target_stable_agent_id"] == stable_agent_id_for_name(
+        "Payment MCP Server"
+    )
     assert captured["agent_id"] == _AGENT_ID
     assert captured["source"] == _SOURCE
     assert captured["workflow_name"] == "Test Workflow Alpha"


### PR DESCRIPTION
# Description

MCP tool calls generated dummy tool-call and farm-response nodes in the background, that were driving animation sequences but were invisible, and served no real purpose. These nodes are now removed, and for the animation, a targeted edge solution is now introduced that uses the already existing graph with resolving agent stable ids for the edge endpoints.


## Issue Link

Fixes #649 

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
