### PR TITLE
chore: add pyright LSP config

### DIFF
--- a/coffeeAGNTCY/coffee_agents/corto/pyrightconfig.json
+++ b/coffeeAGNTCY/coffee_agents/corto/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}

--- a/coffeeAGNTCY/coffee_agents/lungo/pyrightconfig.json
+++ b/coffeeAGNTCY/coffee_agents/lungo/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}

--- a/coffeeAGNTCY/coffee_agents/recruiter/pyrightconfig.json
+++ b/coffeeAGNTCY/coffee_agents/recruiter/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}


### PR DESCRIPTION
# Description

Adds `pyrightconfig.json` to `corto`, `lungo`, and `recruiter`, each pointing at the sub-project's own `.venv`.

These are three independent Python projects (separate `pyproject.toml`/venv each) living under one monorepo. Without per-project pyright config, a language server opening the whole repo can't reliably resolve each sub-project's local imports or installed dependencies — for example `config.config` exists identically in all three and is otherwise ambiguous to resolve correctly. This scopes resolution correctly per project with zero editor-specific setup required.

## Issue Link

None.

## Type of Change

- [x] Other (please describe): developer tooling / LSP configuration, no runtime behavior change

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable) — n/a, no related issue
- [X] I have verified this change is not present in other open pull requests
- [x] Functionality is documented — config is self-describing, no docs needed
- [X] All code style checks pass
- [x] New code contribution is covered by automated tests — n/a, config-only change, no testable behavior
- [x] All new and existing tests pass — no code paths touched
