### PR TITLE
docs(README): fix release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Screenshot](assets/coffee_agntcy.png)
 
-[![Release](https://img.shields.io/github/v/release/agntcy/repo-template?display_name=tag)](CHANGELOG.md)
+[![Release](https://img.shields.io/github/v/release/agntcy/coffeeAgntcy?display_name=tag)](CHANGELOG.md)
 [![Contributor-Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-fbab2c.svg)](CODE_OF_CONDUCT.md)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/agntcy/coffeeAgntcy/badge)](https://securityscorecards.dev/viewer/?uri=github.com/agntcy/coffeeAgntcy)
 


### PR DESCRIPTION
# Description

Fixed README release badge, it was missing the correct repo name, hasn't been updated since cloned from the template.

## Issue Link

.

## Type of Change

- [X] Documentation

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/coffeeAgntcy/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
