### PR TITLE
ci: + ci-gate summary workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,6 +6,7 @@ This directory contains CI/CD workflows for building images, packaging Helm char
 
 | Workflow | Purpose | Triggers |
 |----------|---------|----------|
+| [`ci-gate.yaml`](.github/workflows/ci-gate.yaml) | Required status check: lints every workflow file (actionlint) and waits for/reports on every sibling workflow run on the same commit, including startup failures | pull_request, push (main, tags), workflow_dispatch |
 | [`docker-build-push.yaml`](.github/workflows/docker-build-push.yaml) | Build multi-arch Docker images for all agents and optionally push to GHCR | push (main, tags), pull_request (paths filter), workflow_dispatch |
 | [`docker-build-reusable.yaml`](.github/workflows/docker-build-reusable.yaml) | Reusable job: build and push a single Docker image | workflow_call |
 | [`helm-push.yaml`](.github/workflows/helm-push.yaml) | Lint, package, and (on push to main/tags) push Helm charts to GHCR (OCI) | push (main, tags), pull_request (paths filter), workflow_dispatch |
@@ -16,6 +17,16 @@ This directory contains CI/CD workflows for building images, packaging Helm char
 | [`fe-ci.yaml`](.github/workflows/fe-ci.yaml) | Typecheck, ESLint, and Prettier for the Lungo frontend | push (main, frontend paths), pull_request (main, frontend paths) |
 | [`version-override-test.yaml`](.github/workflows/version-override-test.yaml) | Example invocation of reusable tests with dependency/image overrides | workflow_dispatch |
 | [`docs.yaml`](.github/workflows/docs.yaml) | Publish MkDocs site to GitHub Pages (gh-pages) | push (main, README.md path) |
+
+## ci-gate
+
+Single required status check for the repo, self-contained in one file with no manual list of other workflows to maintain:
+
+1. **Validate** - runs `actionlint` (via `reviewdog/action-actionlint`) against every file under `.github/workflows/` on the checked-out commit, catching schema/syntax/structure issues and shellcheck findings in `run:` scripts. Always runs to completion (`continue-on-error: true`) so it never short-circuits step 2.
+2. **Wait** - since there's no native way for one workflow to block another from starting, this polls `GET /actions/runs?head_sha=...` (the runs API, not the checks API - the checks API silently omits `startup_failure` runs) every minute, after an initial one-minute settle delay, until nothing else for that commit is left `queued`/`in_progress` for two consecutive polls, or 100 minutes elapse.
+3. **Summarize** - always runs regardless of steps 1-2's outcome, writes a table to the job summary (validation result + every sibling run's name/conclusion/link, including anything still pending at timeout), and only then decides pass/fail: `success`/`skipped` count as pass, everything else (`failure`, `startup_failure`, `cancelled`, `timed_out`, `neutral`, or still-pending-at-timeout) counts as fail.
+
+For this to actually gate merges, `CI Gate` needs to be added as a `required_status_checks` context in the branch ruleset (currently managed in `agntcy/org-admin`'s `safe-settings/repos/coffeeAgntcy.yml`, which as of this writing has no `required_status_checks` rule at all).
 
 ## docker-build-push
 
@@ -47,6 +58,8 @@ Reusable workflow called by `docker-build-push.yaml` for each matrix entry. Acce
 | `platforms` | Target platforms (default: linux/amd64,linux/arm64) |
 | `extra_build_args` | Additional newline-separated KEY=value build args (optional) |
 
+The job has `timeout-minutes: 90` - historically, hung builds here ran to GitHub's default 6-hour job ceiling before being force-cancelled; 90 minutes gives comfortable headroom over the longest legitimate run (~28 min) while failing fast on a genuine hang.
+
 ## helm-push
 
 Packages each chart listed under matrix.chart. On push to main or a tag, charts are pushed to `ghcr.io/<org>/coffee_agntcy/helm` as OCI artifacts; PRs only lint and package.
@@ -70,6 +83,8 @@ Reusable workflow called by `helm-push.yaml` for each matrix entry. Accepts:
 | `path` | Path to the chart directory (required) |
 | `package_name` | Package name for the chart (required) |
 | `push` | Whether to push to GHCR OCI registry (default: false) |
+
+The job has `timeout-minutes: 90`, for the same reason as `docker-build-reusable` (longest legitimate run here is ~53 min).
 
 ## test (Python Tests)
 

--- a/.github/workflows/ci-gate.yaml
+++ b/.github/workflows/ci-gate.yaml
@@ -1,0 +1,175 @@
+name: CI Gate
+
+# Single required status check for the repo.
+#
+# - Validates every workflow file under .github/workflows/ (schema, syntax,
+#   structure) via actionlint, on every run - no manual list to keep in sync.
+# - Waits for every sibling workflow run triggered on the same commit to reach
+#   a terminal state, by polling the Actions runs API (not the checks API -
+#   that one silently omits startup_failure runs), then reports on all of them,
+#   including ones that failed at startup, were skipped, or never completed.
+# - Never short-circuits: validation and the wait/report step both run
+#   regardless of each other's outcome, and the pass/fail decision is made
+#   once everything has been collected.
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+    tags: ["*"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  SETTLE_DELAY_SECONDS: 60
+  POLL_INTERVAL_SECONDS: 60
+  OVERALL_TIMEOUT_SECONDS: 6000 # 100 minutes
+  CONSECUTIVE_CLEAN_POLLS_REQUIRED: 2
+
+jobs:
+  ci-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 105
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Validate all workflow files (schema, syntax, structure)
+        id: validate
+        continue-on-error: true
+        uses: reviewdog/action-actionlint@d290e336d5a743810aef4404f757dc862276d2ae # v1.73.4
+        with:
+          reporter: local
+          fail_level: error
+          filter_mode: nofilter
+
+      - name: Wait for sibling workflow runs on this commit
+        id: wait
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          else
+            head_sha="${{ github.sha }}"
+          fi
+
+          self_run_id="${{ github.run_id }}"
+          start_time=$(date +%s)
+          clean_polls=0
+          settled=false
+          last_good_runs_json='[]'
+
+          echo "Waiting ${SETTLE_DELAY_SECONDS}s for sibling runs to be scheduled..."
+          sleep "$SETTLE_DELAY_SECONDS"
+
+          while true; do
+            if fetched=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${head_sha}&per_page=100" \
+              --paginate --jq '.workflow_runs[]' | jq -s '.'); then
+              last_good_runs_json="$fetched"
+
+              pending=$(jq --argjson self "$self_run_id" \
+                '[.[] | select(.id != $self) | select(.status != "completed")] | length' <<<"$last_good_runs_json")
+
+              if [[ "$pending" -eq 0 ]]; then
+                clean_polls=$((clean_polls + 1))
+              else
+                clean_polls=0
+              fi
+              echo "pending=$pending clean_polls=$clean_polls"
+
+              if [[ "$clean_polls" -ge "$CONSECUTIVE_CLEAN_POLLS_REQUIRED" ]]; then
+                settled=true
+                break
+              fi
+            else
+              echo "::warning::failed to list workflow runs from the GitHub API this poll; will retry"
+              clean_polls=0
+            fi
+
+            elapsed=$(($(date +%s) - start_time))
+            if [[ "$elapsed" -ge "$OVERALL_TIMEOUT_SECONDS" ]]; then
+              settled=false
+              break
+            fi
+
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
+
+          echo "$last_good_runs_json" >runs.json
+          echo "settled=$settled" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Summarize and decide
+        if: always()
+        run: |
+          set -uo pipefail
+
+          validate_outcome="${{ steps.validate.outcome }}"
+          settled="${{ steps.wait.outputs.settled }}"
+          self_run_id="${{ github.run_id }}"
+          overall_pass=true
+
+          {
+            echo "## CI Gate summary"
+            echo
+            echo "| Check | Status | Result |"
+            echo "|---|---|---|"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          if [[ "$validate_outcome" == "success" ]]; then
+            echo "| Validate workflow files (actionlint) | success | :white_check_mark: pass |" >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "| Validate workflow files (actionlint) | $validate_outcome | :x: fail |" >>"$GITHUB_STEP_SUMMARY"
+            overall_pass=false
+          fi
+
+          run_count=$(jq --argjson self "$self_run_id" '[.[] | select(.id != $self)] | length' runs.json)
+
+          if [[ "$run_count" -eq 0 ]]; then
+            echo "| _(no sibling workflow runs found for this commit)_ | | |" >>"$GITHUB_STEP_SUMMARY"
+          else
+            while IFS=$'\t' read -r name status conclusion url; do
+              if [[ "$status" != "completed" ]]; then
+                display="did-not-complete ($status)"
+                result_pass=false
+              else
+                display="$conclusion"
+                case "$conclusion" in
+                success | skipped) result_pass=true ;;
+                *) result_pass=false ;;
+                esac
+              fi
+
+              if [[ "$result_pass" == "true" ]]; then
+                icon=":white_check_mark: pass"
+              else
+                icon=":x: fail"
+                overall_pass=false
+              fi
+
+              echo "| [$name]($url) | $display | $icon |" >>"$GITHUB_STEP_SUMMARY"
+            done < <(jq -r --argjson self "$self_run_id" '
+              .[] | select(.id != $self) |
+              [.name, .status, (.conclusion // "null"), .html_url] | @tsv
+            ' runs.json)
+          fi
+
+          if [[ "$settled" != "true" ]]; then
+            echo >>"$GITHUB_STEP_SUMMARY"
+            echo ":warning: hit the overall ${OVERALL_TIMEOUT_SECONDS}s wait timeout before every sibling run reached a terminal status - anything still pending above is treated as a failure." >>"$GITHUB_STEP_SUMMARY"
+            overall_pass=false
+          fi
+
+          cat "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$overall_pass" != "true" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -86,14 +86,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: prepare-path-lists
         run: |
-          paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
-          echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
+          paths_json_corto=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
+          echo "paths_json_corto=$paths_json_corto" | tee -a "$GITHUB_OUTPUT"
 
-          paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
-          echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
+          paths_json_lungo=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
+          echo "paths_json_lungo=$paths_json_lungo" | tee -a "$GITHUB_OUTPUT"
 
-          paths_json_recruiter=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$RECRUITER_DIR" '[$new_val] + .')
-          echo "paths_json_recruiter=$paths_json_recruiter" | tee -a $GITHUB_OUTPUT
+          paths_json_recruiter=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$RECRUITER_DIR" '[$new_val] + .')
+          echo "paths_json_recruiter=$paths_json_recruiter" | tee -a "$GITHUB_OUTPUT"
 
       - name: Check paths have changes for Corto
         if: ${{ github.event_name == 'pull_request' }}
@@ -143,9 +143,9 @@ jobs:
             build_recruiter=${{ steps.check-paths-recruiter.outputs.changed }}
           fi
 
-          echo "build_corto=$build_corto" | tee -a $GITHUB_OUTPUT
-          echo "build_lungo=$build_lungo" | tee -a $GITHUB_OUTPUT
-          echo "build_recruiter=$build_recruiter" | tee -a $GITHUB_OUTPUT
+          echo "build_corto=$build_corto" | tee -a "$GITHUB_OUTPUT"
+          echo "build_lungo=$build_lungo" | tee -a "$GITHUB_OUTPUT"
+          echo "build_recruiter=$build_recruiter" | tee -a "$GITHUB_OUTPUT"
 
   compute-build-parameters:
     runs-on: ubuntu-latest
@@ -175,22 +175,24 @@ jobs:
           # Untrusted input (attacker-controlled on fork PRs): must not be interpolated
           # directly into the script, or a crafted branch name could inject shell commands.
           HEAD_REF: ${{ github.head_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
         run: |
           # default values
           push=false
           image_tag=unknown
           git_branch=${{ github.ref_name }}
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             image_tag=pr-${{ github.event.pull_request.number }}
             git_branch="$HEAD_REF"
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
             push=true
             image_tag=latest
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == refs/tags/* ]]; then
+          elif [[ "$EVENT_NAME" == "push" && "$REF" == refs/tags/* ]]; then
             push=true
             image_tag=${{ github.ref_name }}
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             push=${{ inputs.push }}
             if [[ "${{ inputs.image_tag }}" != "" ]]; then
               image_tag=${{ inputs.image_tag }}
@@ -200,9 +202,9 @@ jobs:
             fi
           fi
 
-          echo "push=$push" | tee -a $GITHUB_OUTPUT
-          echo "image_tag=$image_tag" | tee -a $GITHUB_OUTPUT
-          echo "git_branch=$git_branch" | tee -a $GITHUB_OUTPUT
+          echo "push=$push" | tee -a "$GITHUB_OUTPUT"
+          echo "image_tag=$image_tag" | tee -a "$GITHUB_OUTPUT"
+          echo "git_branch=$git_branch" | tee -a "$GITHUB_OUTPUT"
 
   docker-build-corto:
     needs: [subprojects-to-build, compute-build-parameters]
@@ -213,11 +215,13 @@ jobs:
         image:
           - name: corto-ui
             dockerfile: docker/Dockerfile.ui
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/corto/exchange/frontend
               NPM_CACHE_ID=corto
           - name: corto-exchange
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/corto
               UV_CACHE_ID=corto
@@ -225,6 +229,7 @@ jobs:
               AGENT_SCRIPT=exchange/main.py
           - name: corto-farm
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/corto
               UV_CACHE_ID=corto
@@ -255,11 +260,13 @@ jobs:
         image:
           - name: lungo-ui
             dockerfile: docker/Dockerfile.ui
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo/frontend
               NPM_CACHE_ID=lungo
           - name: auction-supervisor
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -267,6 +274,7 @@ jobs:
               AGENT_SCRIPT=agents/supervisors/auction/main.py
           - name: agentic-workflows-api
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -274,6 +282,7 @@ jobs:
               AGENT_SCRIPT=-m api.agentic_workflows.server
           - name: brazil-farm
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -281,6 +290,7 @@ jobs:
               AGENT_SCRIPT=agents/farms/brazil/farm_server.py
           - name: colombia-farm
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -288,6 +298,7 @@ jobs:
               AGENT_SCRIPT=agents/farms/colombia/farm_server.py
           - name: vietnam-farm
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -295,6 +306,7 @@ jobs:
               AGENT_SCRIPT=agents/farms/vietnam/farm_server.py
           - name: weather-mcp-server
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -302,6 +314,7 @@ jobs:
               AGENT_SCRIPT=agents/mcp_servers/weather_service.py
           - name: payment-mcp-server
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -309,6 +322,7 @@ jobs:
               AGENT_SCRIPT=agents/mcp_servers/payment_service.py
           - name: logistics-shipper
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -316,6 +330,7 @@ jobs:
               AGENT_SCRIPT=agents/logistics/shipper/server.py
           - name: logistics-accountant
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -323,6 +338,7 @@ jobs:
               AGENT_SCRIPT=agents/logistics/accountant/server.py
           - name: logistics-farm
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -330,6 +346,7 @@ jobs:
               AGENT_SCRIPT=agents/logistics/farm/server.py
           - name: logistics-supervisor
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -337,6 +354,7 @@ jobs:
               AGENT_SCRIPT=agents/supervisors/logistics/main.py
           - name: logistics-helpdesk
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo
@@ -344,6 +362,7 @@ jobs:
               AGENT_SCRIPT=agents/logistics/helpdesk/server.py
           - name: recruiter-supervisor
             dockerfile: docker/Dockerfile.python-agent
+            target: ""
             extra_build_args: |
               PROJECT_PATH=coffeeAGNTCY/coffee_agents/lungo
               UV_CACHE_ID=lungo

--- a/.github/workflows/docker-build-reusable.yaml
+++ b/.github/workflows/docker-build-reusable.yaml
@@ -47,6 +47,7 @@ permissions:
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     permissions:
       contents: read

--- a/.github/workflows/docker-build-reusable.yaml
+++ b/.github/workflows/docker-build-reusable.yaml
@@ -75,9 +75,9 @@ jobs:
       - name: Generate metadata
         id: metadata
         run: |
-          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" | tee -a $GITHUB_OUTPUT
-          echo "date_formatted=$(date -u +'%Y-%m-%d')" | tee -a $GITHUB_OUTPUT
-          echo "short_sha=${GITHUB_SHA:0:7}" | tee -a $GITHUB_OUTPUT
+          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" | tee -a "$GITHUB_OUTPUT"
+          echo "date_formatted=$(date -u +'%Y-%m-%d')" | tee -a "$GITHUB_OUTPUT"
+          echo "short_sha=${GITHUB_SHA:0:7}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         if: inputs.push == true

--- a/.github/workflows/helm-package-reusable.yaml
+++ b/.github/workflows/helm-package-reusable.yaml
@@ -73,8 +73,8 @@ jobs:
         id: package
         run: |
           CHART_VERSION=$(grep '^version:' ${{ inputs.path }}/Chart.yaml | awk '{print $2}')
-          helm package ${{ inputs.path }} --dependency-update --version $CHART_VERSION
-          echo "chart_version=$CHART_VERSION" | tee -a $GITHUB_OUTPUT
+          helm package ${{ inputs.path }} --dependency-update --version "$CHART_VERSION"
+          echo "chart_version=$CHART_VERSION" | tee -a "$GITHUB_OUTPUT"
 
       - name: Push Helm Chart
         if: inputs.push == true

--- a/.github/workflows/helm-package-reusable.yaml
+++ b/.github/workflows/helm-package-reusable.yaml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   helm-package-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     permissions:
       packages: write

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -72,11 +72,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: prepare-path-lists
         run: |
-          paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR/$HELM_SUBDIR" '[$new_val] + .')
-          echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
-          
-          paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR/$HELM_SUBDIR" '[$new_val] + .')
-          echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
+          paths_json_corto=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$CORTO_DIR/$HELM_SUBDIR" '[$new_val] + .')
+          echo "paths_json_corto=$paths_json_corto" | tee -a "$GITHUB_OUTPUT"
+
+          paths_json_lungo=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$LUNGO_DIR/$HELM_SUBDIR" '[$new_val] + .')
+          echo "paths_json_lungo=$paths_json_lungo" | tee -a "$GITHUB_OUTPUT"
 
       - name: Check paths have changes for Corto
         if: ${{ github.event_name == 'pull_request' }}
@@ -113,8 +113,8 @@ jobs:
             build_lungo=${{ steps.check-paths-lungo.outputs.changed }}
           fi
 
-          echo "build_corto=$build_corto" | tee -a $GITHUB_OUTPUT
-          echo "build_lungo=$build_lungo" | tee -a $GITHUB_OUTPUT
+          echo "build_corto=$build_corto" | tee -a "$GITHUB_OUTPUT"
+          echo "build_lungo=$build_lungo" | tee -a "$GITHUB_OUTPUT"
 
   helm-package-corto:
     needs: subprojects-to-build

--- a/.github/workflows/test-subprojects-reusable.yaml
+++ b/.github/workflows/test-subprojects-reusable.yaml
@@ -71,14 +71,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: prepare-path-lists
         run: |
-          paths_json_corto=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
-          echo "paths_json_corto=$paths_json_corto" | tee -a $GITHUB_OUTPUT
+          paths_json_corto=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$CORTO_DIR" '[$new_val] + .')
+          echo "paths_json_corto=$paths_json_corto" | tee -a "$GITHUB_OUTPUT"
 
-          paths_json_lungo=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
-          echo "paths_json_lungo=$paths_json_lungo" | tee -a $GITHUB_OUTPUT
+          paths_json_lungo=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$LUNGO_DIR" '[$new_val] + .')
+          echo "paths_json_lungo=$paths_json_lungo" | tee -a "$GITHUB_OUTPUT"
 
-          paths_json_recruiter=$(echo $WORKFLOW_FILES_LIST_JSON | jq -c -r --arg new_val "$RECRUITER_DIR" '[$new_val] + .')
-          echo "paths_json_recruiter=$paths_json_recruiter" | tee -a $GITHUB_OUTPUT
+          paths_json_recruiter=$(echo "$WORKFLOW_FILES_LIST_JSON" | jq -c -r --arg new_val "$RECRUITER_DIR" '[$new_val] + .')
+          echo "paths_json_recruiter=$paths_json_recruiter" | tee -a "$GITHUB_OUTPUT"
 
       - name: Check paths have changes for Corto
         if: ${{ github.event_name == 'pull_request' }}
@@ -128,6 +128,6 @@ jobs:
             test_recruiter=${{ steps.check-paths-recruiter.outputs.changed }}
           fi
 
-          echo "test_corto=$test_corto" | tee -a $GITHUB_OUTPUT
-          echo "test_lungo=$test_lungo" | tee -a $GITHUB_OUTPUT
-          echo "test_recruiter=$test_recruiter" | tee -a $GITHUB_OUTPUT
+          echo "test_corto=$test_corto" | tee -a "$GITHUB_OUTPUT"
+          echo "test_lungo=$test_lungo" | tee -a "$GITHUB_OUTPUT"
+          echo "test_recruiter=$test_recruiter" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

Introduced a new CI workflow called `CI Gate` that has 2 major goals:
- Validate the workflows by running some GHA workflow linting on them using `reviewdog/action-actionlint` to prevent issues arising from the workflow not starting due to syntactic or structural issues.
- Collect all workflow results and give a boolean result for the CI package.

The latter is intended to be used as a flexible required status check that we could wire into the branch protection to both improve our quality gate, mark more scorecard fields and meanwhile keep control over what constitutes the required status check in an in-repo way.

Right now all running CI jobs are expected to be green (even newly added ones or removals don't require any change), later on we can transition to allowlist/disallowlist if needed.

Also fixed some linter issues.

## Issue Link

.

## Type of Change

- [X] Other (please describe): CI

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
